### PR TITLE
Add emqx schemas

### DIFF
--- a/apps.emqx.io/emqx_v2alpha1.json
+++ b/apps.emqx.io/emqx_v2alpha1.json
@@ -1,0 +1,10476 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "bootstrapAPIKeys": {
+          "items": {
+            "properties": {
+              "key": {
+                "pattern": "^[a-zA-Z\\d_]+$",
+                "type": "string"
+              },
+              "secret": {
+                "maxLength": 32,
+                "minLength": 3,
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "secret"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "bootstrapConfig": {
+          "type": "string"
+        },
+        "coreTemplate": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "Containers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "args": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "containerSecurityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "env": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "properties": {
+                          "configMapKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "fieldRef": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "resourceFieldRef": {
+                            "properties": {
+                              "containerName": {
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secretKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "envFrom": {
+                  "items": {
+                    "properties": {
+                      "configMapRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "prefix": {
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraVolumeMounts": {
+                  "items": {
+                    "properties": {
+                      "mountPath": {
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "subPath": {
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraVolumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "spec"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pdName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "repository"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "claimName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "pdID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumePath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "lifecycle": {
+                  "properties": {
+                    "postStart": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "livenessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "podSecurityContext": {
+                  "properties": {
+                    "fsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "containerPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "readinessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "replicas": {
+                  "default": 2,
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "toleRations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumeClaimTemplates": {
+                  "properties": {
+                    "accessModes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "dataSource": {
+                      "properties": {
+                        "apiGroup": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "dataSourceRef": {
+                      "properties": {
+                        "apiGroup": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "resources": {
+                      "properties": {
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "selector": {
+                      "properties": {
+                        "matchExpressions": {
+                          "items": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "values": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "operator"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "matchLabels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "storageClassName": {
+                      "type": "string"
+                    },
+                    "volumeMode": {
+                      "type": "string"
+                    },
+                    "volumeName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "dashboardServiceTemplate": {
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "port",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastTransitionTime": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "message": {
+                        "maxLength": 32768,
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "format": "int64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": [
+                          "True",
+                          "False",
+                          "Unknown"
+                        ],
+                        "type": "string"
+                      },
+                      "type": {
+                        "maxLength": 316,
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "lastTransitionTime",
+                      "message",
+                      "reason",
+                      "status",
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "type"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "loadBalancer": {
+                  "properties": {
+                    "ingress": {
+                      "items": {
+                        "properties": {
+                          "hostname": {
+                            "type": "string"
+                          },
+                          "ip": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "error": {
+                                  "maxLength": 316,
+                                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "protocol": {
+                                  "default": "TCP",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port",
+                                "protocol"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "default": "IfNotPresent",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "listenersServiceTemplate": {
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "port",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastTransitionTime": {
+                        "format": "date-time",
+                        "type": "string"
+                      },
+                      "message": {
+                        "maxLength": 32768,
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "format": "int64",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": [
+                          "True",
+                          "False",
+                          "Unknown"
+                        ],
+                        "type": "string"
+                      },
+                      "type": {
+                        "maxLength": 316,
+                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "lastTransitionTime",
+                      "message",
+                      "reason",
+                      "status",
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "type"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "loadBalancer": {
+                  "properties": {
+                    "ingress": {
+                      "items": {
+                        "properties": {
+                          "hostname": {
+                            "type": "string"
+                          },
+                          "ip": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "error": {
+                                  "maxLength": 316,
+                                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "protocol": {
+                                  "default": "TCP",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port",
+                                "protocol"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicantTemplate": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "Containers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "args": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "command": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "containerSecurityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "env": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "properties": {
+                          "configMapKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "fieldRef": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "resourceFieldRef": {
+                            "properties": {
+                              "containerName": {
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "resource"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "secretKeyRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "key"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "envFrom": {
+                  "items": {
+                    "properties": {
+                      "configMapRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "prefix": {
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraVolumeMounts": {
+                  "items": {
+                    "properties": {
+                      "mountPath": {
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "subPath": {
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraVolumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "spec"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pdName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "repository"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "claimName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "pdID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumePath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "lifecycle": {
+                  "properties": {
+                    "postStart": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "preStop": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "livenessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "podSecurityContext": {
+                  "properties": {
+                    "fsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "containerPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "hostIP": {
+                        "type": "string"
+                      },
+                      "hostPort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "containerPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "readinessProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "replicas": {
+                  "default": 2,
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "startupProbe": {
+                  "properties": {
+                    "exec": {
+                      "properties": {
+                        "command": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "failureThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "grpc": {
+                      "properties": {
+                        "port": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "service": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "httpGet": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "httpHeaders": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "initialDelaySeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "periodSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "successThreshold": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "tcpSocket": {
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "required": [
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "timeoutSeconds": {
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "toleRations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "coreNodeReadyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "coreNodeReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "currentImage": {
+          "type": "string"
+        },
+        "emqxNodes": {
+          "items": {
+            "properties": {
+              "node": {
+                "type": "string"
+              },
+              "node_status": {
+                "type": "string"
+              },
+              "otp_release": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "replicantNodeReadyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicantNodeReplicas": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxbroker_v1beta3.json
+++ b/apps.emqx.io/emqxbroker_v1beta3.json
@@ -1,0 +1,4872 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "affinity": {
+          "properties": {
+            "nodeAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "preference": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "items": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "podAffinityTerm": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaceSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "podAffinityTerm": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaceSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "emqxTemplate": {
+          "properties": {
+            "acl": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "config": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "extraVolumeMounts": {
+              "items": {
+                "properties": {
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "extraVolumes": {
+              "items": {
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "properties": {
+                      "cachingMode": {
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "properties": {
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "properties": {
+                      "monitors": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "properties": {
+                      "driver": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "fieldRef": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "properties": {
+                                "containerName": {
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "properties": {
+                      "medium": {
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "properties": {
+                          "metadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "spec": {
+                            "properties": {
+                              "accessModes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "properties": {
+                                  "apiGroup": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "properties": {
+                                  "apiGroup": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "lun": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "properties": {
+                      "driver": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "properties": {
+                      "datasetName": {
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "properties": {
+                      "directory": {
+                        "type": "string"
+                      },
+                      "repository": {
+                        "type": "string"
+                      },
+                      "revision": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "properties": {
+                      "endpoints": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "type": "string"
+                      },
+                      "lun": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "properties": {
+                      "claimName": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "items": {
+                          "properties": {
+                            "configMap": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "fieldRef": {
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "properties": {
+                                "audience": {
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "properties": {
+                      "group": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      },
+                      "volume": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "type": "string"
+                      },
+                      "system": {
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "image": {
+              "type": "string"
+            },
+            "imagePullPolicy": {
+              "type": "string"
+            },
+            "livenessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "modules": {
+              "items": {
+                "properties": {
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "password": {
+              "default": "public",
+              "type": "string"
+            },
+            "readinessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "registry": {
+              "type": "string"
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "properties": {
+                "fsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "level": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceTemplate": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "allocateLoadBalancerNodePorts": {
+                      "type": "boolean"
+                    },
+                    "clusterIP": {
+                      "type": "string"
+                    },
+                    "clusterIPs": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "externalIPs": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "externalName": {
+                      "type": "string"
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "healthCheckNodePort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "internalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "ipFamilies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "ipFamilyPolicy": {
+                      "type": "string"
+                    },
+                    "loadBalancerClass": {
+                      "type": "string"
+                    },
+                    "loadBalancerIP": {
+                      "type": "string"
+                    },
+                    "loadBalancerSourceRanges": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ports": {
+                      "items": {
+                        "properties": {
+                          "appProtocol": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nodePort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "type": "string"
+                          },
+                          "targetPort": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "port",
+                        "protocol"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "publishNotReadyAddresses": {
+                      "type": "boolean"
+                    },
+                    "selector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "sessionAffinity": {
+                      "type": "string"
+                    },
+                    "sessionAffinityConfig": {
+                      "properties": {
+                        "clientIP": {
+                          "properties": {
+                            "timeoutSeconds": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startupProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "default": "admin",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "env": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "properties": {
+                  "configMapKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "properties": {
+                      "containerName": {
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "extraContainers": {
+          "items": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "items": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "properties": {
+                        "configMapKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "resourceFieldRef": {
+                          "properties": {
+                            "containerName": {
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "secretKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "items": {
+                  "properties": {
+                    "configMapRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "lifecycle": {
+                "properties": {
+                  "postStart": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "preStop": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "livenessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "ports": {
+                "items": {
+                  "properties": {
+                    "containerPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "readinessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resources": {
+                "properties": {
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "securityContext": {
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                  },
+                  "capabilities": {
+                    "properties": {
+                      "add": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "properties": {
+                      "level": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "seccompProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "windowsOptions": {
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdin": {
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "items": {
+                  "properties": {
+                    "devicePath": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "items": {
+                  "properties": {
+                    "mountPath": {
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "subPath": {
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "imagePullSecrets": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "initContainers": {
+          "items": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "items": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "properties": {
+                        "configMapKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "resourceFieldRef": {
+                          "properties": {
+                            "containerName": {
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "secretKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "items": {
+                  "properties": {
+                    "configMapRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "lifecycle": {
+                "properties": {
+                  "postStart": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "preStop": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "livenessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "ports": {
+                "items": {
+                  "properties": {
+                    "containerPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "readinessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resources": {
+                "properties": {
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "securityContext": {
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                  },
+                  "capabilities": {
+                    "properties": {
+                      "add": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "properties": {
+                      "level": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "seccompProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "windowsOptions": {
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdin": {
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "items": {
+                  "properties": {
+                    "devicePath": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "items": {
+                  "properties": {
+                    "mountPath": {
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "subPath": {
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeName": {
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "persistent": {
+          "properties": {
+            "accessModes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "dataSource": {
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "dataSourceRef": {
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "selector": {
+              "properties": {
+                "matchExpressions": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "values": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "storageClassName": {
+              "type": "string"
+            },
+            "volumeMode": {
+              "type": "string"
+            },
+            "volumeName": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "default": 3,
+          "format": "int32",
+          "type": "integer"
+        },
+        "toleRations": {
+          "items": {
+            "properties": {
+              "effect": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "emqxNodes": {
+          "items": {
+            "properties": {
+              "node": {
+                "type": "string"
+              },
+              "node_status": {
+                "type": "string"
+              },
+              "otp_release": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxbroker_v1beta4.json
+++ b/apps.emqx.io/emqxbroker_v1beta4.json
@@ -1,0 +1,6364 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "persistent": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "accessModes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dataSource": {
+                  "properties": {
+                    "apiGroup": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "dataSourceRef": {
+                  "properties": {
+                    "apiGroup": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageClassName": {
+                  "type": "string"
+                },
+                "volumeMode": {
+                  "type": "string"
+                },
+                "volumeName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "default": 3,
+          "format": "int32",
+          "type": "integer"
+        },
+        "serviceTemplate": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "port",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "emqxContainer": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "bootstrapAPIKeys": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "pattern": "^[a-zA-Z\\d_]+$",
+                            "type": "string"
+                          },
+                          "secret": {
+                            "maxLength": 32,
+                            "minLength": 3,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "emqxACL": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "emqxConfig": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "env": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "properties": {
+                              "configMapKeyRef": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "fieldRef": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resourceFieldRef": {
+                                "properties": {
+                                  "containerName": {
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "resource"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "secretKeyRef": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "properties": {
+                          "configMapRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "enum": [
+                            "Always",
+                            "Never",
+                            "IfNotPresent"
+                          ],
+                          "type": "string"
+                        },
+                        "registry": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "suffix": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "lifecycle": {
+                      "properties": {
+                        "postStart": {
+                          "properties": {
+                            "exec": {
+                              "properties": {
+                                "command": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpGet": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tcpSocket": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "preStop": {
+                          "properties": {
+                            "exec": {
+                              "properties": {
+                                "command": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpGet": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tcpSocket": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "livenessProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ports": {
+                      "items": {
+                        "properties": {
+                          "containerPort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "hostIP": {
+                            "type": "string"
+                          },
+                          "hostPort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "containerPort"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "containerPort",
+                        "protocol"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "readinessProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "resources": {
+                      "properties": {
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "allowPrivilegeEscalation": {
+                          "type": "boolean"
+                        },
+                        "capabilities": {
+                          "properties": {
+                            "add": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "drop": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "privileged": {
+                          "type": "boolean"
+                        },
+                        "procMount": {
+                          "type": "string"
+                        },
+                        "readOnlyRootFilesystem": {
+                          "type": "boolean"
+                        },
+                        "runAsGroup": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "startupProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "stdin": {
+                      "type": "boolean"
+                    },
+                    "stdinOnce": {
+                      "type": "boolean"
+                    },
+                    "terminationMessagePath": {
+                      "type": "string"
+                    },
+                    "terminationMessagePolicy": {
+                      "type": "string"
+                    },
+                    "tty": {
+                      "type": "boolean"
+                    },
+                    "volumeDevices": {
+                      "items": {
+                        "properties": {
+                          "devicePath": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "devicePath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "properties": {
+                          "mountPath": {
+                            "type": "string"
+                          },
+                          "mountPropagation": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "subPath": {
+                            "type": "string"
+                          },
+                          "subPathExpr": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "workingDir": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ephemeralContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "imagePullSecrets": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "podSecurityContext": {
+                  "properties": {
+                    "fsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tolerations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "spec"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pdName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "repository"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "claimName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "pdID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumePath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentStatefulSetVersion": {
+          "type": "string"
+        },
+        "emqxNodes": {
+          "items": {
+            "properties": {
+              "node": {
+                "type": "string"
+              },
+              "node_status": {
+                "type": "string"
+              },
+              "otp_release": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxenterprise_v1beta3.json
+++ b/apps.emqx.io/emqxenterprise_v1beta3.json
@@ -1,0 +1,4892 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "affinity": {
+          "properties": {
+            "nodeAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "preference": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "items": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "podAffinityTerm": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaceSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "podAntiAffinity": {
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "podAffinityTerm": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaceSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "namespaces": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaceSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "emqxTemplate": {
+          "properties": {
+            "acl": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "config": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "extraVolumeMounts": {
+              "items": {
+                "properties": {
+                  "mountPath": {
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "type": "boolean"
+                  },
+                  "subPath": {
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "extraVolumes": {
+              "items": {
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureDisk": {
+                    "properties": {
+                      "cachingMode": {
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "azureFile": {
+                    "properties": {
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cephfs": {
+                    "properties": {
+                      "monitors": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "cinder": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "configMap": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "csi": {
+                    "properties": {
+                      "driver": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "downwardAPI": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "fieldRef": {
+                              "properties": {
+                                "apiVersion": {
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "properties": {
+                                "containerName": {
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "emptyDir": {
+                    "properties": {
+                      "medium": {
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "ephemeral": {
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "properties": {
+                          "metadata": {
+                            "properties": {
+                              "annotations": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "finalizers": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "labels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "spec": {
+                            "properties": {
+                              "accessModes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "dataSource": {
+                                "properties": {
+                                  "apiGroup": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "dataSourceRef": {
+                                "properties": {
+                                  "apiGroup": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resources": {
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "selector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "storageClassName": {
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "spec"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "fc": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "lun": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "wwids": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flexVolume": {
+                    "properties": {
+                      "driver": {
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "driver"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "flocker": {
+                    "properties": {
+                      "datasetName": {
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gcePersistentDisk": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "partition": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "pdName": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "pdName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "gitRepo": {
+                    "properties": {
+                      "directory": {
+                        "type": "string"
+                      },
+                      "repository": {
+                        "type": "string"
+                      },
+                      "revision": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "repository"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "glusterfs": {
+                    "properties": {
+                      "endpoints": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "hostPath": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "iscsi": {
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "type": "string"
+                      },
+                      "lun": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "portals": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "targetPortal": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "properties": {
+                      "path": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "persistentVolumeClaim": {
+                    "properties": {
+                      "claimName": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "claimName"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "photonPersistentDisk": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "pdID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "portworxVolume": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumeID"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "projected": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "sources": {
+                        "items": {
+                          "properties": {
+                            "configMap": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "downwardAPI": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "fieldRef": {
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secret": {
+                              "properties": {
+                                "items": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "serviceAccountToken": {
+                              "properties": {
+                                "audience": {
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "quobyte": {
+                    "properties": {
+                      "group": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      },
+                      "volume": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "rbd": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "pool": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "scaleIO": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "sslEnabled": {
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "type": "string"
+                      },
+                      "system": {
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "secret": {
+                    "properties": {
+                      "defaultMode": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "items": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "mode": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "path": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "storageos": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "volumeName": {
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "vsphereVolume": {
+                    "properties": {
+                      "fsType": {
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "volumePath"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "image": {
+              "type": "string"
+            },
+            "imagePullPolicy": {
+              "type": "string"
+            },
+            "license": {
+              "properties": {
+                "data": {
+                  "format": "byte",
+                  "type": "string"
+                },
+                "secretName": {
+                  "type": "string"
+                },
+                "stringData": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "livenessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "modules": {
+              "items": {
+                "properties": {
+                  "configs": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "enable": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "password": {
+              "default": "public",
+              "type": "string"
+            },
+            "readinessProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "registry": {
+              "type": "string"
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "securityContext": {
+              "properties": {
+                "fsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                  "type": "string"
+                },
+                "runAsGroup": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "runAsUser": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "level": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "supplementalGroups": {
+                  "items": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                "sysctls": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpec": {
+                      "type": "string"
+                    },
+                    "gmsaCredentialSpecName": {
+                      "type": "string"
+                    },
+                    "hostProcess": {
+                      "type": "boolean"
+                    },
+                    "runAsUserName": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "serviceTemplate": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "allocateLoadBalancerNodePorts": {
+                      "type": "boolean"
+                    },
+                    "clusterIP": {
+                      "type": "string"
+                    },
+                    "clusterIPs": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "externalIPs": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "externalName": {
+                      "type": "string"
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "healthCheckNodePort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "internalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "ipFamilies": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "ipFamilyPolicy": {
+                      "type": "string"
+                    },
+                    "loadBalancerClass": {
+                      "type": "string"
+                    },
+                    "loadBalancerIP": {
+                      "type": "string"
+                    },
+                    "loadBalancerSourceRanges": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "ports": {
+                      "items": {
+                        "properties": {
+                          "appProtocol": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nodePort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "port": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "type": "string"
+                          },
+                          "targetPort": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "port",
+                        "protocol"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "publishNotReadyAddresses": {
+                      "type": "boolean"
+                    },
+                    "selector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "sessionAffinity": {
+                      "type": "string"
+                    },
+                    "sessionAffinityConfig": {
+                      "properties": {
+                        "clientIP": {
+                          "properties": {
+                            "timeoutSeconds": {
+                              "format": "int32",
+                              "type": "integer"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startupProbe": {
+              "properties": {
+                "exec": {
+                  "properties": {
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "failureThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "grpc": {
+                  "properties": {
+                    "port": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "httpGet": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "httpHeaders": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "scheme": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "initialDelaySeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "periodSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "successThreshold": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "tcpSocket": {
+                  "properties": {
+                    "host": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "required": [
+                    "port"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "terminationGracePeriodSeconds": {
+                  "format": "int64",
+                  "type": "integer"
+                },
+                "timeoutSeconds": {
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "username": {
+              "default": "admin",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "env": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "valueFrom": {
+                "properties": {
+                  "configMapKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "fieldRef": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "resourceFieldRef": {
+                    "properties": {
+                      "containerName": {
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "secretKeyRef": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "optional": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "extraContainers": {
+          "items": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "items": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "properties": {
+                        "configMapKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "resourceFieldRef": {
+                          "properties": {
+                            "containerName": {
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "secretKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "items": {
+                  "properties": {
+                    "configMapRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "lifecycle": {
+                "properties": {
+                  "postStart": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "preStop": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "livenessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "ports": {
+                "items": {
+                  "properties": {
+                    "containerPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "readinessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resources": {
+                "properties": {
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "securityContext": {
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                  },
+                  "capabilities": {
+                    "properties": {
+                      "add": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "properties": {
+                      "level": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "seccompProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "windowsOptions": {
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdin": {
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "items": {
+                  "properties": {
+                    "devicePath": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "items": {
+                  "properties": {
+                    "mountPath": {
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "subPath": {
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "imagePullSecrets": {
+          "items": {
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "initContainers": {
+          "items": {
+            "properties": {
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "command": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "env": {
+                "items": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "properties": {
+                        "configMapKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "fieldRef": {
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "resourceFieldRef": {
+                          "properties": {
+                            "containerName": {
+                              "type": "string"
+                            },
+                            "divisor": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "resource": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resource"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        },
+                        "secretKeyRef": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "optional": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "envFrom": {
+                "items": {
+                  "properties": {
+                    "configMapRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "prefix": {
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "image": {
+                "type": "string"
+              },
+              "imagePullPolicy": {
+                "type": "string"
+              },
+              "lifecycle": {
+                "properties": {
+                  "postStart": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "preStop": {
+                    "properties": {
+                      "exec": {
+                        "properties": {
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "httpGet": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "httpHeaders": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "scheme": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "tcpSocket": {
+                        "properties": {
+                          "host": {
+                            "type": "string"
+                          },
+                          "port": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "required": [
+                          "port"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "livenessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "type": "string"
+              },
+              "ports": {
+                "items": {
+                  "properties": {
+                    "containerPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostPort": {
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "TCP",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "containerPort"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "containerPort",
+                  "protocol"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "readinessProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "resources": {
+                "properties": {
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "securityContext": {
+                "properties": {
+                  "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                  },
+                  "capabilities": {
+                    "properties": {
+                      "add": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "drop": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "privileged": {
+                    "type": "boolean"
+                  },
+                  "procMount": {
+                    "type": "string"
+                  },
+                  "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                  },
+                  "runAsGroup": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "runAsNonRoot": {
+                    "type": "boolean"
+                  },
+                  "runAsUser": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "seLinuxOptions": {
+                    "properties": {
+                      "level": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "seccompProfile": {
+                    "properties": {
+                      "localhostProfile": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "windowsOptions": {
+                    "properties": {
+                      "gmsaCredentialSpec": {
+                        "type": "string"
+                      },
+                      "gmsaCredentialSpecName": {
+                        "type": "string"
+                      },
+                      "hostProcess": {
+                        "type": "boolean"
+                      },
+                      "runAsUserName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "startupProbe": {
+                "properties": {
+                  "exec": {
+                    "properties": {
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "failureThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "grpc": {
+                    "properties": {
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "httpGet": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "httpHeaders": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "scheme": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "initialDelaySeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "periodSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "successThreshold": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tcpSocket": {
+                    "properties": {
+                      "host": {
+                        "type": "string"
+                      },
+                      "port": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "terminationGracePeriodSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "timeoutSeconds": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "stdin": {
+                "type": "boolean"
+              },
+              "stdinOnce": {
+                "type": "boolean"
+              },
+              "terminationMessagePath": {
+                "type": "string"
+              },
+              "terminationMessagePolicy": {
+                "type": "string"
+              },
+              "tty": {
+                "type": "boolean"
+              },
+              "volumeDevices": {
+                "items": {
+                  "properties": {
+                    "devicePath": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "devicePath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "volumeMounts": {
+                "items": {
+                  "properties": {
+                    "mountPath": {
+                      "type": "string"
+                    },
+                    "mountPropagation": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "subPath": {
+                      "type": "string"
+                    },
+                    "subPathExpr": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mountPath",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "workingDir": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "nodeName": {
+          "type": "string"
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "persistent": {
+          "properties": {
+            "accessModes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "dataSource": {
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "dataSourceRef": {
+              "properties": {
+                "apiGroup": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "resources": {
+              "properties": {
+                "limits": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "requests": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "selector": {
+              "properties": {
+                "matchExpressions": {
+                  "items": {
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "values": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "matchLabels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-map-type": "atomic",
+              "additionalProperties": false
+            },
+            "storageClassName": {
+              "type": "string"
+            },
+            "volumeMode": {
+              "type": "string"
+            },
+            "volumeName": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "default": 3,
+          "format": "int32",
+          "type": "integer"
+        },
+        "toleRations": {
+          "items": {
+            "properties": {
+              "effect": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "emqxNodes": {
+          "items": {
+            "properties": {
+              "node": {
+                "type": "string"
+              },
+              "node_status": {
+                "type": "string"
+              },
+              "otp_release": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxenterprise_v1beta4.json
+++ b/apps.emqx.io/emqxenterprise_v1beta4.json
@@ -1,0 +1,6486 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "blueGreenUpdate": {
+          "properties": {
+            "evacuationStrategy": {
+              "properties": {
+                "connEvictRate": {
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "sessEvictRate": {
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "waitTakeover": {
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "initialDelaySeconds": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "license": {
+          "properties": {
+            "data": {
+              "format": "byte",
+              "type": "string"
+            },
+            "secretName": {
+              "type": "string"
+            },
+            "stringData": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "persistent": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "accessModes": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dataSource": {
+                  "properties": {
+                    "apiGroup": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "dataSourceRef": {
+                  "properties": {
+                    "apiGroup": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "resources": {
+                  "properties": {
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "selector": {
+                  "properties": {
+                    "matchExpressions": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "values": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "storageClassName": {
+                  "type": "string"
+                },
+                "volumeMode": {
+                  "type": "string"
+                },
+                "volumeName": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "spec"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "replicas": {
+          "default": 3,
+          "format": "int32",
+          "type": "integer"
+        },
+        "serviceTemplate": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "allocateLoadBalancerNodePorts": {
+                  "type": "boolean"
+                },
+                "clusterIP": {
+                  "type": "string"
+                },
+                "clusterIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "externalIPs": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "externalName": {
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "type": "string"
+                },
+                "healthCheckNodePort": {
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "internalTrafficPolicy": {
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "ipFamilyPolicy": {
+                  "type": "string"
+                },
+                "loadBalancerClass": {
+                  "type": "string"
+                },
+                "loadBalancerIP": {
+                  "type": "string"
+                },
+                "loadBalancerSourceRanges": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "ports": {
+                  "items": {
+                    "properties": {
+                      "appProtocol": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-map-keys": [
+                    "port",
+                    "protocol"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "publishNotReadyAddresses": {
+                  "type": "boolean"
+                },
+                "selector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "sessionAffinity": {
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "properties": {
+                    "clientIP": {
+                      "properties": {
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "template": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "format": "int32",
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "emqxContainer": {
+                  "properties": {
+                    "args": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "bootstrapAPIKeys": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "pattern": "^[a-zA-Z\\d_]+$",
+                            "type": "string"
+                          },
+                          "secret": {
+                            "maxLength": 32,
+                            "minLength": 3,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secret"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "command": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "emqxACL": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "emqxConfig": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "env": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "properties": {
+                              "configMapKeyRef": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "fieldRef": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "resourceFieldRef": {
+                                "properties": {
+                                  "containerName": {
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "resource"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              },
+                              "secretKeyRef": {
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "key"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "envFrom": {
+                      "items": {
+                        "properties": {
+                          "configMapRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "prefix": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "image": {
+                      "properties": {
+                        "prefix": {
+                          "type": "string"
+                        },
+                        "pullPolicy": {
+                          "default": "IfNotPresent",
+                          "enum": [
+                            "Always",
+                            "Never",
+                            "IfNotPresent"
+                          ],
+                          "type": "string"
+                        },
+                        "registry": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "suffix": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "lifecycle": {
+                      "properties": {
+                        "postStart": {
+                          "properties": {
+                            "exec": {
+                              "properties": {
+                                "command": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpGet": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tcpSocket": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "preStop": {
+                          "properties": {
+                            "exec": {
+                              "properties": {
+                                "command": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "httpGet": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "tcpSocket": {
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "required": [
+                                "port"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "livenessProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "ports": {
+                      "items": {
+                        "properties": {
+                          "containerPort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "hostIP": {
+                            "type": "string"
+                          },
+                          "hostPort": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "protocol": {
+                            "default": "TCP",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "containerPort"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "containerPort",
+                        "protocol"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "readinessProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "resources": {
+                      "properties": {
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "allowPrivilegeEscalation": {
+                          "type": "boolean"
+                        },
+                        "capabilities": {
+                          "properties": {
+                            "add": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "drop": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "privileged": {
+                          "type": "boolean"
+                        },
+                        "procMount": {
+                          "type": "string"
+                        },
+                        "readOnlyRootFilesystem": {
+                          "type": "boolean"
+                        },
+                        "runAsGroup": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "startupProbe": {
+                      "properties": {
+                        "exec": {
+                          "properties": {
+                            "command": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "failureThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "grpc": {
+                          "properties": {
+                            "port": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "service": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "httpGet": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "initialDelaySeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "periodSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "successThreshold": {
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "tcpSocket": {
+                          "properties": {
+                            "host": {
+                              "type": "string"
+                            },
+                            "port": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "required": [
+                            "port"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "stdin": {
+                      "type": "boolean"
+                    },
+                    "stdinOnce": {
+                      "type": "boolean"
+                    },
+                    "terminationMessagePath": {
+                      "type": "string"
+                    },
+                    "terminationMessagePolicy": {
+                      "type": "string"
+                    },
+                    "tty": {
+                      "type": "boolean"
+                    },
+                    "volumeDevices": {
+                      "items": {
+                        "properties": {
+                          "devicePath": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "devicePath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumeMounts": {
+                      "items": {
+                        "properties": {
+                          "mountPath": {
+                            "type": "string"
+                          },
+                          "mountPropagation": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "subPath": {
+                            "type": "string"
+                          },
+                          "subPathExpr": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "mountPath",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "workingDir": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "ephemeralContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "extraContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "imagePullSecrets": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "key"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "required": [
+                                  "port"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "default": "TCP",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "containerPort"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array",
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "devicePath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "mountPath",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "podSecurityContext": {
+                  "properties": {
+                    "fsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "format": "int64",
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tolerations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "format": "int64",
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "spec"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "driver"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "pdName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "repository"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "claimName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "pdID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumeID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "volumePath"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "blueGreenUpdateStatus": {
+          "properties": {
+            "currentStatefulSet": {
+              "type": "string"
+            },
+            "evacuationsStatus": {
+              "items": {
+                "properties": {
+                  "connection_eviction_rate": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "connection_goal": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "node": {
+                    "type": "string"
+                  },
+                  "session_eviction_rate": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "session_goal": {
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "session_recipients": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "state": {
+                    "type": "string"
+                  },
+                  "stats": {
+                    "properties": {
+                      "current_connected": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "current_sessions": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "initial_connected": {
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "initial_sessions": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "originStatefulSet": {
+              "type": "string"
+            },
+            "startedAt": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "lastUpdateTime": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "currentStatefulSetVersion": {
+          "type": "string"
+        },
+        "emqxNodes": {
+          "items": {
+            "properties": {
+              "node": {
+                "type": "string"
+              },
+              "node_status": {
+                "type": "string"
+              },
+              "otp_release": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "readyReplicas": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "replicas": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxplugin_v1beta3.json
+++ b/apps.emqx.io/emqxplugin_v1beta3.json
@@ -1,0 +1,44 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "config": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "pluginName": {
+          "type": "string"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "phase": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/apps.emqx.io/emqxplugin_v1beta4.json
+++ b/apps.emqx.io/emqxplugin_v1beta4.json
@@ -1,0 +1,35 @@
+{
+  "properties": {
+    "apiVersion": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "properties": {
+        "config": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "pluginName": {
+          "type": "string"
+        },
+        "selector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
When using Kubeconform the checks failed against emqx crd's. Using the CRD extractor from this repo I extracted them from my K8s cluster.

Upstream CRD's for reference: https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator/templates