### PR TITLE
Added tigera operator schemas

### DIFF
--- a/operator.tigera.io/apiserver_v1.json
+++ b/operator.tigera.io/apiserver_v1.json
@@ -1,0 +1,952 @@
+{
+  "description": "APIServer installs the Tigera API server and related resources. At most one instance of this resource is supported. It must be named \"tigera-secure\".",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the desired state for the Tigera API server.",
+      "properties": {
+        "apiServerDeployment": {
+          "description": "APIServerDeployment configures the calico-apiserver (or tigera-apiserver in Enterprise) Deployment. If used in conjunction with ControlPlaneNodeSelector or ControlPlaneTolerations, then these overrides take precedence.",
+          "properties": {
+            "metadata": {
+              "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the API server Deployment.",
+              "properties": {
+                "minReadySeconds": {
+                  "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for minReadySeconds.",
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "template": {
+                  "description": "Template describes the API server Deployment pod that will be created.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "Spec is the API server Deployment's PodSpec.",
+                      "properties": {
+                        "affinity": {
+                          "description": "Affinity is a group of affinity scheduling rules for the API server pods. If specified, this overrides any affinity that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for affinity. WARNING: Please note that this field will override the default API server Deployment affinity.",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "containers": {
+                          "description": "Containers is a list of API server containers. If specified, this overrides the specified API server Deployment containers. If omitted, the API server Deployment will use its default values for its containers.",
+                          "items": {
+                            "description": "APIServerDeploymentContainer is an API server Deployment container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the API server Deployment container by name.",
+                                "enum": [
+                                  "calico-apiserver",
+                                  "tigera-queryserver"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named API server Deployment container's resources. If omitted, the API server Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "description": "InitContainers is a list of API server init containers. If specified, this overrides the specified API server Deployment init containers. If omitted, the API server Deployment will use its default values for its init containers.",
+                          "items": {
+                            "description": "APIServerDeploymentInitContainer is an API server Deployment init container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the API server Deployment init container by name.",
+                                "enum": [
+                                  "calico-apiserver-certs-key-cert-provisioner"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named API server Deployment init container's resources. If omitted, the API server Deployment will use its default value for this init container's resources.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is the API server pod's scheduling constraints. If specified, each of the key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the API server Deployment and each of this field's key/value pairs are added to the API server Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the API server Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default API server Deployment nodeSelector.",
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "description": "Tolerations is the API server pod's tolerations. If specified, this overrides any tolerations that may be set on the API server Deployment. If omitted, the API server Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default API server Deployment tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed status for the Tigera API server.",
+      "properties": {
+        "state": {
+          "description": "State provides user-readable status.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/operator.tigera.io/imageset_v1.json
+++ b/operator.tigera.io/imageset_v1.json
@@ -1,0 +1,46 @@
+{
+  "description": "ImageSet is used to specify image digests for the images that the operator deploys. The name of the ImageSet is expected to be in the format `<variant>-<release>`. The `variant` used is `enterprise` if the InstallationSpec Variant is `TigeraSecureEnterprise` otherwise it is `calico`. The `release` must match the version of the variant that the operator is built to deploy, this version can be obtained by passing the `--version` flag to the operator binary.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ImageSetSpec defines the desired state of ImageSet.",
+      "properties": {
+        "images": {
+          "description": "Images is the list of images to use digests. All images that the operator will deploy must be specified.",
+          "items": {
+            "properties": {
+              "digest": {
+                "description": "Digest is the image identifier that will be used for the Image. The field should not include a leading `@` and must be prefixed with `sha256:`.",
+                "type": "string"
+              },
+              "image": {
+                "description": "Image is an image that the operator deploys and instead of using the built in tag the operator will use the Digest for the image identifier. The value should be the image name without registry or tag or digest. For the image `docker.io/calico/node:v3.17.1` it should be represented as `calico/node`",
+                "type": "string"
+              }
+            },
+            "required": [
+              "digest",
+              "image"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/operator.tigera.io/installation_v1.json
+++ b/operator.tigera.io/installation_v1.json
@@ -1,0 +1,8553 @@
+{
+  "description": "Installation configures an installation of Calico or Calico Enterprise. At most one instance of this resource is supported. It must be named \"default\". The Installation API installs core networking and network policy components, and provides general install-time configuration.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the desired state for the Calico or Calico Enterprise installation.",
+      "properties": {
+        "calicoKubeControllersDeployment": {
+          "description": "CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence.",
+          "properties": {
+            "metadata": {
+              "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the calico-kube-controllers Deployment.",
+              "properties": {
+                "minReadySeconds": {
+                  "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for minReadySeconds.",
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "template": {
+                  "description": "Template describes the calico-kube-controllers Deployment pod that will be created.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "Spec is the calico-kube-controllers Deployment's PodSpec.",
+                      "properties": {
+                        "affinity": {
+                          "description": "Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods. If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for affinity. WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity.",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "containers": {
+                          "description": "Containers is a list of calico-kube-controllers containers. If specified, this overrides the specified calico-kube-controllers Deployment containers. If omitted, the calico-kube-controllers Deployment will use its default values for its containers.",
+                          "items": {
+                            "description": "CalicoKubeControllersDeploymentContainer is a calico-kube-controllers Deployment container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the calico-kube-controllers Deployment container by name.",
+                                "enum": [
+                                  "calico-kube-controllers"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-kube-controllers Deployment container's resources. If omitted, the calico-kube-controllers Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is the calico-kube-controllers pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment and each of this field's key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector.",
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "description": "Tolerations is the calico-kube-controllers pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "calicoNetwork": {
+          "description": "CalicoNetwork specifies networking configuration options for Calico.",
+          "properties": {
+            "bgp": {
+              "description": "BGP configures whether or not to enable Calico's BGP capabilities.",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ],
+              "type": "string"
+            },
+            "containerIPForwarding": {
+              "description": "ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration. Default: Disabled",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ],
+              "type": "string"
+            },
+            "hostPorts": {
+              "description": "HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin. Default: Enabled",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ],
+              "type": "string"
+            },
+            "ipPools": {
+              "description": "IPPools contains a list of IP pools to create if none exist. At most one IP pool of each address family may be specified. If omitted, a single pool will be configured if needed.",
+              "items": {
+                "properties": {
+                  "blockSize": {
+                    "description": "BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "cidr": {
+                    "description": "CIDR contains the address range for the IP Pool in classless inter-domain routing format.",
+                    "type": "string"
+                  },
+                  "disableBGPExport": {
+                    "default": false,
+                    "description": "DisableBGPExport specifies whether routes from this IP pool's CIDR are exported over BGP. Default: false",
+                    "type": "boolean"
+                  },
+                  "encapsulation": {
+                    "description": "Encapsulation specifies the encapsulation type that will be used with the IP Pool. Default: IPIP",
+                    "enum": [
+                      "IPIPCrossSubnet",
+                      "IPIP",
+                      "VXLAN",
+                      "VXLANCrossSubnet",
+                      "None"
+                    ],
+                    "type": "string"
+                  },
+                  "natOutgoing": {
+                    "description": "NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic. Default: Enabled",
+                    "enum": [
+                      "Enabled",
+                      "Disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "nodeSelector": {
+                    "description": "NodeSelector specifies the node selector that will be set for the IP Pool. Default: 'all()'",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "cidr"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "linuxDataplane": {
+              "description": "LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is used. Default: Iptables",
+              "enum": [
+                "Iptables",
+                "BPF",
+                "VPP"
+              ],
+              "type": "string"
+            },
+            "mtu": {
+              "description": "MTU specifies the maximum transmission unit to use on the pod network. If not specified, Calico will perform MTU auto-detection based on the cluster network.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "multiInterfaceMode": {
+              "description": "MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations using the Calico CNI plugin. Default: None",
+              "enum": [
+                "None",
+                "Multus"
+              ],
+              "type": "string"
+            },
+            "nodeAddressAutodetectionV4": {
+              "description": "NodeAddressAutodetectionV4 specifies an approach to automatically detect node IPv4 addresses. If not specified, will use default auto-detection settings to acquire an IPv4 address for each node.",
+              "properties": {
+                "canReach": {
+                  "description": "CanReach enables IP auto-detection based on which source address on the node is used to reach the specified IP or domain.",
+                  "type": "string"
+                },
+                "cidrs": {
+                  "description": "CIDRS enables IP auto-detection based on which addresses on the nodes are within one of the provided CIDRs.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "firstFound": {
+                  "description": "FirstFound uses default interface matching parameters to select an interface, performing best-effort filtering based on well-known interface names.",
+                  "type": "boolean"
+                },
+                "interface": {
+                  "description": "Interface enables IP auto-detection based on interfaces that match the given regex.",
+                  "type": "string"
+                },
+                "kubernetes": {
+                  "description": "Kubernetes configures Calico to detect node addresses based on the Kubernetes API.",
+                  "enum": [
+                    "NodeInternalIP"
+                  ],
+                  "type": "string"
+                },
+                "skipInterface": {
+                  "description": "SkipInterface enables IP auto-detection based on interfaces that do not match the given regex.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodeAddressAutodetectionV6": {
+              "description": "NodeAddressAutodetectionV6 specifies an approach to automatically detect node IPv6 addresses. If not specified, IPv6 addresses will not be auto-detected.",
+              "properties": {
+                "canReach": {
+                  "description": "CanReach enables IP auto-detection based on which source address on the node is used to reach the specified IP or domain.",
+                  "type": "string"
+                },
+                "cidrs": {
+                  "description": "CIDRS enables IP auto-detection based on which addresses on the nodes are within one of the provided CIDRs.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "firstFound": {
+                  "description": "FirstFound uses default interface matching parameters to select an interface, performing best-effort filtering based on well-known interface names.",
+                  "type": "boolean"
+                },
+                "interface": {
+                  "description": "Interface enables IP auto-detection based on interfaces that match the given regex.",
+                  "type": "string"
+                },
+                "kubernetes": {
+                  "description": "Kubernetes configures Calico to detect node addresses based on the Kubernetes API.",
+                  "enum": [
+                    "NodeInternalIP"
+                  ],
+                  "type": "string"
+                },
+                "skipInterface": {
+                  "description": "SkipInterface enables IP auto-detection based on interfaces that do not match the given regex.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "calicoNodeDaemonSet": {
+          "description": "CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence.",
+          "properties": {
+            "metadata": {
+              "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the DaemonSet.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the calico-node DaemonSet.",
+              "properties": {
+                "minReadySeconds": {
+                  "description": "MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for minReadySeconds.",
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "template": {
+                  "description": "Template describes the calico-node DaemonSet pod that will be created.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "Spec is the calico-node DaemonSet's PodSpec.",
+                      "properties": {
+                        "affinity": {
+                          "description": "Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-node DaemonSet affinity.",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "containers": {
+                          "description": "Containers is a list of calico-node containers. If specified, this overrides the specified calico-node DaemonSet containers. If omitted, the calico-node DaemonSet will use its default values for its containers.",
+                          "items": {
+                            "description": "CalicoNodeDaemonSetContainer is a calico-node DaemonSet container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the calico-node DaemonSet container by name.",
+                                "enum": [
+                                  "calico-node"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "description": "InitContainers is a list of calico-node init containers. If specified, this overrides the specified calico-node DaemonSet init containers. If omitted, the calico-node DaemonSet will use its default values for its init containers.",
+                          "items": {
+                            "description": "CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the calico-node DaemonSet init container by name.",
+                                "enum": [
+                                  "install-cni",
+                                  "hostpath-init",
+                                  "flexvol-driver",
+                                  "mount-bpffs",
+                                  "node-certs-key-cert-provisioner",
+                                  "calico-node-prometheus-server-tls-key-cert-provisioner"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet init container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is the calico-node pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector.",
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "description": "Tolerations is the calico-node pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-node DaemonSet tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "calicoWindowsUpgradeDaemonSet": {
+          "description": "CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.",
+          "properties": {
+            "metadata": {
+              "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the calico-windows-upgrade DaemonSet.",
+              "properties": {
+                "minReadySeconds": {
+                  "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for minReadySeconds.",
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "template": {
+                  "description": "Template describes the calico-windows-upgrade DaemonSet pod that will be created.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "Spec is the calico-windows-upgrade DaemonSet's PodSpec.",
+                      "properties": {
+                        "affinity": {
+                          "description": "Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods. If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity.",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "containers": {
+                          "description": "Containers is a list of calico-windows-upgrade containers. If specified, this overrides the specified calico-windows-upgrade DaemonSet containers. If omitted, the calico-windows-upgrade DaemonSet will use its default values for its containers.",
+                          "items": {
+                            "description": "CalicoWindowsUpgradeDaemonSetContainer is a calico-windows-upgrade DaemonSet container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the calico-windows-upgrade DaemonSet container by name.",
+                                "enum": [
+                                  "calico-windows-upgrade"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-windows-upgrade DaemonSet container's resources. If omitted, the calico-windows-upgrade DaemonSet will use its default value for this container's resources.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is the calico-windows-upgrade pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector.",
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "description": "Tolerations is the calico-windows-upgrade pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "certificateManagement": {
+          "description": "CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization.",
+          "properties": {
+            "caCert": {
+              "description": "Certificate of the authority that signs the CertificateSigningRequests in PEM format.",
+              "format": "byte",
+              "type": "string"
+            },
+            "keyAlgorithm": {
+              "description": "Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate request. Default: RSAWithSize2048",
+              "enum": [
+                "",
+                "RSAWithSize2048",
+                "RSAWithSize4096",
+                "RSAWithSize8192",
+                "ECDSAWithCurve256",
+                "ECDSAWithCurve384",
+                "ECDSAWithCurve521"
+              ],
+              "type": "string"
+            },
+            "signatureAlgorithm": {
+              "description": "Specify the algorithm used for the signature of the X.509 certificate request. Default: SHA256WithRSA",
+              "enum": [
+                "",
+                "SHA256WithRSA",
+                "SHA384WithRSA",
+                "SHA512WithRSA",
+                "ECDSAWithSHA256",
+                "ECDSAWithSHA384",
+                "ECDSAWithSHA512"
+              ],
+              "type": "string"
+            },
+            "signerName": {
+              "description": "When a CSR is issued to the certificates.k8s.io API, the signerName is added to the request in order to accommodate for clusters with multiple signers. Must be formatted as: `<my-domain>/<my-signername>`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "caCert",
+            "signerName"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "cni": {
+          "description": "CNI specifies the CNI that will be used by this installation.",
+          "properties": {
+            "ipam": {
+              "description": "IPAM specifies the pod IP address management that will be used in the Calico or Calico Enterprise installation.",
+              "properties": {
+                "type": {
+                  "description": "Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation. * For CNI Plugin Calico, this field defaults to Calico. * For CNI Plugin GKE, this field defaults to HostLocal. * For CNI Plugin AzureVNET, this field defaults to AzureVNET. * For CNI Plugin AmazonVPC, this field defaults to AmazonVPC. \n The IPAM plugin is installed and configured only if the CNI plugin is set to Calico, for all other values of the CNI plugin the plugin binaries and CNI config is a dependency that is expected to be installed separately. \n Default: Calico",
+                  "enum": [
+                    "Calico",
+                    "HostLocal",
+                    "AmazonVPC",
+                    "AzureVNET"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases this field defaults to Calico. \n For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed separately. \n Default: Calico",
+              "enum": [
+                "Calico",
+                "GKE",
+                "AmazonVPC",
+                "AzureVNET"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "componentResources": {
+          "description": "Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are supported for installations.",
+          "items": {
+            "description": "Deprecated. Please use component resource config fields in Installation.Spec instead. The ComponentResource struct associates a ResourceRequirements with a component by name",
+            "properties": {
+              "componentName": {
+                "description": "ComponentName is an enum which identifies the component",
+                "enum": [
+                  "Node",
+                  "Typha",
+                  "KubeControllers"
+                ],
+                "type": "string"
+              },
+              "resourceRequirements": {
+                "description": "ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.",
+                "properties": {
+                  "limits": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  },
+                  "requests": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "componentName",
+              "resourceRequirements"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "controlPlaneNodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico components. This is globally applied to all resources created by the operator excluding daemonsets.",
+          "type": "object"
+        },
+        "controlPlaneReplicas": {
+          "description": "ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed. This field applies to all control plane components that support High Availability. Defaults to 2.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "controlPlaneTolerations": {
+          "description": "ControlPlaneTolerations specify tolerations which are then globally applied to all resources created by the operator.",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "fipsMode": {
+          "description": "FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards. Default: Disabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "type": "string"
+        },
+        "flexVolumePath": {
+          "description": "FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the kubernetesProvider.",
+          "type": "string"
+        },
+        "imagePath": {
+          "description": "ImagePath allows for the path part of an image to be specified. If specified then the specified value will be used as the image path for each image. If not specified or empty, the default for each image will be used. A special case value, UseDefault, is supported to explicitly specify the default image path will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<imagePath>` portion of the above format.",
+          "type": "string"
+        },
+        "imagePrefix": {
+          "description": "ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value will be used as a prefix on each image. If not specified or empty, no prefix will be used. A special case value, UseDefault, is supported to explicitly specify the default image prefix will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<imagePrefix>` portion of the above format.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is an array of references to container registry pull secrets to use. These are applied to all images to be pulled.",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "kubeletVolumePluginPath": {
+          "description": "KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be enabled by default. If set to 'None', CSI will be disabled. Default: /var/lib/kubelet",
+          "type": "string"
+        },
+        "kubernetesProvider": {
+          "description": "KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific configuration. If the specified value is empty, the Operator will attempt to automatically determine the current provider. If the specified value is not empty, the Operator will still attempt auto-detection, but will additionally compare the auto-detected value to the specified value to confirm they match.",
+          "enum": [
+            "",
+            "EKS",
+            "GKE",
+            "AKS",
+            "OpenShift",
+            "DockerEnterprise",
+            "RKE2"
+          ],
+          "type": "string"
+        },
+        "nodeMetricsPort": {
+          "description": "NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled. If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then prometheus metrics may still be configured through FelixConfiguration.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "nodeUpdateStrategy": {
+          "description": "NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field.",
+          "properties": {
+            "rollingUpdate": {
+              "description": "Rolling update config params. Present only if type = \"RollingUpdate\". --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345",
+              "properties": {
+                "maxSurge": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption. This is beta field and enabled/disabled by DaemonSetUpdateSurge feature gate.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "maxUnavailable": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
+                  "x-kubernetes-int-or-string": true
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "nonPrivileged": {
+          "description": "NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.",
+          "type": "string"
+        },
+        "registry": {
+          "description": "Registry is the default Docker registry used for component Docker images. If specified then the given value must end with a slash character (`/`) and all images will be pulled from this registry. If not specified then the default registries will be used. A special case value, UseDefault, is supported to explicitly specify the default registries will be used. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<registry>` portion of the above format.",
+          "type": "string"
+        },
+        "typhaAffinity": {
+          "description": "Deprecated. Please use Installation.Spec.TyphaDeployment instead. TyphaAffinity allows configuration of node affinity characteristics for Typha pods.",
+          "properties": {
+            "nodeAffinity": {
+              "description": "NodeAffinity describes node affinity scheduling rules for typha.",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+                  "items": {
+                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                    "properties": {
+                      "preference": {
+                        "description": "A node selector term, associated with the corresponding weight.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "weight": {
+                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "WARNING: Please note that if the affinity requirements specified by this field are not met at scheduling time, the pod will NOT be scheduled onto the node. There is no fallback to another affinity rules with this setting. This may cause networking disruption or even catastrophic failure! PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity unless there is a specific well understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and you can guarantee that the RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement. NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes, to avoid scheduling Typhas on virtual-nodes. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                      "items": {
+                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of node selector requirements by node's labels.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchFields": {
+                            "description": "A list of node selector requirements by node's fields.",
+                            "items": {
+                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "The label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "typhaDeployment": {
+          "description": "TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources or TyphaAffinity, then these overrides take precedence.",
+          "properties": {
+            "metadata": {
+              "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "description": "Spec is the specification of the typha Deployment.",
+              "properties": {
+                "minReadySeconds": {
+                  "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for minReadySeconds.",
+                  "format": "int32",
+                  "maximum": 2147483647,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "template": {
+                  "description": "Template describes the typha Deployment pod that will be created.",
+                  "properties": {
+                    "metadata": {
+                      "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                          "type": "object"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "description": "Spec is the typha Deployment's PodSpec.",
+                      "properties": {
+                        "affinity": {
+                          "description": "Affinity is a group of affinity scheduling rules for the typha pods. If specified, this overrides any affinity that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for affinity. If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence. WARNING: Please note that this field will override the default calico-typha Deployment affinity.",
+                          "properties": {
+                            "nodeAffinity": {
+                              "description": "Describes node affinity scheduling rules for the pod.",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                    "properties": {
+                                      "preference": {
+                                        "description": "A node selector term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "preference",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "description": "Required. A list of node selector terms. The terms are ORed.",
+                                      "items": {
+                                        "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "A list of node selector requirements by node's labels.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "description": "A list of node selector requirements by node's fields.",
+                                            "items": {
+                                              "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "The label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "nodeSelectorTerms"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                  "items": {
+                                    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "required": [
+                                      "podAffinityTerm",
+                                      "weight"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                  "items": {
+                                    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "containers": {
+                          "description": "Containers is a list of typha containers. If specified, this overrides the specified typha Deployment containers. If omitted, the typha Deployment will use its default values for its containers.",
+                          "items": {
+                            "description": "TyphaDeploymentContainer is a typha Deployment container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the typha Deployment container by name.",
+                                "enum": [
+                                  "calico-typha"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment container's resources. If omitted, the typha Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "description": "InitContainers is a list of typha init containers. If specified, this overrides the specified typha Deployment init containers. If omitted, the typha Deployment will use its default values for its init containers.",
+                          "items": {
+                            "description": "TyphaDeploymentInitContainer is a typha Deployment init container.",
+                            "properties": {
+                              "name": {
+                                "description": "Name is an enum which identifies the typha Deployment init container by name.",
+                                "enum": [
+                                  "typha-certs-key-cert-provisioner"
+                                ],
+                                "type": "string"
+                              },
+                              "resources": {
+                                "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment init container's resources. If omitted, the typha Deployment will use its default value for this init container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                "properties": {
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "NodeSelector is the calico-typha pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-typha Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector.",
+                          "type": "object"
+                        },
+                        "tolerations": {
+                          "description": "Tolerations is the typha pod's tolerations. If specified, this overrides any tolerations that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-typha Deployment tolerations.",
+                          "items": {
+                            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                            "properties": {
+                              "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                              },
+                              "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer"
+                              },
+                              "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "typhaMetricsPort": {
+          "description": "TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not enabled.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "variant": {
+          "description": "Variant is the product to install - one of Calico or TigeraSecureEnterprise Default: Calico",
+          "enum": [
+            "Calico",
+            "TigeraSecureEnterprise"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Most recently observed state for the Calico or Calico Enterprise installation.",
+      "properties": {
+        "computed": {
+          "description": "Computed is the final installation including overlaid resources.",
+          "properties": {
+            "calicoKubeControllersDeployment": {
+              "description": "CalicoKubeControllersDeployment configures the calico-kube-controllers Deployment. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec is the specification of the calico-kube-controllers Deployment.",
+                  "properties": {
+                    "minReadySeconds": {
+                      "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for minReadySeconds.",
+                      "format": "int32",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "Template describes the calico-kube-controllers Deployment pod that will be created.",
+                      "properties": {
+                        "metadata": {
+                          "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                              "type": "object"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "description": "Spec is the calico-kube-controllers Deployment's PodSpec.",
+                          "properties": {
+                            "affinity": {
+                              "description": "Affinity is a group of affinity scheduling rules for the calico-kube-controllers pods. If specified, this overrides any affinity that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for affinity. WARNING: Please note that this field will override the default calico-kube-controllers Deployment affinity.",
+                              "properties": {
+                                "nodeAffinity": {
+                                  "description": "Describes node affinity scheduling rules for the pod.",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                          "preference": {
+                                            "description": "A node selector term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "preference",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                                          "items": {
+                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "nodeSelectorTerms"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "containers": {
+                              "description": "Containers is a list of calico-kube-controllers containers. If specified, this overrides the specified calico-kube-controllers Deployment containers. If omitted, the calico-kube-controllers Deployment will use its default values for its containers.",
+                              "items": {
+                                "description": "CalicoKubeControllersDeploymentContainer is a calico-kube-controllers Deployment container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the calico-kube-controllers Deployment container by name.",
+                                    "enum": [
+                                      "calico-kube-controllers"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-kube-controllers Deployment container's resources. If omitted, the calico-kube-controllers Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "NodeSelector is the calico-kube-controllers pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If used in conjunction with ControlPlaneNodeSelector, that nodeSelector is set on the calico-kube-controllers Deployment and each of this field's key/value pairs are added to the calico-kube-controllers Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-kube-controllers Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-kube-controllers Deployment nodeSelector.",
+                              "type": "object"
+                            },
+                            "tolerations": {
+                              "description": "Tolerations is the calico-kube-controllers pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-kube-controllers Deployment. If omitted, the calico-kube-controllers Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-kube-controllers Deployment tolerations.",
+                              "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "calicoNetwork": {
+              "description": "CalicoNetwork specifies networking configuration options for Calico.",
+              "properties": {
+                "bgp": {
+                  "description": "BGP configures whether or not to enable Calico's BGP capabilities.",
+                  "enum": [
+                    "Enabled",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "containerIPForwarding": {
+                  "description": "ContainerIPForwarding configures whether ip forwarding will be enabled for containers in the CNI configuration. Default: Disabled",
+                  "enum": [
+                    "Enabled",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "hostPorts": {
+                  "description": "HostPorts configures whether or not Calico will support Kubernetes HostPorts. Valid only when using the Calico CNI plugin. Default: Enabled",
+                  "enum": [
+                    "Enabled",
+                    "Disabled"
+                  ],
+                  "type": "string"
+                },
+                "ipPools": {
+                  "description": "IPPools contains a list of IP pools to create if none exist. At most one IP pool of each address family may be specified. If omitted, a single pool will be configured if needed.",
+                  "items": {
+                    "properties": {
+                      "blockSize": {
+                        "description": "BlockSize specifies the CIDR prefex length to use when allocating per-node IP blocks from the main IP pool CIDR. Default: 26 (IPv4), 122 (IPv6)",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "cidr": {
+                        "description": "CIDR contains the address range for the IP Pool in classless inter-domain routing format.",
+                        "type": "string"
+                      },
+                      "disableBGPExport": {
+                        "default": false,
+                        "description": "DisableBGPExport specifies whether routes from this IP pool's CIDR are exported over BGP. Default: false",
+                        "type": "boolean"
+                      },
+                      "encapsulation": {
+                        "description": "Encapsulation specifies the encapsulation type that will be used with the IP Pool. Default: IPIP",
+                        "enum": [
+                          "IPIPCrossSubnet",
+                          "IPIP",
+                          "VXLAN",
+                          "VXLANCrossSubnet",
+                          "None"
+                        ],
+                        "type": "string"
+                      },
+                      "natOutgoing": {
+                        "description": "NATOutgoing specifies if NAT will be enabled or disabled for outgoing traffic. Default: Enabled",
+                        "enum": [
+                          "Enabled",
+                          "Disabled"
+                        ],
+                        "type": "string"
+                      },
+                      "nodeSelector": {
+                        "description": "NodeSelector specifies the node selector that will be set for the IP Pool. Default: 'all()'",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "cidr"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "linuxDataplane": {
+                  "description": "LinuxDataplane is used to select the dataplane used for Linux nodes. In particular, it causes the operator to add required mounts and environment variables for the particular dataplane. If not specified, iptables mode is used. Default: Iptables",
+                  "enum": [
+                    "Iptables",
+                    "BPF",
+                    "VPP"
+                  ],
+                  "type": "string"
+                },
+                "mtu": {
+                  "description": "MTU specifies the maximum transmission unit to use on the pod network. If not specified, Calico will perform MTU auto-detection based on the cluster network.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "multiInterfaceMode": {
+                  "description": "MultiInterfaceMode configures what will configure multiple interface per pod. Only valid for Calico Enterprise installations using the Calico CNI plugin. Default: None",
+                  "enum": [
+                    "None",
+                    "Multus"
+                  ],
+                  "type": "string"
+                },
+                "nodeAddressAutodetectionV4": {
+                  "description": "NodeAddressAutodetectionV4 specifies an approach to automatically detect node IPv4 addresses. If not specified, will use default auto-detection settings to acquire an IPv4 address for each node.",
+                  "properties": {
+                    "canReach": {
+                      "description": "CanReach enables IP auto-detection based on which source address on the node is used to reach the specified IP or domain.",
+                      "type": "string"
+                    },
+                    "cidrs": {
+                      "description": "CIDRS enables IP auto-detection based on which addresses on the nodes are within one of the provided CIDRs.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "firstFound": {
+                      "description": "FirstFound uses default interface matching parameters to select an interface, performing best-effort filtering based on well-known interface names.",
+                      "type": "boolean"
+                    },
+                    "interface": {
+                      "description": "Interface enables IP auto-detection based on interfaces that match the given regex.",
+                      "type": "string"
+                    },
+                    "kubernetes": {
+                      "description": "Kubernetes configures Calico to detect node addresses based on the Kubernetes API.",
+                      "enum": [
+                        "NodeInternalIP"
+                      ],
+                      "type": "string"
+                    },
+                    "skipInterface": {
+                      "description": "SkipInterface enables IP auto-detection based on interfaces that do not match the given regex.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "nodeAddressAutodetectionV6": {
+                  "description": "NodeAddressAutodetectionV6 specifies an approach to automatically detect node IPv6 addresses. If not specified, IPv6 addresses will not be auto-detected.",
+                  "properties": {
+                    "canReach": {
+                      "description": "CanReach enables IP auto-detection based on which source address on the node is used to reach the specified IP or domain.",
+                      "type": "string"
+                    },
+                    "cidrs": {
+                      "description": "CIDRS enables IP auto-detection based on which addresses on the nodes are within one of the provided CIDRs.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "firstFound": {
+                      "description": "FirstFound uses default interface matching parameters to select an interface, performing best-effort filtering based on well-known interface names.",
+                      "type": "boolean"
+                    },
+                    "interface": {
+                      "description": "Interface enables IP auto-detection based on interfaces that match the given regex.",
+                      "type": "string"
+                    },
+                    "kubernetes": {
+                      "description": "Kubernetes configures Calico to detect node addresses based on the Kubernetes API.",
+                      "enum": [
+                        "NodeInternalIP"
+                      ],
+                      "type": "string"
+                    },
+                    "skipInterface": {
+                      "description": "SkipInterface enables IP auto-detection based on interfaces that do not match the given regex.",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "calicoNodeDaemonSet": {
+              "description": "CalicoNodeDaemonSet configures the calico-node DaemonSet. If used in conjunction with the deprecated ComponentResources, then these overrides take precedence.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the DaemonSet.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec is the specification of the calico-node DaemonSet.",
+                  "properties": {
+                    "minReadySeconds": {
+                      "description": "MinReadySeconds is the minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for minReadySeconds.",
+                      "format": "int32",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "Template describes the calico-node DaemonSet pod that will be created.",
+                      "properties": {
+                        "metadata": {
+                          "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                              "type": "object"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "description": "Spec is the calico-node DaemonSet's PodSpec.",
+                          "properties": {
+                            "affinity": {
+                              "description": "Affinity is a group of affinity scheduling rules for the calico-node pods. If specified, this overrides any affinity that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-node DaemonSet affinity.",
+                              "properties": {
+                                "nodeAffinity": {
+                                  "description": "Describes node affinity scheduling rules for the pod.",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                          "preference": {
+                                            "description": "A node selector term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "preference",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                                          "items": {
+                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "nodeSelectorTerms"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "containers": {
+                              "description": "Containers is a list of calico-node containers. If specified, this overrides the specified calico-node DaemonSet containers. If omitted, the calico-node DaemonSet will use its default values for its containers.",
+                              "items": {
+                                "description": "CalicoNodeDaemonSetContainer is a calico-node DaemonSet container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the calico-node DaemonSet container by name.",
+                                    "enum": [
+                                      "calico-node"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "description": "InitContainers is a list of calico-node init containers. If specified, this overrides the specified calico-node DaemonSet init containers. If omitted, the calico-node DaemonSet will use its default values for its init containers.",
+                              "items": {
+                                "description": "CalicoNodeDaemonSetInitContainer is a calico-node DaemonSet init container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the calico-node DaemonSet init container by name.",
+                                    "enum": [
+                                      "install-cni",
+                                      "hostpath-init",
+                                      "flexvol-driver",
+                                      "mount-bpffs",
+                                      "node-certs-key-cert-provisioner",
+                                      "calico-node-prometheus-server-tls-key-cert-provisioner"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-node DaemonSet init container's resources. If omitted, the calico-node DaemonSet will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "NodeSelector is the calico-node pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-node DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-node DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-node DaemonSet nodeSelector.",
+                              "type": "object"
+                            },
+                            "tolerations": {
+                              "description": "Tolerations is the calico-node pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-node DaemonSet. If omitted, the calico-node DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-node DaemonSet tolerations.",
+                              "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "calicoWindowsUpgradeDaemonSet": {
+              "description": "CalicoWindowsUpgradeDaemonSet configures the calico-windows-upgrade DaemonSet.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec is the specification of the calico-windows-upgrade DaemonSet.",
+                  "properties": {
+                    "minReadySeconds": {
+                      "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for minReadySeconds.",
+                      "format": "int32",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "Template describes the calico-windows-upgrade DaemonSet pod that will be created.",
+                      "properties": {
+                        "metadata": {
+                          "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                              "type": "object"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "description": "Spec is the calico-windows-upgrade DaemonSet's PodSpec.",
+                          "properties": {
+                            "affinity": {
+                              "description": "Affinity is a group of affinity scheduling rules for the calico-windows-upgrade pods. If specified, this overrides any affinity that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for affinity. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet affinity.",
+                              "properties": {
+                                "nodeAffinity": {
+                                  "description": "Describes node affinity scheduling rules for the pod.",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                          "preference": {
+                                            "description": "A node selector term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "preference",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                                          "items": {
+                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "nodeSelectorTerms"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "containers": {
+                              "description": "Containers is a list of calico-windows-upgrade containers. If specified, this overrides the specified calico-windows-upgrade DaemonSet containers. If omitted, the calico-windows-upgrade DaemonSet will use its default values for its containers.",
+                              "items": {
+                                "description": "CalicoWindowsUpgradeDaemonSetContainer is a calico-windows-upgrade DaemonSet container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the calico-windows-upgrade DaemonSet container by name.",
+                                    "enum": [
+                                      "calico-windows-upgrade"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named calico-windows-upgrade DaemonSet container's resources. If omitted, the calico-windows-upgrade DaemonSet will use its default value for this container's resources.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "NodeSelector is the calico-windows-upgrade pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-windows-upgrade DaemonSet nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-windows-upgrade DaemonSet will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-windows-upgrade DaemonSet nodeSelector.",
+                              "type": "object"
+                            },
+                            "tolerations": {
+                              "description": "Tolerations is the calico-windows-upgrade pod's tolerations. If specified, this overrides any tolerations that may be set on the calico-windows-upgrade DaemonSet. If omitted, the calico-windows-upgrade DaemonSet will use its default value for tolerations. WARNING: Please note that this field will override the default calico-windows-upgrade DaemonSet tolerations.",
+                              "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "certificateManagement": {
+              "description": "CertificateManagement configures pods to submit a CertificateSigningRequest to the certificates.k8s.io/v1beta1 API in order to obtain TLS certificates. This feature requires that you bring your own CSR signing and approval process, otherwise pods will be stuck during initialization.",
+              "properties": {
+                "caCert": {
+                  "description": "Certificate of the authority that signs the CertificateSigningRequests in PEM format.",
+                  "format": "byte",
+                  "type": "string"
+                },
+                "keyAlgorithm": {
+                  "description": "Specify the algorithm used by pods to generate a key pair that is associated with the X.509 certificate request. Default: RSAWithSize2048",
+                  "enum": [
+                    "",
+                    "RSAWithSize2048",
+                    "RSAWithSize4096",
+                    "RSAWithSize8192",
+                    "ECDSAWithCurve256",
+                    "ECDSAWithCurve384",
+                    "ECDSAWithCurve521"
+                  ],
+                  "type": "string"
+                },
+                "signatureAlgorithm": {
+                  "description": "Specify the algorithm used for the signature of the X.509 certificate request. Default: SHA256WithRSA",
+                  "enum": [
+                    "",
+                    "SHA256WithRSA",
+                    "SHA384WithRSA",
+                    "SHA512WithRSA",
+                    "ECDSAWithSHA256",
+                    "ECDSAWithSHA384",
+                    "ECDSAWithSHA512"
+                  ],
+                  "type": "string"
+                },
+                "signerName": {
+                  "description": "When a CSR is issued to the certificates.k8s.io API, the signerName is added to the request in order to accommodate for clusters with multiple signers. Must be formatted as: `<my-domain>/<my-signername>`.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "caCert",
+                "signerName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "cni": {
+              "description": "CNI specifies the CNI that will be used by this installation.",
+              "properties": {
+                "ipam": {
+                  "description": "IPAM specifies the pod IP address management that will be used in the Calico or Calico Enterprise installation.",
+                  "properties": {
+                    "type": {
+                      "description": "Specifies the IPAM plugin that will be used in the Calico or Calico Enterprise installation. * For CNI Plugin Calico, this field defaults to Calico. * For CNI Plugin GKE, this field defaults to HostLocal. * For CNI Plugin AzureVNET, this field defaults to AzureVNET. * For CNI Plugin AmazonVPC, this field defaults to AmazonVPC. \n The IPAM plugin is installed and configured only if the CNI plugin is set to Calico, for all other values of the CNI plugin the plugin binaries and CNI config is a dependency that is expected to be installed separately. \n Default: Calico",
+                      "enum": [
+                        "Calico",
+                        "HostLocal",
+                        "AmazonVPC",
+                        "AzureVNET"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "Specifies the CNI plugin that will be used in the Calico or Calico Enterprise installation. * For KubernetesProvider GKE, this field defaults to GKE. * For KubernetesProvider AKS, this field defaults to AzureVNET. * For KubernetesProvider EKS, this field defaults to AmazonVPC. * If aws-node daemonset exists in kube-system when the Installation resource is created, this field defaults to AmazonVPC. * For all other cases this field defaults to Calico. \n For the value Calico, the CNI plugin binaries and CNI config will be installed as part of deployment, for all other values the CNI plugin binaries and CNI config is a dependency that is expected to be installed separately. \n Default: Calico",
+                  "enum": [
+                    "Calico",
+                    "GKE",
+                    "AmazonVPC",
+                    "AzureVNET"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "componentResources": {
+              "description": "Deprecated. Please use CalicoNodeDaemonSet, TyphaDeployment, and KubeControllersDeployment. ComponentResources can be used to customize the resource requirements for each component. Node, Typha, and KubeControllers are supported for installations.",
+              "items": {
+                "description": "Deprecated. Please use component resource config fields in Installation.Spec instead. The ComponentResource struct associates a ResourceRequirements with a component by name",
+                "properties": {
+                  "componentName": {
+                    "description": "ComponentName is an enum which identifies the component",
+                    "enum": [
+                      "Node",
+                      "Typha",
+                      "KubeControllers"
+                    ],
+                    "type": "string"
+                  },
+                  "resourceRequirements": {
+                    "description": "ResourceRequirements allows customization of limits and requests for compute resources such as cpu and memory.",
+                    "properties": {
+                      "limits": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      },
+                      "requests": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "componentName",
+                  "resourceRequirements"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "controlPlaneNodeSelector": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "ControlPlaneNodeSelector is used to select control plane nodes on which to run Calico components. This is globally applied to all resources created by the operator excluding daemonsets.",
+              "type": "object"
+            },
+            "controlPlaneReplicas": {
+              "description": "ControlPlaneReplicas defines how many replicas of the control plane core components will be deployed. This field applies to all control plane components that support High Availability. Defaults to 2.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "controlPlaneTolerations": {
+              "description": "ControlPlaneTolerations specify tolerations which are then globally applied to all resources created by the operator.",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "fipsMode": {
+              "description": "FIPSMode uses images and features only that are using FIPS 140-2 validated cryptographic modules and standards. Default: Disabled",
+              "enum": [
+                "Enabled",
+                "Disabled"
+              ],
+              "type": "string"
+            },
+            "flexVolumePath": {
+              "description": "FlexVolumePath optionally specifies a custom path for FlexVolume. If not specified, FlexVolume will be enabled by default. If set to 'None', FlexVolume will be disabled. The default is based on the kubernetesProvider.",
+              "type": "string"
+            },
+            "imagePath": {
+              "description": "ImagePath allows for the path part of an image to be specified. If specified then the specified value will be used as the image path for each image. If not specified or empty, the default for each image will be used. A special case value, UseDefault, is supported to explicitly specify the default image path will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<imagePath>` portion of the above format.",
+              "type": "string"
+            },
+            "imagePrefix": {
+              "description": "ImagePrefix allows for the prefix part of an image to be specified. If specified then the given value will be used as a prefix on each image. If not specified or empty, no prefix will be used. A special case value, UseDefault, is supported to explicitly specify the default image prefix will be used for each image. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<imagePrefix>` portion of the above format.",
+              "type": "string"
+            },
+            "imagePullSecrets": {
+              "description": "ImagePullSecrets is an array of references to container registry pull secrets to use. These are applied to all images to be pulled.",
+              "items": {
+                "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "kubeletVolumePluginPath": {
+              "description": "KubeletVolumePluginPath optionally specifies enablement of Calico CSI plugin. If not specified, CSI will be enabled by default. If set to 'None', CSI will be disabled. Default: /var/lib/kubelet",
+              "type": "string"
+            },
+            "kubernetesProvider": {
+              "description": "KubernetesProvider specifies a particular provider of the Kubernetes platform and enables provider-specific configuration. If the specified value is empty, the Operator will attempt to automatically determine the current provider. If the specified value is not empty, the Operator will still attempt auto-detection, but will additionally compare the auto-detected value to the specified value to confirm they match.",
+              "enum": [
+                "",
+                "EKS",
+                "GKE",
+                "AKS",
+                "OpenShift",
+                "DockerEnterprise",
+                "RKE2"
+              ],
+              "type": "string"
+            },
+            "nodeMetricsPort": {
+              "description": "NodeMetricsPort specifies which port calico/node serves prometheus metrics on. By default, metrics are not enabled. If specified, this overrides any FelixConfiguration resources which may exist. If omitted, then prometheus metrics may still be configured through FelixConfiguration.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "nodeUpdateStrategy": {
+              "description": "NodeUpdateStrategy can be used to customize the desired update strategy, such as the MaxUnavailable field.",
+              "properties": {
+                "rollingUpdate": {
+                  "description": "Rolling update config params. Present only if type = \"RollingUpdate\". --- TODO: Update this to follow our convention for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`. See https://github.com/kubernetes/kubernetes/issues/35345",
+                  "properties": {
+                    "maxSurge": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption. This is beta field and enabled/disabled by DaemonSetUpdateSurge feature gate.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxUnavailable": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": {
+                  "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nonPrivileged": {
+              "description": "NonPrivileged configures Calico to be run in non-privileged containers as non-root users where possible.",
+              "type": "string"
+            },
+            "registry": {
+              "description": "Registry is the default Docker registry used for component Docker images. If specified then the given value must end with a slash character (`/`) and all images will be pulled from this registry. If not specified then the default registries will be used. A special case value, UseDefault, is supported to explicitly specify the default registries will be used. \n Image format:    `<registry><imagePath>/<imagePrefix><imageName>:<image-tag>` \n This option allows configuring the `<registry>` portion of the above format.",
+              "type": "string"
+            },
+            "typhaAffinity": {
+              "description": "Deprecated. Please use Installation.Spec.TyphaDeployment instead. TyphaAffinity allows configuration of node affinity characteristics for Typha pods.",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "NodeAffinity describes node affinity scheduling rules for typha.",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions.",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "format": "int32",
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "WARNING: Please note that if the affinity requirements specified by this field are not met at scheduling time, the pod will NOT be scheduled onto the node. There is no fallback to another affinity rules with this setting. This may cause networking disruption or even catastrophic failure! PreferredDuringSchedulingIgnoredDuringExecution should be used for affinity unless there is a specific well understood reason to use RequiredDuringSchedulingIgnoredDuringExecution and you can guarantee that the RequiredDuringSchedulingIgnoredDuringExecution will always have sufficient nodes to satisfy the requirement. NOTE: RequiredDuringSchedulingIgnoredDuringExecution is set by default for AKS nodes, to avoid scheduling Typhas on virtual-nodes. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "typhaDeployment": {
+              "description": "TyphaDeployment configures the typha Deployment. If used in conjunction with the deprecated ComponentResources or TyphaAffinity, then these overrides take precedence.",
+              "properties": {
+                "metadata": {
+                  "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the Deployment.",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "description": "Spec is the specification of the typha Deployment.",
+                  "properties": {
+                    "minReadySeconds": {
+                      "description": "MinReadySeconds is the minimum number of seconds for which a newly created Deployment pod should be ready without any of its container crashing, for it to be considered available. If specified, this overrides any minReadySeconds value that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for minReadySeconds.",
+                      "format": "int32",
+                      "maximum": 2147483647,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "template": {
+                      "description": "Template describes the typha Deployment pod that will be created.",
+                      "properties": {
+                        "metadata": {
+                          "description": "Metadata is a subset of a Kubernetes object's metadata that is added to the pod's metadata.",
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Annotations is a map of arbitrary non-identifying metadata. Each of these key/value pairs are added to the object's annotations provided the key does not already exist in the object's annotations.",
+                              "type": "object"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "Labels is a map of string keys and values that may match replicaset and service selectors. Each of these key/value pairs are added to the object's labels provided the key does not already exist in the object's labels.",
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "description": "Spec is the typha Deployment's PodSpec.",
+                          "properties": {
+                            "affinity": {
+                              "description": "Affinity is a group of affinity scheduling rules for the typha pods. If specified, this overrides any affinity that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for affinity. If used in conjunction with the deprecated TyphaAffinity, then this value takes precedence. WARNING: Please note that this field will override the default calico-typha Deployment affinity.",
+                              "properties": {
+                                "nodeAffinity": {
+                                  "description": "Describes node affinity scheduling rules for the pod.",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                          "preference": {
+                                            "description": "A node selector term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "preference",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                                          "items": {
+                                            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "A list of node selector requirements by node's labels.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "description": "A list of node selector requirements by node's fields.",
+                                                "items": {
+                                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "The label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "nodeSelectorTerms"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                      "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                            "properties": {
+                                              "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                    "items": {
+                                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the label key that the selector applies to.",
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "topologyKey"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                            "format": "int32",
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "podAffinityTerm",
+                                          "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                      "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                          "labelSelector": {
+                                            "description": "A label query over a set of resources, in this case pods.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaceSelector": {
+                                            "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                "items": {
+                                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                  "properties": {
+                                                    "key": {
+                                                      "description": "key is the label key that the selector applies to.",
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "containers": {
+                              "description": "Containers is a list of typha containers. If specified, this overrides the specified typha Deployment containers. If omitted, the typha Deployment will use its default values for its containers.",
+                              "items": {
+                                "description": "TyphaDeploymentContainer is a typha Deployment container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the typha Deployment container by name.",
+                                    "enum": [
+                                      "calico-typha"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment container's resources. If omitted, the typha Deployment will use its default value for this container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "description": "InitContainers is a list of typha init containers. If specified, this overrides the specified typha Deployment init containers. If omitted, the typha Deployment will use its default values for its init containers.",
+                              "items": {
+                                "description": "TyphaDeploymentInitContainer is a typha Deployment init container.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is an enum which identifies the typha Deployment init container by name.",
+                                    "enum": [
+                                      "typha-certs-key-cert-provisioner"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "resources": {
+                                    "description": "Resources allows customization of limits and requests for compute resources such as cpu and memory. If specified, this overrides the named typha Deployment init container's resources. If omitted, the typha Deployment will use its default value for this init container's resources. If used in conjunction with the deprecated ComponentResources, then this value takes precedence.",
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "NodeSelector is the calico-typha pod's scheduling constraints. If specified, each of the key/value pairs are added to the calico-typha Deployment nodeSelector provided the key does not already exist in the object's nodeSelector. If omitted, the calico-typha Deployment will use its default value for nodeSelector. WARNING: Please note that this field will modify the default calico-typha Deployment nodeSelector.",
+                              "type": "object"
+                            },
+                            "tolerations": {
+                              "description": "Tolerations is the typha pod's tolerations. If specified, this overrides any tolerations that may be set on the typha Deployment. If omitted, the typha Deployment will use its default value for tolerations. WARNING: Please note that this field will override the default calico-typha Deployment tolerations.",
+                              "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                  "effect": {
+                                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                    "format": "int64",
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "typhaMetricsPort": {
+              "description": "TyphaMetricsPort specifies which port calico/typha serves prometheus metrics on. By default, metrics are not enabled.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "variant": {
+              "description": "Variant is the product to install - one of Calico or TigeraSecureEnterprise Default: Calico",
+              "enum": [
+                "Calico",
+                "TigeraSecureEnterprise"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "conditions": {
+          "description": "Conditions represents the latest observed set of conditions for the component. A component may be one or more of Ready, Progressing, Degraded or other customer types.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "imageSet": {
+          "description": "ImageSet is the name of the ImageSet being used, if there is an ImageSet that is being used. If an ImageSet is not being used then this will not be set.",
+          "type": "string"
+        },
+        "mtu": {
+          "description": "MTU is the most recently observed value for pod network MTU. This may be an explicitly configured value, or based on Calico's native auto-detetion.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "variant": {
+          "description": "Variant is the most recently observed installed variant - one of Calico or TigeraSecureEnterprise",
+          "enum": [
+            "Calico",
+            "TigeraSecureEnterprise"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/operator.tigera.io/tigerastatus_v1.json
+++ b/operator.tigera.io/tigerastatus_v1.json
@@ -1,0 +1,73 @@
+{
+  "description": "TigeraStatus represents the most recently observed status for Calico or a Calico Enterprise functional area.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TigeraStatusSpec defines the desired state of TigeraStatus",
+      "type": "object"
+    },
+    "status": {
+      "description": "TigeraStatusStatus defines the observed state of TigeraStatus",
+      "properties": {
+        "conditions": {
+          "description": "Conditions represents the latest observed set of conditions for this component. A component may be one or more of Available, Progressing, or Degraded.",
+          "items": {
+            "description": "TigeraStatusCondition represents a condition attached to a particular component.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "The timestamp representing the start time for the current status.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "Optionally, a detailed message providing additional context.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the generation that the condition was set based upon. For instance, if generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A brief reason explaining the condition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of the condition. May be True, False, or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of condition. May be Available, Progressing, or Degraded.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "conditions"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
When using Kubeconform the checks failed against tigera-operator crd's. Using the CRD extractor from this repo I extracted them from my K8s cluster.

Upstream CRD's for reference: https://github.com/projectcalico/calico/tree/master/charts/tigera-operator/crds