### PR TITLE
update argoproj.io Argo CD schemas for 2.8.0 release

### DIFF
--- a/argoproj.io/application_v1alpha1.json
+++ b/argoproj.io/application_v1alpha1.json
@@ -295,8 +295,13 @@
                       "type": "array"
                     },
                     "values": {
-                      "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                      "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                       "type": "string"
+                    },
+                    "valuesObject": {
+                      "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                      "type": "object",
+                      "x-kubernetes-preserve-unknown-fields": true
                     },
                     "version": {
                       "description": "Version is the Helm version to use for templating (\"3\")",
@@ -315,6 +320,10 @@
                       },
                       "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                       "type": "object"
+                    },
+                    "commonAnnotationsEnvsubst": {
+                      "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                      "type": "boolean"
                     },
                     "commonLabels": {
                       "additionalProperties": {
@@ -346,6 +355,40 @@
                     "nameSuffix": {
                       "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                       "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                      "type": "string"
+                    },
+                    "replicas": {
+                      "description": "Replicas is a list of Kustomize Replicas override specifications",
+                      "items": {
+                        "properties": {
+                          "count": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Number of replicas",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "name": {
+                            "description": "Name of Deployment or StatefulSet",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "count",
+                          "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
                     },
                     "version": {
                       "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -601,8 +644,13 @@
                         "type": "array"
                       },
                       "values": {
-                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                         "type": "string"
+                      },
+                      "valuesObject": {
+                        "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "version": {
                         "description": "Version is the Helm version to use for templating (\"3\")",
@@ -621,6 +669,10 @@
                         },
                         "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                         "type": "object"
+                      },
+                      "commonAnnotationsEnvsubst": {
+                        "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                        "type": "boolean"
                       },
                       "commonLabels": {
                         "additionalProperties": {
@@ -652,6 +704,40 @@
                       "nameSuffix": {
                         "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                         "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is a list of Kustomize Replicas override specifications",
+                        "items": {
+                          "properties": {
+                            "count": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number of replicas",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "name": {
+                              "description": "Name of Deployment or StatefulSet",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "version": {
                         "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -801,7 +887,7 @@
           "description": "Destination is a reference to the target Kubernetes server and namespace",
           "properties": {
             "name": {
-              "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+              "description": "Name is an alternate way of specifying the target cluster by its symbolic name. This must be set if Server is not set.",
               "type": "string"
             },
             "namespace": {
@@ -809,7 +895,7 @@
               "type": "string"
             },
             "server": {
-              "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+              "description": "Server specifies the URL of the target cluster's Kubernetes control plane API. This must be set if Name is not set.",
               "type": "string"
             }
           },
@@ -1047,8 +1133,13 @@
                   "type": "array"
                 },
                 "values": {
-                  "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                  "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                   "type": "string"
+                },
+                "valuesObject": {
+                  "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                  "type": "object",
+                  "x-kubernetes-preserve-unknown-fields": true
                 },
                 "version": {
                   "description": "Version is the Helm version to use for templating (\"3\")",
@@ -1067,6 +1158,10 @@
                   },
                   "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                   "type": "object"
+                },
+                "commonAnnotationsEnvsubst": {
+                  "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                  "type": "boolean"
                 },
                 "commonLabels": {
                   "additionalProperties": {
@@ -1098,6 +1193,40 @@
                 "nameSuffix": {
                   "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                   "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                  "type": "string"
+                },
+                "replicas": {
+                  "description": "Replicas is a list of Kustomize Replicas override specifications",
+                  "items": {
+                    "properties": {
+                      "count": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number of replicas",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "name": {
+                        "description": "Name of Deployment or StatefulSet",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "count",
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
                 },
                 "version": {
                   "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -1353,8 +1482,13 @@
                     "type": "array"
                   },
                   "values": {
-                    "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                    "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                     "type": "string"
+                  },
+                  "valuesObject": {
+                    "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
                   },
                   "version": {
                     "description": "Version is the Helm version to use for templating (\"3\")",
@@ -1373,6 +1507,10 @@
                     },
                     "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                     "type": "object"
+                  },
+                  "commonAnnotationsEnvsubst": {
+                    "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                    "type": "boolean"
                   },
                   "commonLabels": {
                     "additionalProperties": {
@@ -1404,6 +1542,40 @@
                   "nameSuffix": {
                     "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                     "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                    "type": "string"
+                  },
+                  "replicas": {
+                    "description": "Replicas is a list of Kustomize Replicas override specifications",
+                    "items": {
+                      "properties": {
+                        "count": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "description": "Number of replicas",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "name": {
+                          "description": "Name of Deployment or StatefulSet",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "count",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
                   },
                   "version": {
                     "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -1517,7 +1689,7 @@
                   "type": "boolean"
                 },
                 "selfHeal": {
-                  "description": "SelfHeal specifes whether to revert resources back to their desired state upon modification in the cluster (default: false)",
+                  "description": "SelfHeal specifies whether to revert resources back to their desired state upon modification in the cluster (default: false)",
                   "type": "boolean"
                 }
               },
@@ -1600,7 +1772,7 @@
         "conditions": {
           "description": "Conditions is a list of currently observed application conditions",
           "items": {
-            "description": "ApplicationCondition contains details about an application condition, which is usally an error or warning",
+            "description": "ApplicationCondition contains details about an application condition, which is usually an error or warning",
             "properties": {
               "lastTransitionTime": {
                 "description": "LastTransitionTime is the time the condition was last observed",
@@ -1624,6 +1796,10 @@
             "additionalProperties": false
           },
           "type": "array"
+        },
+        "controllerNamespace": {
+          "description": "ControllerNamespace indicates the namespace in which the application controller is located",
+          "type": "string"
         },
         "health": {
           "description": "Health contains information about the application's current health status",
@@ -1828,8 +2004,13 @@
                         "type": "array"
                       },
                       "values": {
-                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                        "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                         "type": "string"
+                      },
+                      "valuesObject": {
+                        "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "version": {
                         "description": "Version is the Helm version to use for templating (\"3\")",
@@ -1848,6 +2029,10 @@
                         },
                         "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                         "type": "object"
+                      },
+                      "commonAnnotationsEnvsubst": {
+                        "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                        "type": "boolean"
                       },
                       "commonLabels": {
                         "additionalProperties": {
@@ -1879,6 +2064,40 @@
                       "nameSuffix": {
                         "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                         "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                        "type": "string"
+                      },
+                      "replicas": {
+                        "description": "Replicas is a list of Kustomize Replicas override specifications",
+                        "items": {
+                          "properties": {
+                            "count": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "Number of replicas",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "name": {
+                              "description": "Name of Deployment or StatefulSet",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "count",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "version": {
                         "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -2134,8 +2353,13 @@
                           "type": "array"
                         },
                         "values": {
-                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                           "type": "string"
+                        },
+                        "valuesObject": {
+                          "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
                         },
                         "version": {
                           "description": "Version is the Helm version to use for templating (\"3\")",
@@ -2154,6 +2378,10 @@
                           },
                           "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                           "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
                         },
                         "commonLabels": {
                           "additionalProperties": {
@@ -2185,6 +2413,40 @@
                         "nameSuffix": {
                           "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                           "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "version": {
                           "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -2593,8 +2855,13 @@
                               "type": "array"
                             },
                             "values": {
-                              "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                              "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                               "type": "string"
+                            },
+                            "valuesObject": {
+                              "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                              "type": "object",
+                              "x-kubernetes-preserve-unknown-fields": true
                             },
                             "version": {
                               "description": "Version is the Helm version to use for templating (\"3\")",
@@ -2613,6 +2880,10 @@
                               },
                               "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                               "type": "object"
+                            },
+                            "commonAnnotationsEnvsubst": {
+                              "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                              "type": "boolean"
                             },
                             "commonLabels": {
                               "additionalProperties": {
@@ -2644,6 +2915,40 @@
                             "nameSuffix": {
                               "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                               "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                              "type": "string"
+                            },
+                            "replicas": {
+                              "description": "Replicas is a list of Kustomize Replicas override specifications",
+                              "items": {
+                                "properties": {
+                                  "count": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "description": "Number of replicas",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "name": {
+                                    "description": "Name of Deployment or StatefulSet",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "count",
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "version": {
                               "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -2899,8 +3204,13 @@
                                 "type": "array"
                               },
                               "values": {
-                                "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                                "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                                 "type": "string"
+                              },
+                              "valuesObject": {
+                                "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
                               },
                               "version": {
                                 "description": "Version is the Helm version to use for templating (\"3\")",
@@ -2919,6 +3229,10 @@
                                 },
                                 "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                                 "type": "object"
+                              },
+                              "commonAnnotationsEnvsubst": {
+                                "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                                "type": "boolean"
                               },
                               "commonLabels": {
                                 "additionalProperties": {
@@ -2950,6 +3264,40 @@
                               "nameSuffix": {
                                 "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                                 "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                                "type": "string"
+                              },
+                              "replicas": {
+                                "description": "Replicas is a list of Kustomize Replicas override specifications",
+                                "items": {
+                                  "properties": {
+                                    "count": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "description": "Number of replicas",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "name": {
+                                      "description": "Name of Deployment or StatefulSet",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "count",
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
                               },
                               "version": {
                                 "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -3109,6 +3457,25 @@
             "syncResult": {
               "description": "SyncResult is the result of a Sync operation",
               "properties": {
+                "managedNamespaceMetadata": {
+                  "description": "ManagedNamespaceMetadata contains the current sync state of managed namespace metadata",
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "resources": {
                   "description": "Resources contains a list of sync result items for each individual resource in a sync operation",
                   "items": {
@@ -3335,8 +3702,13 @@
                           "type": "array"
                         },
                         "values": {
-                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                           "type": "string"
+                        },
+                        "valuesObject": {
+                          "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
                         },
                         "version": {
                           "description": "Version is the Helm version to use for templating (\"3\")",
@@ -3355,6 +3727,10 @@
                           },
                           "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                           "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
                         },
                         "commonLabels": {
                           "additionalProperties": {
@@ -3386,6 +3762,40 @@
                         "nameSuffix": {
                           "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                           "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "version": {
                           "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -3641,8 +4051,13 @@
                             "type": "array"
                           },
                           "values": {
-                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                             "type": "string"
+                          },
+                          "valuesObject": {
+                            "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
                           },
                           "version": {
                             "description": "Version is the Helm version to use for templating (\"3\")",
@@ -3661,6 +4076,10 @@
                             },
                             "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                             "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                            "type": "boolean"
                           },
                           "commonLabels": {
                             "additionalProperties": {
@@ -3692,6 +4111,40 @@
                           "nameSuffix": {
                             "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                             "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "description": "Replicas is a list of Kustomize Replicas override specifications",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number of replicas",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "description": "Name of Deployment or StatefulSet",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "version": {
                             "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -3913,7 +4366,7 @@
                   "description": "Destination is a reference to the application's destination used for comparison",
                   "properties": {
                     "name": {
-                      "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+                      "description": "Name is an alternate way of specifying the target cluster by its symbolic name. This must be set if Server is not set.",
                       "type": "string"
                     },
                     "namespace": {
@@ -3921,12 +4374,57 @@
                       "type": "string"
                     },
                     "server": {
-                      "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+                      "description": "Server specifies the URL of the target cluster's Kubernetes control plane API. This must be set if Name is not set.",
                       "type": "string"
                     }
                   },
                   "type": "object",
                   "additionalProperties": false
+                },
+                "ignoreDifferences": {
+                  "description": "IgnoreDifferences is a reference to the application's ignored differences used for comparison",
+                  "items": {
+                    "description": "ResourceIgnoreDifferences contains resource filter and list of json paths which should be ignored during comparison with live state.",
+                    "properties": {
+                      "group": {
+                        "type": "string"
+                      },
+                      "jqPathExpressions": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "jsonPointers": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "managedFieldsManagers": {
+                        "description": "ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the desired state defined in the SCM and won't be displayed in diffs",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "kind"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
                 },
                 "source": {
                   "description": "Source is a reference to the application's source used for comparison",
@@ -4085,8 +4583,13 @@
                           "type": "array"
                         },
                         "values": {
-                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                          "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                           "type": "string"
+                        },
+                        "valuesObject": {
+                          "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
                         },
                         "version": {
                           "description": "Version is the Helm version to use for templating (\"3\")",
@@ -4105,6 +4608,10 @@
                           },
                           "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                           "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                          "type": "boolean"
                         },
                         "commonLabels": {
                           "additionalProperties": {
@@ -4136,6 +4643,40 @@
                         "nameSuffix": {
                           "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                           "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "description": "Replicas is a list of Kustomize Replicas override specifications",
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number of replicas",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "description": "Name of Deployment or StatefulSet",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "version": {
                           "description": "Version controls which version of Kustomize to use for rendering manifests",
@@ -4391,8 +4932,13 @@
                             "type": "array"
                           },
                           "values": {
-                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block",
+                            "description": "Values specifies Helm values to be passed to helm template, typically defined as a block. ValuesObject takes precedence over Values, so use one or the other.",
                             "type": "string"
+                          },
+                          "valuesObject": {
+                            "description": "ValuesObject specifies Helm values to be passed to helm template, defined as a map. This takes precedence over Values.",
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
                           },
                           "version": {
                             "description": "Version is the Helm version to use for templating (\"3\")",
@@ -4411,6 +4957,10 @@
                             },
                             "description": "CommonAnnotations is a list of additional annotations to add to rendered manifests",
                             "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "description": "CommonAnnotationsEnvsubst specifies whether to apply env variables substitution for annotation values",
+                            "type": "boolean"
                           },
                           "commonLabels": {
                             "additionalProperties": {
@@ -4442,6 +4992,40 @@
                           "nameSuffix": {
                             "description": "NameSuffix is a suffix appended to resources for Kustomize apps",
                             "type": "string"
+                          },
+                          "namespace": {
+                            "description": "Namespace sets the namespace that Kustomize adds to all resources",
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "description": "Replicas is a list of Kustomize Replicas override specifications",
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Number of replicas",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "description": "Name of Deployment or StatefulSet",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "version": {
                             "description": "Version controls which version of Kustomize to use for rendering manifests",

--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -11,6 +11,9 @@
     },
     "spec": {
       "properties": {
+        "applyNestedSelectors": {
+          "type": "boolean"
+        },
         "generators": {
           "items": {
             "properties": {
@@ -312,6 +315,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -326,6 +333,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -350,6 +360,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -565,6 +605,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -579,6 +623,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -603,6 +650,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -1075,6 +1152,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -1089,6 +1170,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -1113,6 +1197,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -1328,6 +1442,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -1342,6 +1460,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -1366,6 +1487,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -1844,6 +1995,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -1858,6 +2013,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -1882,6 +2040,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -2097,6 +2285,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -2111,6 +2303,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -2135,6 +2330,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -2305,6 +2530,12 @@
                     ],
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "values": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
                   }
                 },
                 "required": [
@@ -2321,6 +2552,9 @@
                       "x-kubernetes-preserve-unknown-fields": true
                     },
                     "type": "array"
+                  },
+                  "elementsYaml": {
+                    "type": "string"
                   },
                   "template": {
                     "properties": {
@@ -2571,6 +2805,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -2585,6 +2823,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -2609,6 +2850,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -2824,6 +3095,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -2838,6 +3113,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -2862,6 +3140,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -3343,6 +3651,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -3357,6 +3669,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -3381,6 +3696,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -3596,6 +3941,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -3610,6 +3959,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -3634,6 +3986,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -4106,6 +4488,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -4120,6 +4506,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -4144,6 +4533,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -4359,6 +4778,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -4373,6 +4796,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -4397,6 +4823,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -4875,6 +5331,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -4889,6 +5349,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -4913,6 +5376,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -5128,6 +5621,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -5142,6 +5639,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -5166,6 +5666,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -5336,6 +5866,12 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "required": [
@@ -5352,6 +5888,9 @@
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "type": "array"
+                            },
+                            "elementsYaml": {
+                              "type": "string"
                             },
                             "template": {
                               "properties": {
@@ -5602,6 +6141,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -5616,6 +6159,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -5640,6 +6186,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -5855,6 +6431,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -5869,6 +6449,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -5893,6 +6476,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -6077,8 +6690,954 @@
                         "merge": {
                           "x-kubernetes-preserve-unknown-fields": true
                         },
+                        "plugin": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "input": {
+                              "properties": {
+                                "parameters": {
+                                  "additionalProperties": {
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "configMapRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "pullRequest": {
                           "properties": {
+                            "azuredevops": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "organization",
+                                "project",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucket": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bearerToken": {
+                                  "properties": {
+                                    "tokenRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "tokenRef"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "bitbucketServer": {
                               "properties": {
                                 "api": {
@@ -6132,6 +7691,9 @@
                               "items": {
                                 "properties": {
                                   "branchMatch": {
+                                    "type": "string"
+                                  },
+                                  "targetBranchMatch": {
                                     "type": "string"
                                   }
                                 },
@@ -6227,6 +7789,9 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
                                 },
                                 "labels": {
                                   "items": {
@@ -6516,6 +8081,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -6530,6 +8099,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -6554,6 +8126,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -6769,6 +8371,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -6783,6 +8389,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -6807,6 +8416,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -6984,6 +8623,39 @@
                         },
                         "scmProvider": {
                           "properties": {
+                            "awsCodeCommit": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "tagFilters": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "azureDevOps": {
                               "properties": {
                                 "accessTokenRef": {
@@ -7226,7 +8898,13 @@
                                 "group": {
                                   "type": "string"
                                 },
+                                "includeSharedProjects": {
+                                  "type": "boolean"
+                                },
                                 "includeSubgroups": {
+                                  "type": "boolean"
+                                },
+                                "insecure": {
                                   "type": "boolean"
                                 },
                                 "tokenRef": {
@@ -7505,6 +9183,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -7519,6 +9201,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -7543,6 +9228,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -7758,6 +9473,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -7772,6 +9491,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -7796,6 +9518,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -7966,6 +9718,12 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -8263,6 +10021,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -8277,6 +10039,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -8301,6 +10066,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -8516,6 +10311,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -8530,6 +10329,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -8554,6 +10356,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -9035,6 +10867,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -9049,6 +10885,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -9073,6 +10912,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -9288,6 +11157,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -9302,6 +11175,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -9326,6 +11202,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -9798,6 +11704,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -9812,6 +11722,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -9836,6 +11749,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -10051,6 +11994,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -10065,6 +12012,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -10089,6 +12039,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -10567,6 +12547,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -10581,6 +12565,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -10605,6 +12592,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -10820,6 +12837,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -10834,6 +12855,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -10858,6 +12882,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -11028,6 +13082,12 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "required": [
@@ -11044,6 +13104,9 @@
                                 "x-kubernetes-preserve-unknown-fields": true
                               },
                               "type": "array"
+                            },
+                            "elementsYaml": {
+                              "type": "string"
                             },
                             "template": {
                               "properties": {
@@ -11294,6 +13357,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -11308,6 +13375,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -11332,6 +13402,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -11547,6 +13647,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -11561,6 +13665,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -11585,6 +13692,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -11769,8 +13906,954 @@
                         "merge": {
                           "x-kubernetes-preserve-unknown-fields": true
                         },
+                        "plugin": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "input": {
+                              "properties": {
+                                "parameters": {
+                                  "additionalProperties": {
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "requeueAfterSeconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "template": {
+                              "properties": {
+                                "metadata": {
+                                  "properties": {
+                                    "annotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "finalizers": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "labels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "spec": {
+                                  "properties": {
+                                    "destination": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "server": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "ignoreDifferences": {
+                                      "items": {
+                                        "properties": {
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "jqPathExpressions": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "jsonPointers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "managedFieldsManagers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "kind"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "info": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "project": {
+                                      "type": "string"
+                                    },
+                                    "revisionHistoryLimit": {
+                                      "format": "int64",
+                                      "type": "integer"
+                                    },
+                                    "source": {
+                                      "properties": {
+                                        "chart": {
+                                          "type": "string"
+                                        },
+                                        "directory": {
+                                          "properties": {
+                                            "exclude": {
+                                              "type": "string"
+                                            },
+                                            "include": {
+                                              "type": "string"
+                                            },
+                                            "jsonnet": {
+                                              "properties": {
+                                                "extVars": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "libs": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "tlas": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "code": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "recurse": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "helm": {
+                                          "properties": {
+                                            "fileParameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "ignoreMissingValueFiles": {
+                                              "type": "boolean"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "forceString": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "passCredentials": {
+                                              "type": "boolean"
+                                            },
+                                            "releaseName": {
+                                              "type": "string"
+                                            },
+                                            "skipCrds": {
+                                              "type": "boolean"
+                                            },
+                                            "valueFiles": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "values": {
+                                              "type": "string"
+                                            },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "kustomize": {
+                                          "properties": {
+                                            "commonAnnotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
+                                            },
+                                            "commonLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "forceCommonAnnotations": {
+                                              "type": "boolean"
+                                            },
+                                            "forceCommonLabels": {
+                                              "type": "boolean"
+                                            },
+                                            "images": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
+                                            "namePrefix": {
+                                              "type": "string"
+                                            },
+                                            "nameSuffix": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "plugin": {
+                                          "properties": {
+                                            "env": {
+                                              "items": {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "parameters": {
+                                              "items": {
+                                                "properties": {
+                                                  "array": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "map": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "string": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "repoURL": {
+                                          "type": "string"
+                                        },
+                                        "targetRevision": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "repoURL"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "sources": {
+                                      "items": {
+                                        "properties": {
+                                          "chart": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "properties": {
+                                              "exclude": {
+                                                "type": "string"
+                                              },
+                                              "include": {
+                                                "type": "string"
+                                              },
+                                              "jsonnet": {
+                                                "properties": {
+                                                  "extVars": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "libs": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "tlas": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "code": {
+                                                          "type": "boolean"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "name",
+                                                        "value"
+                                                      ],
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "recurse": {
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "helm": {
+                                            "properties": {
+                                              "fileParameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "ignoreMissingValueFiles": {
+                                                "type": "boolean"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "forceString": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "passCredentials": {
+                                                "type": "boolean"
+                                              },
+                                              "releaseName": {
+                                                "type": "string"
+                                              },
+                                              "skipCrds": {
+                                                "type": "boolean"
+                                              },
+                                              "valueFiles": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "values": {
+                                                "type": "string"
+                                              },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "kustomize": {
+                                            "properties": {
+                                              "commonAnnotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
+                                              },
+                                              "commonLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "forceCommonAnnotations": {
+                                                "type": "boolean"
+                                              },
+                                              "forceCommonLabels": {
+                                                "type": "boolean"
+                                              },
+                                              "images": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namePrefix": {
+                                                "type": "string"
+                                              },
+                                              "nameSuffix": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "plugin": {
+                                            "properties": {
+                                              "env": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "parameters": {
+                                                "items": {
+                                                  "properties": {
+                                                    "array": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "map": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "string": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "repoURL": {
+                                            "type": "string"
+                                          },
+                                          "targetRevision": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "repoURL"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "syncPolicy": {
+                                      "properties": {
+                                        "automated": {
+                                          "properties": {
+                                            "allowEmpty": {
+                                              "type": "boolean"
+                                            },
+                                            "prune": {
+                                              "type": "boolean"
+                                            },
+                                            "selfHeal": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "managedNamespaceMetadata": {
+                                          "properties": {
+                                            "annotations": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            },
+                                            "labels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "retry": {
+                                          "properties": {
+                                            "backoff": {
+                                              "properties": {
+                                                "duration": {
+                                                  "type": "string"
+                                                },
+                                                "factor": {
+                                                  "format": "int64",
+                                                  "type": "integer"
+                                                },
+                                                "maxDuration": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "limit": {
+                                              "format": "int64",
+                                              "type": "integer"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "syncOptions": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "destination",
+                                    "project"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "metadata",
+                                "spec"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "configMapRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "pullRequest": {
                           "properties": {
+                            "azuredevops": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "organization": {
+                                  "type": "string"
+                                },
+                                "project": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                },
+                                "tokenRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "secretName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "secretName"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "organization",
+                                "project",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "bitbucket": {
+                              "properties": {
+                                "api": {
+                                  "type": "string"
+                                },
+                                "basicAuth": {
+                                  "properties": {
+                                    "passwordRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "username": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "passwordRef",
+                                    "username"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "bearerToken": {
+                                  "properties": {
+                                    "tokenRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "secretName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "secretName"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "required": [
+                                    "tokenRef"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "repo": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "repo"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "bitbucketServer": {
                               "properties": {
                                 "api": {
@@ -11824,6 +14907,9 @@
                               "items": {
                                 "properties": {
                                   "branchMatch": {
+                                    "type": "string"
+                                  },
+                                  "targetBranchMatch": {
                                     "type": "string"
                                   }
                                 },
@@ -11919,6 +15005,9 @@
                               "properties": {
                                 "api": {
                                   "type": "string"
+                                },
+                                "insecure": {
+                                  "type": "boolean"
                                 },
                                 "labels": {
                                   "items": {
@@ -12208,6 +15297,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -12222,6 +15315,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -12246,6 +15342,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -12461,6 +15587,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -12475,6 +15605,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -12499,6 +15632,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -12676,6 +15839,39 @@
                         },
                         "scmProvider": {
                           "properties": {
+                            "awsCodeCommit": {
+                              "properties": {
+                                "allBranches": {
+                                  "type": "boolean"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "tagFilters": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "azureDevOps": {
                               "properties": {
                                 "accessTokenRef": {
@@ -12918,7 +16114,13 @@
                                 "group": {
                                   "type": "string"
                                 },
+                                "includeSharedProjects": {
+                                  "type": "boolean"
+                                },
                                 "includeSubgroups": {
+                                  "type": "boolean"
+                                },
+                                "insecure": {
                                   "type": "boolean"
                                 },
                                 "tokenRef": {
@@ -13197,6 +16399,10 @@
                                             "values": {
                                               "type": "string"
                                             },
+                                            "valuesObject": {
+                                              "type": "object",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            },
                                             "version": {
                                               "type": "string"
                                             }
@@ -13211,6 +16417,9 @@
                                                 "type": "string"
                                               },
                                               "type": "object"
+                                            },
+                                            "commonAnnotationsEnvsubst": {
+                                              "type": "boolean"
                                             },
                                             "commonLabels": {
                                               "additionalProperties": {
@@ -13235,6 +16444,36 @@
                                             },
                                             "nameSuffix": {
                                               "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "replicas": {
+                                              "items": {
+                                                "properties": {
+                                                  "count": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "count",
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "version": {
                                               "type": "string"
@@ -13450,6 +16689,10 @@
                                               "values": {
                                                 "type": "string"
                                               },
+                                              "valuesObject": {
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                              },
                                               "version": {
                                                 "type": "string"
                                               }
@@ -13464,6 +16707,9 @@
                                                   "type": "string"
                                                 },
                                                 "type": "object"
+                                              },
+                                              "commonAnnotationsEnvsubst": {
+                                                "type": "boolean"
                                               },
                                               "commonLabels": {
                                                 "additionalProperties": {
@@ -13488,6 +16734,36 @@
                                               },
                                               "nameSuffix": {
                                                 "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "replicas": {
+                                                "items": {
+                                                  "properties": {
+                                                    "count": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "count",
+                                                    "name"
+                                                  ],
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "version": {
                                                 "type": "string"
@@ -13658,6 +16934,12 @@
                               ],
                               "type": "object",
                               "additionalProperties": false
+                            },
+                            "values": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
                             }
                           },
                           "type": "object",
@@ -13961,6 +17243,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -13975,6 +17261,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -13999,6 +17288,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -14214,6 +17533,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -14228,6 +17551,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -14252,6 +17578,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -14431,8 +17787,954 @@
                 "type": "object",
                 "additionalProperties": false
               },
+              "plugin": {
+                "properties": {
+                  "configMapRef": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "input": {
+                    "properties": {
+                      "parameters": {
+                        "additionalProperties": {
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "requeueAfterSeconds": {
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "template": {
+                    "properties": {
+                      "metadata": {
+                        "properties": {
+                          "annotations": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "finalizers": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "labels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "spec": {
+                        "properties": {
+                          "destination": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ignoreDifferences": {
+                            "items": {
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "jqPathExpressions": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "jsonPointers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "managedFieldsManagers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "kind"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "info": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "value"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "project": {
+                            "type": "string"
+                          },
+                          "revisionHistoryLimit": {
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          "source": {
+                            "properties": {
+                              "chart": {
+                                "type": "string"
+                              },
+                              "directory": {
+                                "properties": {
+                                  "exclude": {
+                                    "type": "string"
+                                  },
+                                  "include": {
+                                    "type": "string"
+                                  },
+                                  "jsonnet": {
+                                    "properties": {
+                                      "extVars": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "libs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "tlas": {
+                                        "items": {
+                                          "properties": {
+                                            "code": {
+                                              "type": "boolean"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "recurse": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "helm": {
+                                "properties": {
+                                  "fileParameters": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ignoreMissingValueFiles": {
+                                    "type": "boolean"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "forceString": {
+                                          "type": "boolean"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "passCredentials": {
+                                    "type": "boolean"
+                                  },
+                                  "releaseName": {
+                                    "type": "string"
+                                  },
+                                  "skipCrds": {
+                                    "type": "boolean"
+                                  },
+                                  "valueFiles": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "values": {
+                                    "type": "string"
+                                  },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "kustomize": {
+                                "properties": {
+                                  "commonAnnotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
+                                  },
+                                  "commonLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "forceCommonAnnotations": {
+                                    "type": "boolean"
+                                  },
+                                  "forceCommonLabels": {
+                                    "type": "boolean"
+                                  },
+                                  "images": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namePrefix": {
+                                    "type": "string"
+                                  },
+                                  "nameSuffix": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "plugin": {
+                                "properties": {
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "parameters": {
+                                    "items": {
+                                      "properties": {
+                                        "array": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "map": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "string": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ref": {
+                                "type": "string"
+                              },
+                              "repoURL": {
+                                "type": "string"
+                              },
+                              "targetRevision": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "repoURL"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "chart": {
+                                  "type": "string"
+                                },
+                                "directory": {
+                                  "properties": {
+                                    "exclude": {
+                                      "type": "string"
+                                    },
+                                    "include": {
+                                      "type": "string"
+                                    },
+                                    "jsonnet": {
+                                      "properties": {
+                                        "extVars": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "libs": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        "tlas": {
+                                          "items": {
+                                            "properties": {
+                                              "code": {
+                                                "type": "boolean"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name",
+                                              "value"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "recurse": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "helm": {
+                                  "properties": {
+                                    "fileParameters": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "ignoreMissingValueFiles": {
+                                      "type": "boolean"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "forceString": {
+                                            "type": "boolean"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "passCredentials": {
+                                      "type": "boolean"
+                                    },
+                                    "releaseName": {
+                                      "type": "string"
+                                    },
+                                    "skipCrds": {
+                                      "type": "boolean"
+                                    },
+                                    "valueFiles": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "values": {
+                                      "type": "string"
+                                    },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "kustomize": {
+                                  "properties": {
+                                    "commonAnnotations": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
+                                    },
+                                    "commonLabels": {
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "forceCommonAnnotations": {
+                                      "type": "boolean"
+                                    },
+                                    "forceCommonLabels": {
+                                      "type": "boolean"
+                                    },
+                                    "images": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "namePrefix": {
+                                      "type": "string"
+                                    },
+                                    "nameSuffix": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "plugin": {
+                                  "properties": {
+                                    "env": {
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "parameters": {
+                                      "items": {
+                                        "properties": {
+                                          "array": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "map": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "string": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "ref": {
+                                  "type": "string"
+                                },
+                                "repoURL": {
+                                  "type": "string"
+                                },
+                                "targetRevision": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "repoURL"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "syncPolicy": {
+                            "properties": {
+                              "automated": {
+                                "properties": {
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  },
+                                  "prune": {
+                                    "type": "boolean"
+                                  },
+                                  "selfHeal": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "managedNamespaceMetadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "retry": {
+                                "properties": {
+                                  "backoff": {
+                                    "properties": {
+                                      "duration": {
+                                        "type": "string"
+                                      },
+                                      "factor": {
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "maxDuration": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "limit": {
+                                    "format": "int64",
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "syncOptions": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "destination",
+                          "project"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "metadata",
+                      "spec"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "values": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "configMapRef"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
               "pullRequest": {
                 "properties": {
+                  "azuredevops": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "labels": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "organization": {
+                        "type": "string"
+                      },
+                      "project": {
+                        "type": "string"
+                      },
+                      "repo": {
+                        "type": "string"
+                      },
+                      "tokenRef": {
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "secretName"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "organization",
+                      "project",
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "bitbucket": {
+                    "properties": {
+                      "api": {
+                        "type": "string"
+                      },
+                      "basicAuth": {
+                        "properties": {
+                          "passwordRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "secretName"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "username": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "passwordRef",
+                          "username"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "bearerToken": {
+                        "properties": {
+                          "tokenRef": {
+                            "properties": {
+                              "key": {
+                                "type": "string"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "secretName"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "tokenRef"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "owner": {
+                        "type": "string"
+                      },
+                      "repo": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "owner",
+                      "repo"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "bitbucketServer": {
                     "properties": {
                       "api": {
@@ -14486,6 +18788,9 @@
                     "items": {
                       "properties": {
                         "branchMatch": {
+                          "type": "string"
+                        },
+                        "targetBranchMatch": {
                           "type": "string"
                         }
                       },
@@ -14581,6 +18886,9 @@
                     "properties": {
                       "api": {
                         "type": "string"
+                      },
+                      "insecure": {
+                        "type": "boolean"
                       },
                       "labels": {
                         "items": {
@@ -14870,6 +19178,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -14884,6 +19196,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -14908,6 +19223,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -15123,6 +19468,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -15137,6 +19486,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -15161,6 +19513,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -15338,6 +19720,39 @@
               },
               "scmProvider": {
                 "properties": {
+                  "awsCodeCommit": {
+                    "properties": {
+                      "allBranches": {
+                        "type": "boolean"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "role": {
+                        "type": "string"
+                      },
+                      "tagFilters": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "azureDevOps": {
                     "properties": {
                       "accessTokenRef": {
@@ -15580,7 +19995,13 @@
                       "group": {
                         "type": "string"
                       },
+                      "includeSharedProjects": {
+                        "type": "boolean"
+                      },
                       "includeSubgroups": {
+                        "type": "boolean"
+                      },
+                      "insecure": {
                         "type": "boolean"
                       },
                       "tokenRef": {
@@ -15859,6 +20280,10 @@
                                   "values": {
                                     "type": "string"
                                   },
+                                  "valuesObject": {
+                                    "type": "object",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
                                   "version": {
                                     "type": "string"
                                   }
@@ -15873,6 +20298,9 @@
                                       "type": "string"
                                     },
                                     "type": "object"
+                                  },
+                                  "commonAnnotationsEnvsubst": {
+                                    "type": "boolean"
                                   },
                                   "commonLabels": {
                                     "additionalProperties": {
@@ -15897,6 +20325,36 @@
                                   },
                                   "nameSuffix": {
                                     "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "replicas": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "count",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "version": {
                                     "type": "string"
@@ -16112,6 +20570,10 @@
                                     "values": {
                                       "type": "string"
                                     },
+                                    "valuesObject": {
+                                      "type": "object",
+                                      "x-kubernetes-preserve-unknown-fields": true
+                                    },
                                     "version": {
                                       "type": "string"
                                     }
@@ -16126,6 +20588,9 @@
                                         "type": "string"
                                       },
                                       "type": "object"
+                                    },
+                                    "commonAnnotationsEnvsubst": {
+                                      "type": "boolean"
                                     },
                                     "commonLabels": {
                                       "additionalProperties": {
@@ -16150,6 +20615,36 @@
                                     },
                                     "nameSuffix": {
                                       "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "replicas": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "count",
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "version": {
                                       "type": "string"
@@ -16320,6 +20815,12 @@
                     ],
                     "type": "object",
                     "additionalProperties": false
+                  },
+                  "values": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
                   }
                 },
                 "type": "object",
@@ -16370,6 +20871,24 @@
         },
         "goTemplate": {
           "type": "boolean"
+        },
+        "goTemplateOptions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "preservedFields": {
+          "properties": {
+            "annotations": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
         },
         "strategy": {
           "properties": {
@@ -16429,6 +20948,15 @@
         },
         "syncPolicy": {
           "properties": {
+            "applicationsSync": {
+              "enum": [
+                "create-only",
+                "create-update",
+                "create-delete",
+                "sync"
+              ],
+              "type": "string"
+            },
             "preserveResourcesOnDeletion": {
               "type": "boolean"
             }
@@ -16685,6 +21213,10 @@
                         "values": {
                           "type": "string"
                         },
+                        "valuesObject": {
+                          "type": "object",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
                         "version": {
                           "type": "string"
                         }
@@ -16699,6 +21231,9 @@
                             "type": "string"
                           },
                           "type": "object"
+                        },
+                        "commonAnnotationsEnvsubst": {
+                          "type": "boolean"
                         },
                         "commonLabels": {
                           "additionalProperties": {
@@ -16723,6 +21258,36 @@
                         },
                         "nameSuffix": {
                           "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "replicas": {
+                          "items": {
+                            "properties": {
+                              "count": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "count",
+                              "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "version": {
                           "type": "string"
@@ -16938,6 +21503,10 @@
                           "values": {
                             "type": "string"
                           },
+                          "valuesObject": {
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
+                          },
                           "version": {
                             "type": "string"
                           }
@@ -16952,6 +21521,9 @@
                               "type": "string"
                             },
                             "type": "object"
+                          },
+                          "commonAnnotationsEnvsubst": {
+                            "type": "boolean"
                           },
                           "commonLabels": {
                             "additionalProperties": {
@@ -16976,6 +21548,36 @@
                           },
                           "nameSuffix": {
                             "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "replicas": {
+                            "items": {
+                              "properties": {
+                                "count": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "count",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "version": {
                             "type": "string"

--- a/argoproj.io/appproject_v1alpha1.json
+++ b/argoproj.io/appproject_v1alpha1.json
@@ -67,7 +67,7 @@
             "description": "ApplicationDestination holds information about the application's destination",
             "properties": {
               "name": {
-                "description": "Name is an alternate way of specifying the target cluster by its symbolic name",
+                "description": "Name is an alternate way of specifying the target cluster by its symbolic name. This must be set if Server is not set.",
                 "type": "string"
               },
               "namespace": {
@@ -75,7 +75,7 @@
                 "type": "string"
               },
               "server": {
-                "description": "Server specifies the URL of the target cluster and must be set to the Kubernetes control plane API",
+                "description": "Server specifies the URL of the target cluster's Kubernetes control plane API. This must be set if Name is not set.",
                 "type": "string"
               }
             },


### PR DESCRIPTION
Argo CD just did a release ([`v2.8.0`](https://github.com/argoproj/argo-cd/releases/tag/v2.8.0)) that added some major updates to their CRDs.

Thanks for maintaining this project!