### PR TITLE
update cert manager clusterissuer

### DIFF
--- a/cert-manager.io/clusterissuer_v1.json
+++ b/cert-manager.io/clusterissuer_v1.json
@@ -61,16 +61,14 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
               "required": [
                 "keyID",
                 "keySecretRef"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "preferredChain": {
               "description": "PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let's Encrypt's DST crosssign you would use: \"DST Root CA X3\" or \"ISRG Root X1\" for the newer Let's Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer's CN",
@@ -92,8 +90,7 @@
               "required": [
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "server": {
               "description": "Server is the URL used to access the ACME server's 'directory' endpoint. For example, for Let's Encrypt's staging endpoint, you would use: \"https://acme-staging-v02.api.letsencrypt.org/directory\". Only ACME v2 endpoints (i.e. RFC 8555) are supported.",
@@ -129,8 +126,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "host": {
                             "type": "string"
@@ -140,8 +136,7 @@
                           "accountSecretRef",
                           "host"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "akamai": {
                         "description": "Use the Akamai DNS zone management API to manage DNS01 challenge records.",
@@ -161,8 +156,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "clientSecretSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
@@ -179,8 +173,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "clientTokenSecretRef": {
                             "description": "A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.",
@@ -197,8 +190,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "serviceConsumerDomain": {
                             "type": "string"
@@ -210,8 +202,7 @@
                           "clientTokenSecretRef",
                           "serviceConsumerDomain"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "azureDNS": {
                         "description": "Use the Microsoft Azure DNS API to manage DNS01 challenge records.",
@@ -235,8 +226,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "environment": {
                             "description": "name of the Azure environment (default AzurePublicCloud)",
@@ -264,8 +254,7 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "resourceGroupName": {
                             "description": "resource group the DNS zone is located in",
@@ -284,8 +273,7 @@
                           "resourceGroupName",
                           "subscriptionID"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "cloudDNS": {
                         "description": "Use the Google Cloud DNS API to manage DNS01 challenge records.",
@@ -312,15 +300,13 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "project"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "cloudflare": {
                         "description": "Use the Cloudflare API to manage DNS01 challenge records.",
@@ -340,8 +326,7 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "apiTokenSecretRef": {
                             "description": "API token used to authenticate with Cloudflare.",
@@ -358,16 +343,14 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "email": {
                             "description": "Email of the account, only required when using API key based authentication.",
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "cnameStrategy": {
                         "description": "CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.",
@@ -395,21 +378,19 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "tokenSecretRef"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "rfc2136": {
                         "description": "Use RFC2136 (\"Dynamic Updates in the Domain Name System\") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.",
                         "properties": {
                           "nameserver": {
-                            "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
+                            "description": "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.",
                             "type": "string"
                           },
                           "tsigAlgorithm": {
@@ -435,22 +416,37 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "nameserver"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "route53": {
                         "description": "Use the AWS Route53 API to manage DNS01 challenge records.",
                         "properties": {
                           "accessKeyID": {
-                            "description": "The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "description": "The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                             "type": "string"
+                          },
+                          "accessKeyIDSecretRef": {
+                            "description": "The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "properties": {
+                              "key": {
+                                "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object"
                           },
                           "hostedZoneID": {
                             "description": "If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.",
@@ -465,7 +461,7 @@
                             "type": "string"
                           },
                           "secretAccessKeySecretRef": {
-                            "description": "The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
+                            "description": "The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials",
                             "properties": {
                               "key": {
                                 "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
@@ -479,15 +475,13 @@
                             "required": [
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "region"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "webhook": {
                         "description": "Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.",
@@ -509,12 +503,10 @@
                           "groupName",
                           "solverName"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "http01": {
                     "description": "Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.",
@@ -532,7 +524,7 @@
                           "parentRefs": {
                             "description": "When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/v1alpha2/api-types/httproute/#attaching-to-gateways",
                             "items": {
-                              "description": "ParentRef identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid. \n References to objects with invalid Group and Kind are not valid, and must be rejected by the implementation, with appropriate Conditions set on the containing object.",
+                              "description": "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid.",
                               "properties": {
                                 "group": {
                                   "default": "gateway.networking.k8s.io",
@@ -543,7 +535,7 @@
                                 },
                                 "kind": {
                                   "default": "Gateway",
-                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) Support: Custom (Other Resources)",
+                                  "description": "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Custom (Other Resources)",
                                   "maxLength": 63,
                                   "minLength": 1,
                                   "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
@@ -562,8 +554,15 @@
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                   "type": "string"
                                 },
+                                "port": {
+                                  "description": "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n \\u003cgateway:experimental\\u003e",
+                                  "format": "int32",
+                                  "maximum": 65535,
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
                                 "sectionName": {
-                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
+                                  "description": "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core",
                                   "maxLength": 253,
                                   "minLength": 1,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
@@ -573,8 +572,7 @@
                               "required": [
                                 "name"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -583,8 +581,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "ingress": {
                         "description": "The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.",
@@ -614,12 +611,10 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "name": {
                             "description": "The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.",
@@ -646,8 +641,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "spec": {
                                 "description": "PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.",
@@ -691,8 +685,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -721,14 +714,13 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "weight": {
                                                   "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
@@ -740,8 +732,7 @@
                                                 "preference",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "type": "array"
                                           },
@@ -778,8 +769,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -808,14 +798,13 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "type": "array"
                                               }
@@ -824,11 +813,10 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
-                                            "additionalProperties": false
+                                            "x-kubernetes-map-type": "atomic"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAffinity": {
                                         "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
@@ -869,8 +857,7 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "type": "array"
                                                         },
@@ -883,10 +870,10 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaceSelector": {
-                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -913,8 +900,7 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "type": "array"
                                                         },
@@ -927,10 +913,10 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
-                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                                       "items": {
                                                         "type": "string"
                                                       },
@@ -944,8 +930,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
@@ -957,15 +942,14 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "type": "array"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                                             "items": {
-                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running",
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
@@ -995,8 +979,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -1009,10 +992,10 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaceSelector": {
-                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -1039,8 +1022,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -1053,10 +1035,10 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
-                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                                   "items": {
                                                     "type": "string"
                                                   },
@@ -1070,14 +1052,12 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "type": "array"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       },
                                       "podAntiAffinity": {
                                         "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
@@ -1118,8 +1098,7 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "type": "array"
                                                         },
@@ -1132,10 +1111,10 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaceSelector": {
-                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                                       "properties": {
                                                         "matchExpressions": {
                                                           "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -1162,8 +1141,7 @@
                                                               "key",
                                                               "operator"
                                                             ],
-                                                            "type": "object",
-                                                            "additionalProperties": false
+                                                            "type": "object"
                                                           },
                                                           "type": "array"
                                                         },
@@ -1176,10 +1154,10 @@
                                                         }
                                                       },
                                                       "type": "object",
-                                                      "additionalProperties": false
+                                                      "x-kubernetes-map-type": "atomic"
                                                     },
                                                     "namespaces": {
-                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                                       "items": {
                                                         "type": "string"
                                                       },
@@ -1193,8 +1171,7 @@
                                                   "required": [
                                                     "topologyKey"
                                                   ],
-                                                  "type": "object",
-                                                  "additionalProperties": false
+                                                  "type": "object"
                                                 },
                                                 "weight": {
                                                   "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
@@ -1206,15 +1183,14 @@
                                                 "podAffinityTerm",
                                                 "weight"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "type": "array"
                                           },
                                           "requiredDuringSchedulingIgnoredDuringExecution": {
                                             "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
                                             "items": {
-                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                              "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \\u003ctopologyKey\\u003e matches that of any node on which a pod of the set of pods is running",
                                               "properties": {
                                                 "labelSelector": {
                                                   "description": "A label query over a set of resources, in this case pods.",
@@ -1244,8 +1220,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -1258,10 +1233,10 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaceSelector": {
-                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.",
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
                                                   "properties": {
                                                     "matchExpressions": {
                                                       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -1288,8 +1263,7 @@
                                                           "key",
                                                           "operator"
                                                         ],
-                                                        "type": "object",
-                                                        "additionalProperties": false
+                                                        "type": "object"
                                                       },
                                                       "type": "array"
                                                     },
@@ -1302,10 +1276,10 @@
                                                     }
                                                   },
                                                   "type": "object",
-                                                  "additionalProperties": false
+                                                  "x-kubernetes-map-type": "atomic"
                                                 },
                                                 "namespaces": {
-                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
                                                   "items": {
                                                     "type": "string"
                                                   },
@@ -1319,18 +1293,15 @@
                                               "required": [
                                                 "topologyKey"
                                               ],
-                                              "type": "object",
-                                              "additionalProperties": false
+                                              "type": "object"
                                             },
                                             "type": "array"
                                           }
                                         },
-                                        "type": "object",
-                                        "additionalProperties": false
+                                        "type": "object"
                                       }
                                     },
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "nodeSelector": {
                                     "additionalProperties": {
@@ -1350,7 +1321,7 @@
                                   "tolerations": {
                                     "description": "If specified, the pod's tolerations.",
                                     "items": {
-                                      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                      "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \\u003ckey,value,effect\\u003e using the matching operator \\u003coperator\\u003e.",
                                       "properties": {
                                         "effect": {
                                           "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -1374,30 +1345,25 @@
                                           "type": "string"
                                         }
                                       },
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "serviceType": {
                             "description": "Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.",
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "selector": {
                     "description": "Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.",
@@ -1424,12 +1390,10 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
@@ -1438,8 +1402,7 @@
             "privateKeySecretRef",
             "server"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "ca": {
           "description": "CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.",
@@ -1466,8 +1429,7 @@
           "required": [
             "secretName"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "selfSigned": {
           "description": "SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.",
@@ -1480,8 +1442,7 @@
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "vault": {
           "description": "Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.",
@@ -1515,8 +1476,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -1524,8 +1484,7 @@
                     "roleId",
                     "secretRef"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "kubernetes": {
                   "description": "Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.",
@@ -1553,16 +1512,14 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
                     "role",
                     "secretRef"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "tokenSecretRef": {
                   "description": "TokenSecretRef authenticates with Vault by presenting a token.",
@@ -1579,17 +1536,32 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "caBundle": {
-              "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection.",
+              "description": "PEM-encoded CA bundle (base64-encoded) used to validate Vault server certificate. Only used if the Server URL is using HTTPS protocol. This parameter is ignored for plain HTTP protocol connection. If not set the system root certificates are used to validate the TLS connection. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the cert-manager controller system root certificates are used to validate the TLS connection.",
               "format": "byte",
               "type": "string"
+            },
+            "caBundleSecretRef": {
+              "description": "CABundleSecretRef is a reference to a Secret which contains the CABundle which will be used when connecting to Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundleSecretRef nor CABundle are defined, the cert-manager controller system root certificates are used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.",
+              "properties": {
+                "key": {
+                  "description": "The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
             },
             "namespace": {
               "description": "Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: \"ns1\" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces",
@@ -1609,8 +1581,7 @@
             "path",
             "server"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "venafi": {
           "description": "Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.",
@@ -1633,8 +1604,7 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "url": {
                   "description": "URL is the base URL for Venafi Cloud. Defaults to \"https://api.venafi.cloud/v1\".",
@@ -1644,8 +1614,7 @@
               "required": [
                 "apiTokenSecretRef"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "tpp": {
               "description": "TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.",
@@ -1666,8 +1635,7 @@
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "url": {
                   "description": "URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: \"https://tpp.example.com/vedsdk\".",
@@ -1678,8 +1646,7 @@
                 "credentialsRef",
                 "url"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "zone": {
               "description": "Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.",
@@ -1689,12 +1656,10 @@
           "required": [
             "zone"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "status": {
       "description": "Status of the ClusterIssuer. This is set and managed automatically.",
@@ -1711,8 +1676,7 @@
               "type": "string"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "conditions": {
           "description": "List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.",
@@ -1755,8 +1719,7 @@
               "status",
               "type"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array",
           "x-kubernetes-list-map-keys": [
@@ -1765,8 +1728,7 @@
           "x-kubernetes-list-type": "map"
         }
       },
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
I think there are more api updates for this version, but this resolves schema validation issues I have had with route53 dns resolver configuration: https://github.com/cert-manager/cert-manager/blob/master/deploy/crds/crd-clusterissuers.yaml#L371C41-L371C47