### PR TITLE
feat: add all velero.io CRDs

### DIFF
--- a/velero.io/backup_v1.json
+++ b/velero.io/backup_v1.json
@@ -1,0 +1,581 @@
+{
+  "description": "Backup is a Velero resource that represents the capture of Kubernetes cluster state at a point in time (API objects and associated volume state).",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BackupSpec defines the specification for a Velero backup.",
+      "properties": {
+        "csiSnapshotTimeout": {
+          "description": "CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to ReadyToUse during creation, before returning error as timeout. The default value is 10 minute.",
+          "type": "string"
+        },
+        "defaultVolumesToFsBackup": {
+          "description": "DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used for all volumes by default.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "defaultVolumesToRestic": {
+          "description": "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. \n Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "excludedClusterScopedResources": {
+          "description": "ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to \"*\", all cluster-scoped resource types are excluded. The default value is empty.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "excludedNamespaceScopedResources": {
+          "description": "ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to \"*\", all namespace-scoped resource types are excluded. The default value is empty.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "excludedNamespaces": {
+          "description": "ExcludedNamespaces contains a list of namespaces that are not included in the backup.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "excludedResources": {
+          "description": "ExcludedResources is a slice of resource names that are not included in the backup.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "hooks": {
+          "description": "Hooks represent custom behaviors that should be executed at different phases of the backup.",
+          "properties": {
+            "resources": {
+              "description": "Resources are hooks that should be executed when backing up individual instances of a resource.",
+              "items": {
+                "description": "BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on the rules defined for namespaces, resources, and label selector.",
+                "properties": {
+                  "excludedNamespaces": {
+                    "description": "ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "excludedResources": {
+                    "description": "ExcludedResources specifies the resources to which this hook spec does not apply.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "includedNamespaces": {
+                    "description": "IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies to all namespaces.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "includedResources": {
+                    "description": "IncludedResources specifies the resources to which this hook spec applies. If empty, it applies to all resources.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "labelSelector": {
+                    "description": "LabelSelector, if specified, filters the resources to which this hook spec applies.",
+                    "nullable": true,
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name is the name of this hook.",
+                    "type": "string"
+                  },
+                  "post": {
+                    "description": "PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup. These are executed after all \"additional items\" from item actions are processed.",
+                    "items": {
+                      "description": "BackupResourceHook defines a hook for a resource.",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec defines an exec hook.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command and arguments to execute.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "container": {
+                              "description": "Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.",
+                              "type": "string"
+                            },
+                            "onError": {
+                              "description": "OnError specifies how Velero should behave if it encounters an error executing this hook.",
+                              "enum": [
+                                "Continue",
+                                "Fail"
+                              ],
+                              "type": "string"
+                            },
+                            "timeout": {
+                              "description": "Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "command"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "exec"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "pre": {
+                    "description": "PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup. These are executed before any \"additional items\" from item actions are processed.",
+                    "items": {
+                      "description": "BackupResourceHook defines a hook for a resource.",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec defines an exec hook.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command and arguments to execute.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "container": {
+                              "description": "Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.",
+                              "type": "string"
+                            },
+                            "onError": {
+                              "description": "OnError specifies how Velero should behave if it encounters an error executing this hook.",
+                              "enum": [
+                                "Continue",
+                                "Fail"
+                              ],
+                              "type": "string"
+                            },
+                            "timeout": {
+                              "description": "Timeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "command"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "exec"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "includeClusterResources": {
+          "description": "IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the backup.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "includedClusterScopedResources": {
+          "description": "IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to \"*\", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "includedNamespaceScopedResources": {
+          "description": "IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is \"*\".",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "includedNamespaces": {
+          "description": "IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "includedResources": {
+          "description": "IncludedResources is a slice of resource names to include in the backup. If empty, all resources are included.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "itemOperationTimeout": {
+          "description": "ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations The default value is 1 hour.",
+          "type": "string"
+        },
+        "labelSelector": {
+          "description": "LabelSelector is a metav1.LabelSelector to filter with when adding individual objects to the backup. If empty or nil, all objects are included. Optional.",
+          "nullable": true,
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metadata": {
+          "properties": {
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "orLabelSelectors": {
+          "description": "OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "orderedResources": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format \"namespace/objectname\".  For cluster resources, simply use \"objectname\".",
+          "nullable": true,
+          "type": "object"
+        },
+        "resourcePolicy": {
+          "description": "ResourcePolicy specifies the referenced resource policies that backup should follow",
+          "properties": {
+            "apiGroup": {
+              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind is the type of resource being referenced",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of resource being referenced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "snapshotVolumes": {
+          "description": "SnapshotVolumes specifies whether to take snapshots of any PV's referenced in the set of objects included in the Backup.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "storageLocation": {
+          "description": "StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.",
+          "type": "string"
+        },
+        "ttl": {
+          "description": "TTL is a time.Duration-parseable string describing how long the Backup should be retained for.",
+          "type": "string"
+        },
+        "volumeSnapshotLocations": {
+          "description": "VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupStatus captures the current status of a Velero backup.",
+      "properties": {
+        "backupItemOperationsAttempted": {
+          "description": "BackupItemOperationsAttempted is the total number of attempted async BackupItemAction operations for this backup.",
+          "type": "integer"
+        },
+        "backupItemOperationsCompleted": {
+          "description": "BackupItemOperationsCompleted is the total number of successfully completed async BackupItemAction operations for this backup.",
+          "type": "integer"
+        },
+        "backupItemOperationsFailed": {
+          "description": "BackupItemOperationsFailed is the total number of async BackupItemAction operations for this backup which ended with an error.",
+          "type": "integer"
+        },
+        "completionTimestamp": {
+          "description": "CompletionTimestamp records the time a backup was completed. Completion time is recorded even on failed backups. Completion time is recorded before uploading the backup object. The server's time is used for CompletionTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "csiVolumeSnapshotsAttempted": {
+          "description": "CSIVolumeSnapshotsAttempted is the total number of attempted CSI VolumeSnapshots for this backup.",
+          "type": "integer"
+        },
+        "csiVolumeSnapshotsCompleted": {
+          "description": "CSIVolumeSnapshotsCompleted is the total number of successfully completed CSI VolumeSnapshots for this backup.",
+          "type": "integer"
+        },
+        "errors": {
+          "description": "Errors is a count of all error messages that were generated during execution of the backup.  The actual errors are in the backup's log file in object storage.",
+          "type": "integer"
+        },
+        "expiration": {
+          "description": "Expiration is when this Backup is eligible for garbage-collection.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "failureReason": {
+          "description": "FailureReason is an error that caused the entire backup to fail.",
+          "type": "string"
+        },
+        "formatVersion": {
+          "description": "FormatVersion is the backup format version, including major, minor, and patch version.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the Backup.",
+          "enum": [
+            "New",
+            "FailedValidation",
+            "InProgress",
+            "WaitingForPluginOperations",
+            "WaitingForPluginOperationsPartiallyFailed",
+            "Finalizing",
+            "FinalizingPartiallyFailed",
+            "Completed",
+            "PartiallyFailed",
+            "Failed",
+            "Deleting"
+          ],
+          "type": "string"
+        },
+        "progress": {
+          "description": "Progress contains information about the backup's execution progress. Note that this information is best-effort only -- if Velero fails to update it during a backup for any reason, it may be inaccurate/stale.",
+          "nullable": true,
+          "properties": {
+            "itemsBackedUp": {
+              "description": "ItemsBackedUp is the number of items that have actually been written to the backup tarball so far.",
+              "type": "integer"
+            },
+            "totalItems": {
+              "description": "TotalItems is the total number of items to be backed up. This number may change throughout the execution of the backup due to plugins that return additional related items to back up, the velero.io/exclude-from-backup label, and various other filters that happen as items are processed.",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "startTimestamp": {
+          "description": "StartTimestamp records the time a backup was started. Separate from CreationTimestamp, since that value changes on restores. The server's time is used for StartTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "validationErrors": {
+          "description": "ValidationErrors is a slice of all validation errors (if applicable).",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "version": {
+          "description": "Version is the backup format major version. Deprecated: Please see FormatVersion",
+          "type": "integer"
+        },
+        "volumeSnapshotsAttempted": {
+          "description": "VolumeSnapshotsAttempted is the total number of attempted volume snapshots for this backup.",
+          "type": "integer"
+        },
+        "volumeSnapshotsCompleted": {
+          "description": "VolumeSnapshotsCompleted is the total number of successfully completed volume snapshots for this backup.",
+          "type": "integer"
+        },
+        "warnings": {
+          "description": "Warnings is a count of all warning messages that were generated during execution of the backup. The actual warnings are in the backup's log file in object storage.",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/backuprepository_v1.json
+++ b/velero.io/backuprepository_v1.json
@@ -1,0 +1,80 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BackupRepositorySpec is the specification for a BackupRepository.",
+      "properties": {
+        "backupStorageLocation": {
+          "description": "BackupStorageLocation is the name of the BackupStorageLocation that should contain this repository.",
+          "type": "string"
+        },
+        "maintenanceFrequency": {
+          "description": "MaintenanceFrequency is how often maintenance should be run.",
+          "type": "string"
+        },
+        "repositoryType": {
+          "description": "RepositoryType indicates the type of the backend repository",
+          "enum": [
+            "kopia",
+            "restic",
+            ""
+          ],
+          "type": "string"
+        },
+        "resticIdentifier": {
+          "description": "ResticIdentifier is the full restic-compatible string for identifying this repository.",
+          "type": "string"
+        },
+        "volumeNamespace": {
+          "description": "VolumeNamespace is the namespace this backup repository contains pod volume backups for.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupStorageLocation",
+        "maintenanceFrequency",
+        "resticIdentifier",
+        "volumeNamespace"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupRepositoryStatus is the current status of a BackupRepository.",
+      "properties": {
+        "lastMaintenanceTime": {
+          "description": "LastMaintenanceTime is the last time maintenance was run.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a message about the current status of the BackupRepository.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the BackupRepository.",
+          "enum": [
+            "New",
+            "Ready",
+            "NotReady"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/backupstoragelocation_v1.json
+++ b/velero.io/backupstoragelocation_v1.json
@@ -1,0 +1,149 @@
+{
+  "description": "BackupStorageLocation is a location where Velero stores backup objects",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "BackupStorageLocationSpec defines the desired state of a Velero BackupStorageLocation",
+      "properties": {
+        "accessMode": {
+          "description": "AccessMode defines the permissions for the backup storage location.",
+          "enum": [
+            "ReadOnly",
+            "ReadWrite"
+          ],
+          "type": "string"
+        },
+        "backupSyncPeriod": {
+          "description": "BackupSyncPeriod defines how frequently to sync backup API objects from object storage. A value of 0 disables sync.",
+          "nullable": true,
+          "type": "string"
+        },
+        "config": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Config is for provider-specific configuration fields.",
+          "type": "object"
+        },
+        "credential": {
+          "description": "Credential contains the credential information intended to be used with this location",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "default": {
+          "description": "Default indicates this location is the default backup storage location.",
+          "type": "boolean"
+        },
+        "objectStorage": {
+          "description": "ObjectStorageLocation specifies the settings necessary to connect to a provider's object storage.",
+          "properties": {
+            "bucket": {
+              "description": "Bucket is the bucket to use for object storage.",
+              "type": "string"
+            },
+            "caCert": {
+              "description": "CACert defines a CA bundle to use when verifying TLS connections to the provider.",
+              "format": "byte",
+              "type": "string"
+            },
+            "prefix": {
+              "description": "Prefix is the path inside a bucket to use for Velero storage. Optional.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "bucket"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Provider is the provider of the backup storage.",
+          "type": "string"
+        },
+        "validationFrequency": {
+          "description": "ValidationFrequency defines how frequently to validate the corresponding object storage. A value of 0 disables validation.",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "required": [
+        "objectStorage",
+        "provider"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "BackupStorageLocationStatus defines the observed state of BackupStorageLocation",
+      "properties": {
+        "accessMode": {
+          "description": "AccessMode is an unused field. \n Deprecated: there is now an AccessMode field on the Spec and this field will be removed entirely as of v2.0.",
+          "enum": [
+            "ReadOnly",
+            "ReadWrite"
+          ],
+          "type": "string"
+        },
+        "lastSyncedRevision": {
+          "description": "LastSyncedRevision is the value of the `metadata/revision` file in the backup storage location the last time the BSL's contents were synced into the cluster. \n Deprecated: this field is no longer updated or used for detecting changes to the location's contents and will be removed entirely in v2.0.",
+          "type": "string"
+        },
+        "lastSyncedTime": {
+          "description": "LastSyncedTime is the last time the contents of the location were synced into the cluster.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "lastValidationTime": {
+          "description": "LastValidationTime is the last time the backup store location was validated the cluster.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a message about the backup storage location's status.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the BackupStorageLocation.",
+          "enum": [
+            "Available",
+            "Unavailable"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/deletebackuprequest_v1.json
+++ b/velero.io/deletebackuprequest_v1.json
@@ -1,0 +1,54 @@
+{
+  "description": "DeleteBackupRequest is a request to delete one or more backups.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DeleteBackupRequestSpec is the specification for which backups to delete.",
+      "properties": {
+        "backupName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DeleteBackupRequestStatus is the current status of a DeleteBackupRequest.",
+      "properties": {
+        "errors": {
+          "description": "Errors contains any errors that were encountered during the deletion process.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "phase": {
+          "description": "Phase is the current state of the DeleteBackupRequest.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Processed"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/downloadrequest_v1.json
+++ b/velero.io/downloadrequest_v1.json
@@ -1,0 +1,85 @@
+{
+  "description": "DownloadRequest is a request to download an artifact from backup object storage, such as a backup log file.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "DownloadRequestSpec is the specification for a download request.",
+      "properties": {
+        "target": {
+          "description": "Target is what to download (e.g. logs for a backup).",
+          "properties": {
+            "kind": {
+              "description": "Kind is the type of file to download.",
+              "enum": [
+                "BackupLog",
+                "BackupContents",
+                "BackupVolumeSnapshots",
+                "BackupItemOperations",
+                "BackupResourceList",
+                "BackupResults",
+                "RestoreLog",
+                "RestoreResults",
+                "RestoreResourceList",
+                "RestoreItemOperations",
+                "CSIBackupVolumeSnapshots",
+                "CSIBackupVolumeSnapshotContents"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the kubernetes resource with which the file is associated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "target"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "DownloadRequestStatus is the current status of a DownloadRequest.",
+      "properties": {
+        "downloadURL": {
+          "description": "DownloadURL contains the pre-signed URL for the target file.",
+          "type": "string"
+        },
+        "expiration": {
+          "description": "Expiration is when this DownloadRequest expires and can be deleted by the system.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the DownloadRequest.",
+          "enum": [
+            "New",
+            "Processed"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/podvolumebackup_v1.json
+++ b/velero.io/podvolumebackup_v1.json
@@ -1,0 +1,153 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PodVolumeBackupSpec is the specification for a PodVolumeBackup.",
+      "properties": {
+        "backupStorageLocation": {
+          "description": "BackupStorageLocation is the name of the backup storage location where the backup repository is stored.",
+          "type": "string"
+        },
+        "node": {
+          "description": "Node is the name of the node that the Pod is running on.",
+          "type": "string"
+        },
+        "pod": {
+          "description": "Pod is a reference to the pod containing the volume to be backed up.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "repoIdentifier": {
+          "description": "RepoIdentifier is the backup repository identifier.",
+          "type": "string"
+        },
+        "tags": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Tags are a map of key-value pairs that should be applied to the volume backup as tags.",
+          "type": "object"
+        },
+        "uploaderType": {
+          "description": "UploaderType is the type of the uploader to handle the data transfer.",
+          "enum": [
+            "kopia",
+            "restic",
+            ""
+          ],
+          "type": "string"
+        },
+        "volume": {
+          "description": "Volume is the name of the volume within the Pod to be backed up.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupStorageLocation",
+        "node",
+        "pod",
+        "repoIdentifier",
+        "volume"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PodVolumeBackupStatus is the current status of a PodVolumeBackup.",
+      "properties": {
+        "completionTimestamp": {
+          "description": "CompletionTimestamp records the time a backup was completed. Completion time is recorded even on failed backups. Completion time is recorded before uploading the backup object. The server's time is used for CompletionTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a message about the pod volume backup's status.",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path is the full path within the controller pod being backed up.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the PodVolumeBackup.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Completed",
+            "Failed"
+          ],
+          "type": "string"
+        },
+        "progress": {
+          "description": "Progress holds the total number of bytes of the volume and the current number of backed up bytes. This can be used to display progress information about the backup operation.",
+          "properties": {
+            "bytesDone": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "totalBytes": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "snapshotID": {
+          "description": "SnapshotID is the identifier for the snapshot of the pod volume.",
+          "type": "string"
+        },
+        "startTimestamp": {
+          "description": "StartTimestamp records the time a backup was started. Separate from CreationTimestamp, since that value changes on restores. The server's time is used for StartTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/podvolumerestore_v1.json
+++ b/velero.io/podvolumerestore_v1.json
@@ -1,0 +1,143 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "PodVolumeRestoreSpec is the specification for a PodVolumeRestore.",
+      "properties": {
+        "backupStorageLocation": {
+          "description": "BackupStorageLocation is the name of the backup storage location where the backup repository is stored.",
+          "type": "string"
+        },
+        "pod": {
+          "description": "Pod is a reference to the pod containing the volume to be restored.",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "repoIdentifier": {
+          "description": "RepoIdentifier is the backup repository identifier.",
+          "type": "string"
+        },
+        "snapshotID": {
+          "description": "SnapshotID is the ID of the volume snapshot to be restored.",
+          "type": "string"
+        },
+        "sourceNamespace": {
+          "description": "SourceNamespace is the original namespace for namaspace mapping.",
+          "type": "string"
+        },
+        "uploaderType": {
+          "description": "UploaderType is the type of the uploader to handle the data transfer.",
+          "enum": [
+            "kopia",
+            "restic",
+            ""
+          ],
+          "type": "string"
+        },
+        "volume": {
+          "description": "Volume is the name of the volume within the Pod to be restored.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupStorageLocation",
+        "pod",
+        "repoIdentifier",
+        "snapshotID",
+        "sourceNamespace",
+        "volume"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "PodVolumeRestoreStatus is the current status of a PodVolumeRestore.",
+      "properties": {
+        "completionTimestamp": {
+          "description": "CompletionTimestamp records the time a restore was completed. Completion time is recorded even on failed restores. The server's time is used for CompletionTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "message": {
+          "description": "Message is a message about the pod volume restore's status.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the PodVolumeRestore.",
+          "enum": [
+            "New",
+            "InProgress",
+            "Completed",
+            "Failed"
+          ],
+          "type": "string"
+        },
+        "progress": {
+          "description": "Progress holds the total number of bytes of the snapshot and the current number of restored bytes. This can be used to display progress information about the restore operation.",
+          "properties": {
+            "bytesDone": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "totalBytes": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "startTimestamp": {
+          "description": "StartTimestamp records the time a restore was started. The server's time is used for StartTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/restore_v1.json
+++ b/velero.io/restore_v1.json
@@ -1,0 +1,466 @@
+{
+  "description": "Restore is a Velero resource that represents the application of resources from a Velero backup to a target Kubernetes cluster.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "RestoreSpec defines the specification for a Velero restore.",
+      "properties": {
+        "backupName": {
+          "description": "BackupName is the unique name of the Velero backup to restore from.",
+          "type": "string"
+        },
+        "excludedNamespaces": {
+          "description": "ExcludedNamespaces contains a list of namespaces that are not included in the restore.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "excludedResources": {
+          "description": "ExcludedResources is a slice of resource names that are not included in the restore.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "existingResourcePolicy": {
+          "description": "ExistingResourcePolicy specifies the restore behavior for the kubernetes resource to be restored",
+          "nullable": true,
+          "type": "string"
+        },
+        "hooks": {
+          "description": "Hooks represent custom behaviors that should be executed during or post restore.",
+          "properties": {
+            "resources": {
+              "items": {
+                "description": "RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on the rules defined for namespaces, resources, and label selector.",
+                "properties": {
+                  "excludedNamespaces": {
+                    "description": "ExcludedNamespaces specifies the namespaces to which this hook spec does not apply.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "excludedResources": {
+                    "description": "ExcludedResources specifies the resources to which this hook spec does not apply.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "includedNamespaces": {
+                    "description": "IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies to all namespaces.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "includedResources": {
+                    "description": "IncludedResources specifies the resources to which this hook spec applies. If empty, it applies to all resources.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "nullable": true,
+                    "type": "array"
+                  },
+                  "labelSelector": {
+                    "description": "LabelSelector, if specified, filters the resources to which this hook spec applies.",
+                    "nullable": true,
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "matchLabels": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "name": {
+                    "description": "Name is the name of this hook.",
+                    "type": "string"
+                  },
+                  "postHooks": {
+                    "description": "PostHooks is a list of RestoreResourceHooks to execute during and after restoring a resource.",
+                    "items": {
+                      "description": "RestoreResourceHook defines a restore hook for a resource.",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec defines an exec restore hook.",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command and arguments to execute from within a container after a pod has been restored.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "minItems": 1,
+                              "type": "array"
+                            },
+                            "container": {
+                              "description": "Container is the container in the pod where the command should be executed. If not specified, the pod's first container is used.",
+                              "type": "string"
+                            },
+                            "execTimeout": {
+                              "description": "ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before considering the execution a failure.",
+                              "type": "string"
+                            },
+                            "onError": {
+                              "description": "OnError specifies how Velero should behave if it encounters an error executing this hook.",
+                              "enum": [
+                                "Continue",
+                                "Fail"
+                              ],
+                              "type": "string"
+                            },
+                            "waitTimeout": {
+                              "description": "WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready before attempting to run the command.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "command"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "init": {
+                          "description": "Init defines an init restore hook.",
+                          "properties": {
+                            "initContainers": {
+                              "description": "InitContainers is list of init containers to be added to a pod during its restore.",
+                              "items": {
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "timeout": {
+                              "description": "Timeout defines the maximum amount of time Velero should wait for the initContainers to complete.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "includeClusterResources": {
+          "description": "IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the restore. If null, defaults to true.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "includedNamespaces": {
+          "description": "IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "includedResources": {
+          "description": "IncludedResources is a slice of resource names to include in the restore. If empty, all resources in the backup are included.",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "itemOperationTimeout": {
+          "description": "ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations The default value is 1 hour.",
+          "type": "string"
+        },
+        "labelSelector": {
+          "description": "LabelSelector is a metav1.LabelSelector to filter with when restoring individual objects from the backup. If empty or nil, all objects are included. Optional.",
+          "nullable": true,
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "namespaceMapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "NamespaceMapping is a map of source namespace names to target namespace names to restore into. Any source namespaces not included in the map will be restored into namespaces of the same name.",
+          "type": "object"
+        },
+        "orLabelSelectors": {
+          "description": "OrLabelSelectors is list of metav1.LabelSelector to filter with when restoring individual objects from the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in restore request, only one of them can be used",
+          "items": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "properties": {
+              "matchExpressions": {
+                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                "items": {
+                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                  "properties": {
+                    "key": {
+                      "description": "key is the label key that the selector applies to.",
+                      "type": "string"
+                    },
+                    "operator": {
+                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "operator"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                "type": "object"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "preserveNodePorts": {
+          "description": "PreserveNodePorts specifies whether to restore old nodePorts from backup.",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "restorePVs": {
+          "description": "RestorePVs specifies whether to restore all included PVs from snapshot",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "restoreStatus": {
+          "description": "RestoreStatus specifies which resources we should restore the status field. If nil, no objects are included. Optional.",
+          "nullable": true,
+          "properties": {
+            "excludedResources": {
+              "description": "ExcludedResources specifies the resources to which will not restore the status.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "includedResources": {
+              "description": "IncludedResources specifies the resources to which will restore the status. If empty, it applies to all resources.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "scheduleName": {
+          "description": "ScheduleName is the unique name of the Velero schedule to restore from. If specified, and BackupName is empty, Velero will restore from the most recent successful backup created from this schedule.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "backupName"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "RestoreStatus captures the current status of a Velero restore",
+      "properties": {
+        "completionTimestamp": {
+          "description": "CompletionTimestamp records the time the restore operation was completed. Completion time is recorded even on failed restore. The server's time is used for StartTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "errors": {
+          "description": "Errors is a count of all error messages that were generated during execution of the restore. The actual errors are stored in object storage.",
+          "type": "integer"
+        },
+        "failureReason": {
+          "description": "FailureReason is an error that caused the entire restore to fail.",
+          "type": "string"
+        },
+        "phase": {
+          "description": "Phase is the current state of the Restore",
+          "enum": [
+            "New",
+            "FailedValidation",
+            "InProgress",
+            "WaitingForPluginOperations",
+            "WaitingForPluginOperationsPartiallyFailed",
+            "Completed",
+            "PartiallyFailed",
+            "Failed"
+          ],
+          "type": "string"
+        },
+        "progress": {
+          "description": "Progress contains information about the restore's execution progress. Note that this information is best-effort only -- if Velero fails to update it during a restore for any reason, it may be inaccurate/stale.",
+          "nullable": true,
+          "properties": {
+            "itemsRestored": {
+              "description": "ItemsRestored is the number of items that have actually been restored so far",
+              "type": "integer"
+            },
+            "totalItems": {
+              "description": "TotalItems is the total number of items to be restored. This number may change throughout the execution of the restore due to plugins that return additional related items to restore",
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restoreItemOperationsAttempted": {
+          "description": "RestoreItemOperationsAttempted is the total number of attempted async RestoreItemAction operations for this restore.",
+          "type": "integer"
+        },
+        "restoreItemOperationsCompleted": {
+          "description": "RestoreItemOperationsCompleted is the total number of successfully completed async RestoreItemAction operations for this restore.",
+          "type": "integer"
+        },
+        "restoreItemOperationsFailed": {
+          "description": "RestoreItemOperationsFailed is the total number of async RestoreItemAction operations for this restore which ended with an error.",
+          "type": "integer"
+        },
+        "startTimestamp": {
+          "description": "StartTimestamp records the time the restore operation was started. The server's time is used for StartTimestamps",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "validationErrors": {
+          "description": "ValidationErrors is a slice of all validation errors (if applicable)",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "warnings": {
+          "description": "Warnings is a count of all warning messages that were generated during execution of the restore. The actual warnings are stored in object storage.",
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/schedule_v1.json
+++ b/velero.io/schedule_v1.json
@@ -15,6 +15,10 @@
     "spec": {
       "description": "ScheduleSpec defines the specification for a Velero schedule",
       "properties": {
+        "paused": {
+          "description": "Paused specifies whether the schedule is paused or not",
+          "type": "boolean"
+        },
         "schedule": {
           "description": "Schedule is a Cron expression defining when to run the Backup.",
           "type": "string"
@@ -26,9 +30,31 @@
               "description": "CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to ReadyToUse during creation, before returning error as timeout. The default value is 10 minute.",
               "type": "string"
             },
-            "defaultVolumesToRestic": {
-              "description": "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default.",
+            "defaultVolumesToFsBackup": {
+              "description": "DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used for all volumes by default.",
+              "nullable": true,
               "type": "boolean"
+            },
+            "defaultVolumesToRestic": {
+              "description": "DefaultVolumesToRestic specifies whether restic should be used to take a backup of all pod volumes by default. \n Deprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead.",
+              "nullable": true,
+              "type": "boolean"
+            },
+            "excludedClusterScopedResources": {
+              "description": "ExcludedClusterScopedResources is a slice of cluster-scoped resource type names to exclude from the backup. If set to \"*\", all cluster-scoped resource types are excluded. The default value is empty.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "excludedNamespaceScopedResources": {
+              "description": "ExcludedNamespaceScopedResources is a slice of namespace-scoped resource type names to exclude from the backup. If set to \"*\", all namespace-scoped resource types are excluded. The default value is empty.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
             },
             "excludedNamespaces": {
               "description": "ExcludedNamespaces contains a list of namespaces that are not included in the backup.",
@@ -115,7 +141,8 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             },
                             "type": "array"
                           },
@@ -127,7 +154,8 @@
                             "type": "object"
                           }
                         },
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "name": {
                         "description": "Name is the name of this hook.",
@@ -169,13 +197,15 @@
                               "required": [
                                 "command"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "exec"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       },
@@ -215,13 +245,15 @@
                               "required": [
                                 "command"
                               ],
-                              "type": "object"
+                              "type": "object",
+                              "additionalProperties": false
                             }
                           },
                           "required": [
                             "exec"
                           ],
-                          "type": "object"
+                          "type": "object",
+                          "additionalProperties": false
                         },
                         "type": "array"
                       }
@@ -229,18 +261,36 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "nullable": true,
                   "type": "array"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "includeClusterResources": {
               "description": "IncludeClusterResources specifies whether cluster-scoped resources should be included for consideration in the backup.",
               "nullable": true,
               "type": "boolean"
+            },
+            "includedClusterScopedResources": {
+              "description": "IncludedClusterScopedResources is a slice of cluster-scoped resource type names to include in the backup. If set to \"*\", all cluster-scoped resource types are included. The default value is empty, which means only related cluster-scoped resources are included.",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            },
+            "includedNamespaceScopedResources": {
+              "description": "IncludedNamespaceScopedResources is a slice of namespace-scoped resource type names to include in the backup. The default value is \"*\".",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
             },
             "includedNamespaces": {
               "description": "IncludedNamespaces is a slice of namespace names to include objects from. If empty, all namespaces are included.",
@@ -257,6 +307,10 @@
               },
               "nullable": true,
               "type": "array"
+            },
+            "itemOperationTimeout": {
+              "description": "ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations The default value is 1 hour.",
+              "type": "string"
             },
             "labelSelector": {
               "description": "LabelSelector is a metav1.LabelSelector to filter with when adding individual objects to the backup. If empty or nil, all objects are included. Optional.",
@@ -287,7 +341,8 @@
                       "key",
                       "operator"
                     ],
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "type": "array"
                 },
@@ -299,7 +354,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "metadata": {
               "properties": {
@@ -310,7 +366,8 @@
                   "type": "object"
                 }
               },
-              "type": "object"
+              "type": "object",
+              "additionalProperties": false
             },
             "orLabelSelectors": {
               "description": "OrLabelSelectors is list of metav1.LabelSelector to filter with when adding individual objects to the backup. If multiple provided they will be joined by the OR operator. LabelSelector as well as OrLabelSelectors cannot co-exist in backup request, only one of them can be used.",
@@ -342,7 +399,8 @@
                         "key",
                         "operator"
                       ],
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "type": "array"
                   },
@@ -354,7 +412,8 @@
                     "type": "object"
                   }
                 },
-                "type": "object"
+                "type": "object",
+                "additionalProperties": false
               },
               "nullable": true,
               "type": "array"
@@ -363,12 +422,35 @@
               "additionalProperties": {
                 "type": "string"
               },
-              "description": "OrderedResources specifies the backup order of resources of specific Kind. The map key is the Kind name and value is a list of resource names separated by commas. Each resource name has format \"namespace/resourcename\".  For cluster resources, simply use \"resourcename\".",
+              "description": "OrderedResources specifies the backup order of resources of specific Kind. The map key is the resource name and value is a list of object names separated by commas. Each resource name has format \"namespace/objectname\".  For cluster resources, simply use \"objectname\".",
               "nullable": true,
               "type": "object"
             },
+            "resourcePolicy": {
+              "description": "ResourcePolicy specifies the referenced resource policies that backup should follow",
+              "properties": {
+                "apiGroup": {
+                  "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind is the type of resource being referenced",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name is the name of resource being referenced",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "kind",
+                "name"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
             "snapshotVolumes": {
-              "description": "SnapshotVolumes specifies whether to take cloud snapshots of any PV's referenced in the set of objects included in the Backup.",
+              "description": "SnapshotVolumes specifies whether to take snapshots of any PV's referenced in the set of objects included in the Backup.",
               "nullable": true,
               "type": "boolean"
             },
@@ -388,7 +470,8 @@
               "type": "array"
             }
           },
-          "type": "object"
+          "type": "object",
+          "additionalProperties": false
         },
         "useOwnerReferencesInBackup": {
           "description": "UseOwnerReferencesBackup specifies whether to use OwnerReferences on backups created by this Schedule.",
@@ -400,7 +483,8 @@
         "schedule",
         "template"
       ],
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     },
     "status": {
       "description": "ScheduleStatus captures the current state of a Velero schedule",
@@ -428,7 +512,8 @@
           "type": "array"
         }
       },
-      "type": "object"
+      "type": "object",
+      "additionalProperties": false
     }
   },
   "type": "object"

--- a/velero.io/serverstatusrequest_v1.json
+++ b/velero.io/serverstatusrequest_v1.json
@@ -1,0 +1,68 @@
+{
+  "description": "ServerStatusRequest is a request to access current status information about the Velero server.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ServerStatusRequestSpec is the specification for a ServerStatusRequest.",
+      "type": "object"
+    },
+    "status": {
+      "description": "ServerStatusRequestStatus is the current status of a ServerStatusRequest.",
+      "properties": {
+        "phase": {
+          "description": "Phase is the current lifecycle phase of the ServerStatusRequest.",
+          "enum": [
+            "New",
+            "Processed"
+          ],
+          "type": "string"
+        },
+        "plugins": {
+          "description": "Plugins list information about the plugins running on the Velero server",
+          "items": {
+            "description": "PluginInfo contains attributes of a Velero plugin",
+            "properties": {
+              "kind": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "nullable": true,
+          "type": "array"
+        },
+        "processedTimestamp": {
+          "description": "ProcessedTimestamp is when the ServerStatusRequest was processed by the ServerStatusRequestController.",
+          "format": "date-time",
+          "nullable": true,
+          "type": "string"
+        },
+        "serverVersion": {
+          "description": "ServerVersion is the Velero server version.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/velero.io/volumesnapshotlocation_v1.json
+++ b/velero.io/volumesnapshotlocation_v1.json
@@ -1,0 +1,75 @@
+{
+  "description": "VolumeSnapshotLocation is a location where Velero stores volume snapshots.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "VolumeSnapshotLocationSpec defines the specification for a Velero VolumeSnapshotLocation.",
+      "properties": {
+        "config": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Config is for provider-specific configuration fields.",
+          "type": "object"
+        },
+        "credential": {
+          "description": "Credential contains the credential information intended to be used with this location",
+          "properties": {
+            "key": {
+              "description": "The key of the secret to select from.  Must be a valid secret key.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+              "type": "string"
+            },
+            "optional": {
+              "description": "Specify whether the Secret or its key must be defined",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "provider": {
+          "description": "Provider is the provider of the volume storage.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "provider"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "VolumeSnapshotLocationStatus describes the current status of a Velero VolumeSnapshotLocation.",
+      "properties": {
+        "phase": {
+          "description": "VolumeSnapshotLocationPhase is the lifecycle phase of a Velero VolumeSnapshotLocation.",
+          "enum": [
+            "Available",
+            "Unavailable"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This adds the following CRDs for Velero:

* backups
* backuprepositories
* backupstoragelocations
* deletebackuprequests
* downloadrequests
* podvolumebackups
* podvolumerestores
* restores
* schedules
* serverstatusrequests
* volumesnapshotlocations

The CRDs / schemas were extracted with:

```
cd velero.io/
git clone git@github.com:vmware-tanzu/helm-charts.git velero-helm-charts cd velero-helm-charts/ && git checkout velero-4.4.1 && cd .. find velero-helm-charts/ -wholename '*/crds/*.yaml' -exec python3 ../openapi2jsonschema.py {} \;
```

Closes https://github.com/datreeio/CRDs-catalog/issues/200