### PR TITLE
[acid.zalan.do] Add Zalando Postgres Operator Schemas

### DIFF
--- a/acid.zalan.do/operatorconfiguration_v1.json
+++ b/acid.zalan.do/operatorconfiguration_v1.json
@@ -1,0 +1,896 @@
+{
+  "type": "object",
+  "required": [
+    "kind",
+    "apiVersion",
+    "configuration"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "OperatorConfiguration"
+      ]
+    },
+    "apiVersion": {
+      "type": "string",
+      "enum": [
+        "acid.zalan.do/v1"
+      ]
+    },
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "crd_categories": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "docker_image": {
+          "type": "string",
+          "default": "ghcr.io/zalando/spilo-15:3.0-p1"
+        },
+        "enable_crd_registration": {
+          "type": "boolean",
+          "default": true
+        },
+        "enable_crd_validation": {
+          "type": "boolean",
+          "description": "deprecated",
+          "default": true
+        },
+        "enable_lazy_spilo_upgrade": {
+          "type": "boolean",
+          "default": false
+        },
+        "enable_pgversion_env_var": {
+          "type": "boolean",
+          "default": true
+        },
+        "enable_shm_volume": {
+          "type": "boolean",
+          "default": true
+        },
+        "enable_spilo_wal_path_compat": {
+          "type": "boolean",
+          "default": false
+        },
+        "enable_team_id_clustername_prefix": {
+          "type": "boolean",
+          "default": false
+        },
+        "etcd_host": {
+          "type": "string",
+          "default": ""
+        },
+        "ignore_instance_limits_annotation_key": {
+          "type": "string"
+        },
+        "kubernetes_use_configmaps": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_instances": {
+          "type": "integer",
+          "description": "-1 = disabled",
+          "minimum": -1,
+          "default": -1
+        },
+        "min_instances": {
+          "type": "integer",
+          "description": "-1 = disabled",
+          "minimum": -1,
+          "default": -1
+        },
+        "resync_period": {
+          "type": "string",
+          "default": "30m"
+        },
+        "repair_period": {
+          "type": "string",
+          "default": "5m"
+        },
+        "set_memory_request_to_limit": {
+          "type": "boolean",
+          "default": false
+        },
+        "sidecar_docker_images": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sidecars": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "workers": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 8
+        },
+        "users": {
+          "type": "object",
+          "properties": {
+            "additional_owner_roles": {
+              "type": "array",
+              "nullable": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "enable_password_rotation": {
+              "type": "boolean",
+              "default": false
+            },
+            "password_rotation_interval": {
+              "type": "integer",
+              "default": 90
+            },
+            "password_rotation_user_retention": {
+              "type": "integer",
+              "default": 180
+            },
+            "replication_username": {
+              "type": "string",
+              "default": "standby"
+            },
+            "super_username": {
+              "type": "string",
+              "default": "postgres"
+            }
+          },
+          "additionalProperties": false
+        },
+        "major_version_upgrade": {
+          "type": "object",
+          "properties": {
+            "major_version_upgrade_mode": {
+              "type": "string",
+              "default": "off"
+            },
+            "major_version_upgrade_team_allow_list": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "minimal_major_version": {
+              "type": "string",
+              "default": "11"
+            },
+            "target_major_version": {
+              "type": "string",
+              "default": "15"
+            }
+          },
+          "additionalProperties": false
+        },
+        "kubernetes": {
+          "type": "object",
+          "properties": {
+            "additional_pod_capabilities": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "cluster_domain": {
+              "type": "string",
+              "default": "cluster.local"
+            },
+            "cluster_labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {
+                "application": "spilo"
+              }
+            },
+            "cluster_name_label": {
+              "type": "string",
+              "default": "cluster-name"
+            },
+            "custom_pod_annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "delete_annotation_date_key": {
+              "type": "string"
+            },
+            "delete_annotation_name_key": {
+              "type": "string"
+            },
+            "downscaler_annotations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "enable_cross_namespace_secret": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_init_containers": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_pod_antiaffinity": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_pod_disruption_budget": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_readiness_probe": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_sidecars": {
+              "type": "boolean",
+              "default": true
+            },
+            "ignored_annotations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "infrastructure_roles_secret_name": {
+              "type": "string"
+            },
+            "infrastructure_roles_secrets": {
+              "type": "array",
+              "nullable": true,
+              "items": {
+                "type": "object",
+                "required": [
+                  "secretname",
+                  "userkey",
+                  "passwordkey"
+                ],
+                "properties": {
+                  "secretname": {
+                    "type": "string"
+                  },
+                  "userkey": {
+                    "type": "string"
+                  },
+                  "passwordkey": {
+                    "type": "string"
+                  },
+                  "rolekey": {
+                    "type": "string"
+                  },
+                  "defaultuservalue": {
+                    "type": "string"
+                  },
+                  "defaultrolevalue": {
+                    "type": "string"
+                  },
+                  "details": {
+                    "type": "string"
+                  },
+                  "template": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "inherited_annotations": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "inherited_labels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "master_pod_move_timeout": {
+              "type": "string",
+              "default": "20m"
+            },
+            "node_readiness_label": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "node_readiness_label_merge": {
+              "type": "string",
+              "enum": [
+                "AND",
+                "OR"
+              ]
+            },
+            "oauth_token_secret_name": {
+              "type": "string",
+              "default": "postgresql-operator"
+            },
+            "pdb_name_format": {
+              "type": "string",
+              "default": "postgres-{cluster}-pdb"
+            },
+            "pod_antiaffinity_preferred_during_scheduling": {
+              "type": "boolean",
+              "default": false
+            },
+            "pod_antiaffinity_topology_key": {
+              "type": "string",
+              "default": "kubernetes.io/hostname"
+            },
+            "pod_environment_configmap": {
+              "type": "string"
+            },
+            "pod_environment_secret": {
+              "type": "string"
+            },
+            "pod_management_policy": {
+              "type": "string",
+              "enum": [
+                "ordered_ready",
+                "parallel"
+              ],
+              "default": "ordered_ready"
+            },
+            "pod_priority_class_name": {
+              "type": "string"
+            },
+            "pod_role_label": {
+              "type": "string",
+              "default": "spilo-role"
+            },
+            "pod_service_account_definition": {
+              "type": "string",
+              "default": ""
+            },
+            "pod_service_account_name": {
+              "type": "string",
+              "default": "postgres-pod"
+            },
+            "pod_service_account_role_binding_definition": {
+              "type": "string",
+              "default": ""
+            },
+            "pod_terminate_grace_period": {
+              "type": "string",
+              "default": "5m"
+            },
+            "secret_name_template": {
+              "type": "string",
+              "default": "{username}.{cluster}.credentials.{tprkind}.{tprgroup}"
+            },
+            "share_pgsocket_with_sidecars": {
+              "type": "boolean",
+              "default": false
+            },
+            "spilo_allow_privilege_escalation": {
+              "type": "boolean",
+              "default": true
+            },
+            "spilo_runasuser": {
+              "type": "integer"
+            },
+            "spilo_runasgroup": {
+              "type": "integer"
+            },
+            "spilo_fsgroup": {
+              "type": "integer"
+            },
+            "spilo_privileged": {
+              "type": "boolean",
+              "default": false
+            },
+            "storage_resize_mode": {
+              "type": "string",
+              "enum": [
+                "ebs",
+                "mixed",
+                "pvc",
+                "off"
+              ],
+              "default": "pvc"
+            },
+            "toleration": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "watched_namespace": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "postgres_pod_resources": {
+          "type": "object",
+          "properties": {
+            "default_cpu_limit": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "1"
+            },
+            "default_cpu_request": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "100m"
+            },
+            "default_memory_limit": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "500Mi"
+            },
+            "default_memory_request": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "100Mi"
+            },
+            "max_cpu_request": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+            },
+            "max_memory_request": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+            },
+            "min_cpu_limit": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "250m"
+            },
+            "min_memory_limit": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "250Mi"
+            }
+          },
+          "additionalProperties": false
+        },
+        "timeouts": {
+          "type": "object",
+          "properties": {
+            "patroni_api_check_interval": {
+              "type": "string",
+              "default": "1s"
+            },
+            "patroni_api_check_timeout": {
+              "type": "string",
+              "default": "5s"
+            },
+            "pod_label_wait_timeout": {
+              "type": "string",
+              "default": "10m"
+            },
+            "pod_deletion_wait_timeout": {
+              "type": "string",
+              "default": "10m"
+            },
+            "ready_wait_interval": {
+              "type": "string",
+              "default": "4s"
+            },
+            "ready_wait_timeout": {
+              "type": "string",
+              "default": "30s"
+            },
+            "resource_check_interval": {
+              "type": "string",
+              "default": "3s"
+            },
+            "resource_check_timeout": {
+              "type": "string",
+              "default": "10m"
+            }
+          },
+          "additionalProperties": false
+        },
+        "load_balancer": {
+          "type": "object",
+          "properties": {
+            "custom_service_annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "db_hosted_zone": {
+              "type": "string",
+              "default": "db.example.com"
+            },
+            "enable_master_load_balancer": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_master_pooler_load_balancer": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_replica_load_balancer": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_replica_pooler_load_balancer": {
+              "type": "boolean",
+              "default": false
+            },
+            "external_traffic_policy": {
+              "type": "string",
+              "enum": [
+                "Cluster",
+                "Local"
+              ],
+              "default": "Cluster"
+            },
+            "master_dns_name_format": {
+              "type": "string",
+              "default": "{cluster}.{namespace}.{hostedzone}"
+            },
+            "master_legacy_dns_name_format": {
+              "type": "string",
+              "default": "{cluster}.{team}.{hostedzone}"
+            },
+            "replica_dns_name_format": {
+              "type": "string",
+              "default": "{cluster}-repl.{namespace}.{hostedzone}"
+            },
+            "replica_legacy_dns_name_format": {
+              "type": "string",
+              "default": "{cluster}-repl.{team}.{hostedzone}"
+            }
+          },
+          "additionalProperties": false
+        },
+        "aws_or_gcp": {
+          "type": "object",
+          "properties": {
+            "additional_secret_mount": {
+              "type": "string"
+            },
+            "additional_secret_mount_path": {
+              "type": "string",
+              "default": "/meta/credentials"
+            },
+            "aws_region": {
+              "type": "string",
+              "default": "eu-central-1"
+            },
+            "enable_ebs_gp3_migration": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_ebs_gp3_migration_max_size": {
+              "type": "integer",
+              "default": 1000
+            },
+            "gcp_credentials": {
+              "type": "string"
+            },
+            "kube_iam_role": {
+              "type": "string"
+            },
+            "log_s3_bucket": {
+              "type": "string"
+            },
+            "wal_az_storage_account": {
+              "type": "string"
+            },
+            "wal_gs_bucket": {
+              "type": "string"
+            },
+            "wal_s3_bucket": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "logical_backup": {
+          "type": "object",
+          "properties": {
+            "logical_backup_azure_storage_account_name": {
+              "type": "string"
+            },
+            "logical_backup_azure_storage_container": {
+              "type": "string"
+            },
+            "logical_backup_azure_storage_account_key": {
+              "type": "string"
+            },
+            "logical_backup_cpu_limit": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+            },
+            "logical_backup_cpu_request": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+            },
+            "logical_backup_docker_image": {
+              "type": "string",
+              "default": "registry.opensource.zalan.do/acid/logical-backup:v1.10.0"
+            },
+            "logical_backup_google_application_credentials": {
+              "type": "string"
+            },
+            "logical_backup_job_prefix": {
+              "type": "string",
+              "default": "logical-backup-"
+            },
+            "logical_backup_memory_limit": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+            },
+            "logical_backup_memory_request": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+            },
+            "logical_backup_provider": {
+              "type": "string",
+              "enum": [
+                "az",
+                "gcs",
+                "s3"
+              ],
+              "default": "s3"
+            },
+            "logical_backup_s3_access_key_id": {
+              "type": "string"
+            },
+            "logical_backup_s3_bucket": {
+              "type": "string"
+            },
+            "logical_backup_s3_endpoint": {
+              "type": "string"
+            },
+            "logical_backup_s3_region": {
+              "type": "string"
+            },
+            "logical_backup_s3_secret_access_key": {
+              "type": "string"
+            },
+            "logical_backup_s3_sse": {
+              "type": "string"
+            },
+            "logical_backup_s3_retention_time": {
+              "type": "string"
+            },
+            "logical_backup_schedule": {
+              "type": "string",
+              "pattern": "^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$",
+              "default": "30 00 * * *"
+            }
+          },
+          "additionalProperties": false
+        },
+        "debug": {
+          "type": "object",
+          "properties": {
+            "debug_logging": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_database_access": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "teams_api": {
+          "type": "object",
+          "properties": {
+            "enable_admin_role_for_users": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_postgres_team_crd": {
+              "type": "boolean",
+              "default": true
+            },
+            "enable_postgres_team_crd_superusers": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_team_member_deprecation": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_team_superuser": {
+              "type": "boolean",
+              "default": false
+            },
+            "enable_teams_api": {
+              "type": "boolean",
+              "default": true
+            },
+            "pam_configuration": {
+              "type": "string",
+              "default": "https://info.example.com/oauth2/tokeninfo?access_token= uid realm=/employees"
+            },
+            "pam_role_name": {
+              "type": "string",
+              "default": "zalandos"
+            },
+            "postgres_superuser_teams": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "protected_role_names": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "admin",
+                "cron_admin"
+              ]
+            },
+            "role_deletion_suffix": {
+              "type": "string",
+              "default": "_deleted"
+            },
+            "team_admin_role": {
+              "type": "string",
+              "default": "admin"
+            },
+            "team_api_role_configuration": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "default": {
+                "log_statement": "all"
+              }
+            },
+            "teams_api_url": {
+              "type": "string",
+              "default": "https://teams.example.com/api/"
+            }
+          },
+          "additionalProperties": false
+        },
+        "logging_rest_api": {
+          "type": "object",
+          "properties": {
+            "api_port": {
+              "type": "integer",
+              "default": 8080
+            },
+            "cluster_history_entries": {
+              "type": "integer",
+              "default": 1000
+            },
+            "ring_log_lines": {
+              "type": "integer",
+              "default": 100
+            }
+          },
+          "additionalProperties": false
+        },
+        "scalyr": {
+          "type": "object",
+          "properties": {
+            "scalyr_api_key": {
+              "type": "string"
+            },
+            "scalyr_cpu_limit": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "1"
+            },
+            "scalyr_cpu_request": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "100m"
+            },
+            "scalyr_image": {
+              "type": "string"
+            },
+            "scalyr_memory_limit": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "500Mi"
+            },
+            "scalyr_memory_request": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "50Mi"
+            },
+            "scalyr_server_url": {
+              "type": "string",
+              "default": "https://upload.eu.scalyr.com"
+            }
+          },
+          "additionalProperties": false
+        },
+        "connection_pooler": {
+          "type": "object",
+          "properties": {
+            "connection_pooler_schema": {
+              "type": "string",
+              "default": "pooler"
+            },
+            "connection_pooler_user": {
+              "type": "string",
+              "default": "pooler"
+            },
+            "connection_pooler_image": {
+              "type": "string",
+              "default": "registry.opensource.zalan.do/acid/pgbouncer:master-27"
+            },
+            "connection_pooler_max_db_connections": {
+              "type": "integer",
+              "default": 60
+            },
+            "connection_pooler_mode": {
+              "type": "string",
+              "enum": [
+                "session",
+                "transaction"
+              ],
+              "default": "transaction"
+            },
+            "connection_pooler_number_of_instances": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 2
+            },
+            "connection_pooler_default_cpu_limit": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "1"
+            },
+            "connection_pooler_default_cpu_request": {
+              "type": "string",
+              "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$",
+              "default": "500m"
+            },
+            "connection_pooler_default_memory_limit": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "100Mi"
+            },
+            "connection_pooler_default_memory_request": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$",
+              "default": "100Mi"
+            }
+          },
+          "additionalProperties": false
+        },
+        "patroni": {
+          "type": "object",
+          "properties": {
+            "enable_patroni_failsafe_mode": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/acid.zalan.do/postgresql_v1.json
+++ b/acid.zalan.do/postgresql_v1.json
@@ -1,0 +1,871 @@
+{
+  "type": "object",
+  "required": [
+    "kind",
+    "apiVersion",
+    "spec"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "postgresql"
+      ]
+    },
+    "apiVersion": {
+      "type": "string",
+      "enum": [
+        "acid.zalan.do/v1"
+      ]
+    },
+    "spec": {
+      "type": "object",
+      "required": [
+        "numberOfInstances",
+        "teamId",
+        "postgresql",
+        "volume"
+      ],
+      "properties": {
+        "additionalVolumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "mountPath",
+              "volumeSource"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "mountPath": {
+                "type": "string"
+              },
+              "targetContainers": {
+                "type": "array",
+                "nullable": true,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "volumeSource": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+              },
+              "subPath": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "allowedSourceRanges": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "string",
+            "pattern": "^(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\.(\\d|[1-9]\\d|1\\d\\d|2[0-4]\\d|25[0-5])\\/(\\d|[1-2]\\d|3[0-2])$"
+          }
+        },
+        "clone": {
+          "type": "object",
+          "required": [
+            "cluster"
+          ],
+          "properties": {
+            "cluster": {
+              "type": "string"
+            },
+            "s3_endpoint": {
+              "type": "string"
+            },
+            "s3_access_key_id": {
+              "type": "string"
+            },
+            "s3_secret_access_key": {
+              "type": "string"
+            },
+            "s3_force_path_style": {
+              "type": "boolean"
+            },
+            "s3_wal_path": {
+              "type": "string"
+            },
+            "timestamp": {
+              "type": "string",
+              "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([+-]([01][0-9]|2[0-3]):[0-5][0-9]))$"
+            },
+            "uid": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "connectionPooler": {
+          "type": "object",
+          "properties": {
+            "dockerImage": {
+              "type": "string"
+            },
+            "maxDBConnections": {
+              "type": "integer"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "session",
+                "transaction"
+              ]
+            },
+            "numberOfInstances": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "resources": {
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "type": "string",
+                      "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                    },
+                    "memory": {
+                      "type": "string",
+                      "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "schema": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "databases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "dockerImage": {
+          "type": "string"
+        },
+        "enableConnectionPooler": {
+          "type": "boolean"
+        },
+        "enableReplicaConnectionPooler": {
+          "type": "boolean"
+        },
+        "enableLogicalBackup": {
+          "type": "boolean"
+        },
+        "enableMasterLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableMasterPoolerLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableReplicaLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableReplicaPoolerLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableShmVolume": {
+          "type": "boolean"
+        },
+        "env": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "init_containers": {
+          "type": "array",
+          "description": "deprecated",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "initContainers": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "logicalBackupSchedule": {
+          "type": "string",
+          "pattern": "^(\\d+|\\*)(/\\d+)?(\\s+(\\d+|\\*)(/\\d+)?){4}$"
+        },
+        "maintenanceWindows": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^\\ *((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))-((Mon|Tue|Wed|Thu|Fri|Sat|Sun):(2[0-3]|[01]?\\d):([0-5]?\\d)|(2[0-3]|[01]?\\d):([0-5]?\\d))\\ *$"
+          }
+        },
+        "masterServiceAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "nodeAffinity": {
+          "type": "object",
+          "properties": {
+            "preferredDuringSchedulingIgnoredDuringExecution": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "preference",
+                  "weight"
+                ],
+                "properties": {
+                  "preference": {
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "matchFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "weight": {
+                    "format": "int32",
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "type": "object",
+              "required": [
+                "nodeSelectorTerms"
+              ],
+              "properties": {
+                "nodeSelectorTerms": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "matchFields": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "numberOfInstances": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "patroni": {
+          "type": "object",
+          "properties": {
+            "failsafe_mode": {
+              "type": "boolean"
+            },
+            "initdb": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "loop_wait": {
+              "type": "integer"
+            },
+            "maximum_lag_on_failover": {
+              "type": "integer"
+            },
+            "pg_hba": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "retry_timeout": {
+              "type": "integer"
+            },
+            "slots": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "synchronous_mode": {
+              "type": "boolean"
+            },
+            "synchronous_mode_strict": {
+              "type": "boolean"
+            },
+            "synchronous_node_count": {
+              "type": "integer"
+            },
+            "ttl": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        },
+        "podAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "pod_priority_class_name": {
+          "type": "string",
+          "description": "deprecated"
+        },
+        "podPriorityClassName": {
+          "type": "string"
+        },
+        "postgresql": {
+          "type": "object",
+          "required": [
+            "version"
+          ],
+          "properties": {
+            "version": {
+              "type": "string",
+              "enum": [
+                "10",
+                "11",
+                "12",
+                "13",
+                "14",
+                "15"
+              ]
+            },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "preparedDatabases": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "defaultUsers": {
+                "type": "boolean"
+              },
+              "extensions": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "schemas": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "defaultUsers": {
+                      "type": "boolean"
+                    },
+                    "defaultRoles": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "secretNamespace": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "replicaLoadBalancer": {
+          "type": "boolean",
+          "description": "deprecated"
+        },
+        "replicaServiceAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                }
+              },
+              "additionalProperties": false
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "pattern": "^(\\d+m|\\d+(\\.\\d{1,3})?)$"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "serviceAnnotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sidecars": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        },
+        "spiloRunAsUser": {
+          "type": "integer"
+        },
+        "spiloRunAsGroup": {
+          "type": "integer"
+        },
+        "spiloFSGroup": {
+          "type": "integer"
+        },
+        "standby": {
+          "type": "object",
+          "properties": {
+            "s3_wal_path": {
+              "type": "string"
+            },
+            "gs_wal_path": {
+              "type": "string"
+            },
+            "standby_host": {
+              "type": "string"
+            },
+            "standby_port": {
+              "type": "string"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "s3_wal_path"
+              ]
+            },
+            {
+              "required": [
+                "gs_wal_path"
+              ]
+            },
+            {
+              "required": [
+                "standby_host"
+              ]
+            }
+          ],
+          "additionalProperties": false
+        },
+        "streams": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "applicationId",
+              "database",
+              "tables"
+            ],
+            "properties": {
+              "applicationId": {
+                "type": "string"
+              },
+              "batchSize": {
+                "type": "integer"
+              },
+              "database": {
+                "type": "string"
+              },
+              "filter": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "tables": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object",
+                  "required": [
+                    "eventType"
+                  ],
+                  "properties": {
+                    "eventType": {
+                      "type": "string"
+                    },
+                    "idColumn": {
+                      "type": "string"
+                    },
+                    "payloadColumn": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "teamId": {
+          "type": "string"
+        },
+        "tls": {
+          "type": "object",
+          "required": [
+            "secretName"
+          ],
+          "properties": {
+            "secretName": {
+              "type": "string"
+            },
+            "certificateFile": {
+              "type": "string"
+            },
+            "privateKeyFile": {
+              "type": "string"
+            },
+            "caFile": {
+              "type": "string"
+            },
+            "caSecretName": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "tolerations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "operator": {
+                "type": "string",
+                "enum": [
+                  "Equal",
+                  "Exists"
+                ]
+              },
+              "value": {
+                "type": "string"
+              },
+              "effect": {
+                "type": "string",
+                "enum": [
+                  "NoExecute",
+                  "NoSchedule",
+                  "PreferNoSchedule"
+                ]
+              },
+              "tolerationSeconds": {
+                "type": "integer"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "useLoadBalancer": {
+          "type": "boolean",
+          "description": "deprecated"
+        },
+        "users": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "bypassrls",
+                "BYPASSRLS",
+                "nobypassrls",
+                "NOBYPASSRLS",
+                "createdb",
+                "CREATEDB",
+                "nocreatedb",
+                "NOCREATEDB",
+                "createrole",
+                "CREATEROLE",
+                "nocreaterole",
+                "NOCREATEROLE",
+                "inherit",
+                "INHERIT",
+                "noinherit",
+                "NOINHERIT",
+                "login",
+                "LOGIN",
+                "nologin",
+                "NOLOGIN",
+                "replication",
+                "REPLICATION",
+                "noreplication",
+                "NOREPLICATION",
+                "superuser",
+                "SUPERUSER",
+                "nosuperuser",
+                "NOSUPERUSER"
+              ]
+            }
+          }
+        },
+        "usersWithInPlaceSecretRotation": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "usersWithSecretRotation": {
+          "type": "array",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "volume": {
+          "type": "object",
+          "required": [
+            "size"
+          ],
+          "properties": {
+            "iops": {
+              "type": "integer"
+            },
+            "selector": {
+              "type": "object",
+              "properties": {
+                "matchExpressions": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string",
+                        "enum": [
+                          "DoesNotExist",
+                          "Exists",
+                          "In",
+                          "NotIn"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "matchLabels": {
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
+                }
+              },
+              "additionalProperties": false
+            },
+            "size": {
+              "type": "string",
+              "pattern": "^(\\d+(e\\d+)?|\\d+(\\.\\d+)?(e\\d+)?[EPTGMK]i?)$"
+            },
+            "storageClass": {
+              "type": "string"
+            },
+            "subPath": {
+              "type": "string"
+            },
+            "throughput": {
+              "type": "integer"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/acid.zalan.do/postgresteam_v1.json
+++ b/acid.zalan.do/postgresteam_v1.json
@@ -1,0 +1,64 @@
+{
+  "type": "object",
+  "required": [
+    "kind",
+    "apiVersion",
+    "spec"
+  ],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "PostgresTeam"
+      ]
+    },
+    "apiVersion": {
+      "type": "string",
+      "enum": [
+        "acid.zalan.do/v1"
+      ]
+    },
+    "spec": {
+      "type": "object",
+      "properties": {
+        "additionalSuperuserTeams": {
+          "type": "object",
+          "description": "Map for teamId and associated additional superuser teams",
+          "additionalProperties": {
+            "type": "array",
+            "nullable": true,
+            "description": "List of teams to become Postgres superusers",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalTeams": {
+          "type": "object",
+          "description": "Map for teamId and associated additional teams",
+          "additionalProperties": {
+            "type": "array",
+            "nullable": true,
+            "description": "List of teams whose members will also be added to the Postgres cluster",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalMembers": {
+          "type": "object",
+          "description": "Map for teamId and associated additional users",
+          "additionalProperties": {
+            "type": "array",
+            "nullable": true,
+            "description": "List of users who will also be added to the Postgres cluster",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
Added Zalando Postgres Operator Schemas.

Group: `acid.zalan.do`.

A list of CRDs:
- `OperatorConfiguration`
- `postgresql`
- `PostgresTeam`

Here is the commands I used to generate them:

```bash
python openapi2jsonschema.py https://github.com/zalando/postgres-operator/raw/master/charts/postgres-operator/crds/operatorconfigurations.yaml

python openapi2jsonschema.py https://github.com/zalando/postgres-operator/raw/master/charts/postgres-operator/crds/postgresqls.yaml

python openapi2jsonschema.py https://github.com/zalando/postgres-operator/raw/master/charts/postgres-operator/crds/postgresteams.yaml
```

Reference: <https://github.com/zalando/postgres-operator/tree/master/charts/postgres-operator/crds>
Source: <https://github.com/zalando/postgres-operator/tree/master>