### PR TITLE
fix: update alb controller crds

### DIFF
--- a/elbv2.k8s.aws/ingressclassparams_v1beta1.json
+++ b/elbv2.k8s.aws/ingressclassparams_v1beta1.json
@@ -29,6 +29,13 @@
           "type": "object",
           "additionalProperties": false
         },
+        "inboundCIDRs": {
+          "description": "InboundCIDRs specifies the CIDRs that are allowed to access the Ingresses that belong to IngressClass with this IngressClassParams.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "ipAddressType": {
           "description": "IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.",
           "enum": [
@@ -102,6 +109,7 @@
             }
           },
           "type": "object",
+          "x-kubernetes-map-type": "atomic",
           "additionalProperties": false
         },
         "scheme": {
@@ -111,6 +119,37 @@
             "internet-facing"
           ],
           "type": "string"
+        },
+        "sslPolicy": {
+          "description": "SSLPolicy specifies the SSL Policy for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "type": "string"
+        },
+        "subnets": {
+          "description": "Subnets defines the subnets for all Ingresses that belong to IngressClass with this IngressClassParams.",
+          "properties": {
+            "ids": {
+              "description": "IDs specify the resource IDs of subnets. Exactly one of this or `tags` must be specified.",
+              "items": {
+                "description": "SubnetID specifies a subnet ID.",
+                "pattern": "subnet-[0-9a-f]+",
+                "type": "string"
+              },
+              "minItems": 1,
+              "type": "array"
+            },
+            "tags": {
+              "additionalProperties": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "description": "Tags specifies subnets in the load balancer's VPC where each tag specified in the map key contains one of the values in the corresponding value list. Exactly one of this or `ids` must be specified.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "tags": {
           "description": "Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.",

--- a/elbv2.k8s.aws/targetgroupbinding_v1alpha1.json
+++ b/elbv2.k8s.aws/targetgroupbinding_v1alpha1.json
@@ -1,162 +1,169 @@
 {
-  "openAPIV3Schema": {
-    "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
-    "properties": {
-      "apiVersion": {
-        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-        "type": "string"
-      },
-      "kind": {
-        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-        "type": "string"
-      },
-      "metadata": {
-        "type": "object"
-      },
-      "spec": {
-        "description": "TargetGroupBindingSpec defines the desired state of TargetGroupBinding",
-        "properties": {
-          "networking": {
-            "description": "networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.",
-            "properties": {
-              "ingress": {
-                "description": "List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.",
-                "items": {
-                  "properties": {
-                    "from": {
-                      "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
-                      "items": {
-                        "description": "NetworkingPeer defines the source/destination peer for networking rules.",
-                        "properties": {
-                          "ipBlock": {
-                            "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
-                            "properties": {
-                              "cidr": {
-                                "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "cidr"
-                            ],
-                            "type": "object"
-                          },
-                          "securityGroup": {
-                            "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
-                            "properties": {
-                              "groupID": {
-                                "description": "GroupID is the EC2 SecurityGroupID.",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "groupID"
-                            ],
-                            "type": "object"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "ports": {
-                      "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
-                      "items": {
-                        "properties": {
-                          "port": {
-                            "anyOf": [
-                              {
-                                "type": "integer"
-                              },
-                              {
-                                "type": "string"
-                              }
-                            ],
-                            "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
-                            "x-kubernetes-int-or-string": true
-                          },
-                          "protocol": {
-                            "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
-                            "enum": [
-                              "TCP",
-                              "UDP"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "type": "object"
-                      },
-                      "type": "array"
-                    }
-                  },
-                  "required": [
-                    "from",
-                    "ports"
-                  ],
-                  "type": "object"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          },
-          "serviceRef": {
-            "description": "serviceRef is a reference to a Kubernetes Service and ServicePort.",
-            "properties": {
-              "name": {
-                "description": "Name is the name of the Service.",
-                "type": "string"
-              },
-              "port": {
-                "anyOf": [
-                  {
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ],
-                "description": "Port is the port of the ServicePort.",
-                "x-kubernetes-int-or-string": true
-              }
-            },
-            "required": [
-              "name",
-              "port"
-            ],
-            "type": "object"
-          },
-          "targetGroupARN": {
-            "description": "targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.",
-            "type": "string"
-          },
-          "targetType": {
-            "description": "targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.",
-            "enum": [
-              "instance",
-              "ip"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "serviceRef",
-          "targetGroupARN"
-        ],
-        "type": "object"
-      },
-      "status": {
-        "description": "TargetGroupBindingStatus defines the observed state of TargetGroupBinding",
-        "properties": {
-          "observedGeneration": {
-            "description": "The generation observed by the TargetGroupBinding controller.",
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      }
+  "description": "TargetGroupBinding is the Schema for the TargetGroupBinding API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
     },
-    "type": "object"
-  }
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TargetGroupBindingSpec defines the desired state of TargetGroupBinding",
+      "properties": {
+        "networking": {
+          "description": "networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.",
+          "properties": {
+            "ingress": {
+              "description": "List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.",
+              "items": {
+                "properties": {
+                  "from": {
+                    "description": "List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.",
+                    "items": {
+                      "description": "NetworkingPeer defines the source/destination peer for networking rules.",
+                      "properties": {
+                        "ipBlock": {
+                          "description": "IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.",
+                          "properties": {
+                            "cidr": {
+                              "description": "CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "cidr"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "securityGroup": {
+                          "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
+                          "properties": {
+                            "groupID": {
+                              "description": "GroupID is the EC2 SecurityGroupID.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "groupID"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "ports": {
+                    "description": "List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.",
+                    "items": {
+                      "properties": {
+                        "port": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "protocol": {
+                          "description": "The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.",
+                          "enum": [
+                            "TCP",
+                            "UDP"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "from",
+                  "ports"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "serviceRef": {
+          "description": "serviceRef is a reference to a Kubernetes Service and ServicePort.",
+          "properties": {
+            "name": {
+              "description": "Name is the name of the Service.",
+              "type": "string"
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "description": "Port is the port of the ServicePort.",
+              "x-kubernetes-int-or-string": true
+            }
+          },
+          "required": [
+            "name",
+            "port"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetGroupARN": {
+          "description": "targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.",
+          "type": "string"
+        },
+        "targetType": {
+          "description": "targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.",
+          "enum": [
+            "instance",
+            "ip"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "serviceRef",
+        "targetGroupARN"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "TargetGroupBindingStatus defines the observed state of TargetGroupBinding",
+      "properties": {
+        "observedGeneration": {
+          "description": "The generation observed by the TargetGroupBinding controller.",
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
 }

--- a/elbv2.k8s.aws/targetgroupbinding_v1beta1.json
+++ b/elbv2.k8s.aws/targetgroupbinding_v1beta1.json
@@ -47,7 +47,8 @@
                           "required": [
                             "cidr"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "securityGroup": {
                           "description": "SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.",
@@ -60,10 +61,12 @@
                           "required": [
                             "groupID"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "type": "array"
                   },
@@ -93,7 +96,8 @@
                           "type": "string"
                         }
                       },
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "type": "array"
                   }
@@ -102,12 +106,14 @@
                   "from",
                   "ports"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "nodeSelector": {
           "description": "node selector for instance type target groups to only register certain nodes",
@@ -137,7 +143,8 @@
                   "key",
                   "operator"
                 ],
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "type": "array"
             },
@@ -150,7 +157,8 @@
             }
           },
           "type": "object",
-          "x-kubernetes-map-type": "atomic"
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
         },
         "serviceRef": {
           "description": "serviceRef is a reference to a Kubernetes Service and ServicePort.",
@@ -176,7 +184,8 @@
             "name",
             "port"
           ],
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "targetGroupARN": {
           "description": "targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.",
@@ -196,7 +205,8 @@
         "serviceRef",
         "targetGroupARN"
       ],
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "status": {
       "description": "TargetGroupBindingStatus defines the observed state of TargetGroupBinding",
@@ -207,7 +217,8 @@
           "type": "integer"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "type": "object"


### PR DESCRIPTION
This takes the CRDs from ALB controller v2.5.

The following example is based on the ALB controller documentation:
```shell
kubeconform -summary -output json -schema-location './elbv2.k8s.aws/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' - <<EOF
apiVersion: elbv2.k8s.aws/v1beta1
kind: IngressClassParams
metadata:
  name: alb-internal
spec:
  group:
    name: my-cluster-alb-group
  scheme: internal
  inboundCIDRs: ['10.0.0.0/8']
  tags:
    - key: k8s.acme.org/managed-by
      value: loadbalancer-controller
    - key: k8s.acme.org/cluster-name
      value: my-cluster
EOF

{
  "resources": [],
  "summary": {
    "valid": 1,
    "invalid": 0,
    "errors": 0,
    "skipped": 0
  }
}
```

Comparing the same resource to the current version of the CRDs-catalog project:
```shell
kubeconform -summary -output json -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' - <<EOF
apiVersion: elbv2.k8s.aws/v1beta1
kind: IngressClassParams
metadata:
  name: alb-internal
spec:
  group:
    name: my-cluster-alb-group
  scheme: internal
  inboundCIDRs: ['10.0.0.0/8']
  tags:
    - key: k8s.acme.org/managed-by
      value: loadbalancer-controller
    - key: k8s.acme.org/cluster-name
      value: my-cluster
EOF

{
  "resources": [
    {
      "filename": "stdin",
      "kind": "IngressClassParams",
      "name": "alb-internal",
      "version": "elbv2.k8s.aws/v1beta1",
      "status": "statusInvalid",
      "msg": "problem validating schema. Check JSON formatting: jsonschema: '/spec' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/elbv2.k8s.aws/ingressclassparams_v1beta1.json#/properties/spec/additionalProperties: additionalProperties 'inboundCIDRs' not allowed",
      "validationErrors": [
        {
          "path": "/spec",
          "msg": "additionalProperties 'inboundCIDRs' not allowed"
        }
      ]
    }
  ],
  "summary": {
    "valid": 0,
    "invalid": 1,
    "errors": 0,
    "skipped": 0
  }
}
```
