### PR TITLE
feat: Add OpenShift Machine-Config-Operator CRDs

### DIFF
--- a/openshift/v4.11-strict/containerruntimeconfig_v1.json
+++ b/openshift/v4.11-strict/containerruntimeconfig_v1.json
@@ -1,0 +1,143 @@
+{
+  "description": "ContainerRuntimeConfig describes a customized Container Runtime configuration.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ContainerRuntimeConfigSpec defines the desired state of ContainerRuntimeConfig",
+      "type": "object",
+      "required": [
+        "containerRuntimeConfig"
+      ],
+      "properties": {
+        "containerRuntimeConfig": {
+          "description": "ContainerRuntimeConfiguration defines the tuneables of the container runtime. It's important to note that, since the fields of the ContainerRuntimeConfiguration are directly read by the upstream kubernetes golang client, the validation of those values is handled directly by that golang client which is outside of the controller for ContainerRuntimeConfiguration. Please ensure the valid values are used for those fields as invalid values may render cluster nodes unusable.",
+          "type": "object",
+          "properties": {
+            "logLevel": {
+              "description": "logLevel specifies the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug.",
+              "type": "string"
+            },
+            "logSizeMax": {
+              "description": "logSizeMax specifies the Maximum size allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer.",
+              "type": "string"
+            },
+            "overlaySize": {
+              "description": "overlaySize specifies the maximum size of a container image. This flag can be used to set quota on the size of container images.",
+              "type": "string"
+            },
+            "pidsLimit": {
+              "description": "pidsLimit specifies the maximum number of processes allowed in a container",
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "additionalProperties": false
+        },
+        "machineConfigPoolSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ContainerRuntimeConfigStatus defines the observed state of a ContainerRuntimeConfig",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "ContainerRuntimeConfigCondition defines the state of the ContainerRuntimeConfig",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the time of the last update to the current status object.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message provides additional information about the current condition. This is only to be consumed by humans.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.  Reasons are PascalCase",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type specifies the state of the operator's reconciliation functionality.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.11-strict/kubeletconfig_v1.json
+++ b/openshift/v4.11-strict/kubeletconfig_v1.json
@@ -1,0 +1,189 @@
+{
+  "description": "KubeletConfig describes a customized Kubelet configuration.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeletConfigSpec defines the desired state of KubeletConfig",
+      "type": "object",
+      "properties": {
+        "autoSizingReserved": {
+          "description": "Automatically set optimal system reserved",
+          "type": "boolean"
+        },
+        "tlsSecurityProfile": {
+          "description": "tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. \n If unset, the default is based on the apiservers.config.openshift.io/cluster resource. \n Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout. \n Note that the minimum TLS version for ingress controllers is 1.1, and the maximum TLS version is 1.2.  An implication of this restriction is that the Modern TLS profile type cannot be used because it requires TLS 1.3.",
+          "properties": {
+            "custom": {
+              "description": "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n   ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256   minTLSVersion: TLSv1.1",
+              "nullable": true,
+              "properties": {
+                "ciphers": {
+                  "description": "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n   ciphers:     - DES-CBC3-SHA",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "minTLSVersion": {
+                  "description": "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n   minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12",
+                  "enum": [
+                    "VersionTLS10",
+                    "VersionTLS11",
+                    "VersionTLS12",
+                    "VersionTLS13"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "intermediate": {
+              "description": "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.2",
+              "nullable": true,
+              "type": "object"
+            },
+            "modern": {
+              "description": "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported.",
+              "nullable": true,
+              "type": "object"
+            },
+            "old": {
+              "description": "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_AES_128_GCM_SHA256     - TLS_RSA_WITH_AES_256_GCM_SHA384     - TLS_RSA_WITH_AES_128_CBC_SHA256     - TLS_RSA_WITH_AES_128_CBC_SHA     - TLS_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_3DES_EDE_CBC_SHA   minTLSVersion: TLSv1.0",
+              "nullable": true,
+              "type": "object"
+            },
+            "type": {
+              "description": "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.",
+              "enum": [
+                "Old",
+                "Intermediate",
+                "Modern",
+                "Custom"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "logLevel defines the log level of the Kubelet",
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "kubeletConfig": {
+          "description": "The fields of the kubelet configuration are defined in kubernetes upstream. Please refer to the types defined in the version/commit used by OpenShift of the upstream kubernetes. It's important to note that, since the fields of the kubelet configuration are directly fetched from upstream the validation of those values is handled directly by the kubelet. Please refer to the upstream version of the relavent kubernetes for the valid values of these fields. Invalid values of the kubelet configuration fields may render cluster nodes unusable.",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "machineConfigPoolSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeletConfigStatus defines the observed state of a KubeletConfig",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "KubeletConfigCondition defines the state of the KubeletConfig",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the time of the last update to the current status object.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message provides additional information about the current condition. This is only to be consumed by humans.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.  Reasons are PascalCase",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type specifies the state of the operator's reconciliation functionality.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.11-strict/machineconfig_v1.json
+++ b/openshift/v4.11-strict/machineconfig_v1.json
@@ -1,0 +1,393 @@
+{
+  "description": "MachineConfig defines the configuration for a machine",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineConfigSpec is the spec for MachineConfig",
+      "type": "object",
+      "properties": {
+        "config": {
+          "description": "Config is a Ignition Config object.",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true,
+          "required": [
+            "ignition"
+          ],
+          "properties": {
+            "ignition": {
+              "description": "Ignition section contains metadata about the configuration itself. We only permit a subsection of ignition fields for MachineConfigs.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+              "properties": {
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "append": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string"
+                          },
+                          "verification": {
+                            "type": "object",
+                            "properties": {
+                              "hash": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "replace": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string"
+                        },
+                        "verification": {
+                          "type": "object",
+                          "properties": {
+                            "hash": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "security": {
+                  "type": "object",
+                  "properties": {
+                    "tls": {
+                      "type": "object",
+                      "properties": {
+                        "certificateAuthorities": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string"
+                              },
+                              "verification": {
+                                "type": "object",
+                                "properties": {
+                                  "hash": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "timeouts": {
+                  "type": "object",
+                  "properties": {
+                    "httpResponseHeaders": {
+                      "type": "integer"
+                    },
+                    "httpTotal": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "version": {
+                  "description": "Version string is the semantic version number of the spec",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "passwd": {
+              "type": "object",
+              "properties": {
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of user. Must be \\\"core\\\" user.",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "Public keys to be assigned to user core.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "storage": {
+              "description": "Storage describes the desired state of the system's storage devices.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+              "properties": {
+                "directories": {
+                  "description": "Directories is the list of directories to be created",
+                  "type": "array",
+                  "items": {
+                    "description": "Items is list of directories to be written",
+                    "type": "object",
+                    "properties": {
+                      "filesystem": {
+                        "description": "Filesystem is the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group object specifies group of the owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Mode is the file's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0644 -> 420)",
+                        "type": "integer"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite specifies whether to delete preexisting nodes at the path",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Path is the absolute path to the file",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User object specifies the file's owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "files": {
+                  "description": "Files is the list of files to be created/modified",
+                  "type": "array",
+                  "items": {
+                    "description": "Items is list of files to be written",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true,
+                    "properties": {
+                      "contents": {
+                        "description": "Contents specifies options related to the contents of the file",
+                        "type": "object",
+                        "properties": {
+                          "compression": {
+                            "description": "The type of compression used on the contents (null or gzip). Compression cannot be used with S3.",
+                            "type": "string"
+                          },
+                          "source": {
+                            "description": "Source is the URL of the file contents. Supported schemes are http, https, tftp, s3, and data. When using http, it is advisable to use the verification option to ensure the contents haven't been modified.",
+                            "type": "string"
+                          },
+                          "verification": {
+                            "description": "Verification specifies options related to the verification of the file contents",
+                            "type": "object",
+                            "properties": {
+                              "hash": {
+                                "description": "Hash is the hash of the config, in the form <type>-<value> where type is sha512",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "filesystem": {
+                        "description": "Filesystem is the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group object specifies group of the owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID specifies group ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the group name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Mode specifies the file's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0644 -> 420)",
+                        "type": "integer"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite specifies whether to delete preexisting nodes at the path",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Path is the absolute path to the file",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User object specifies the file's owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "systemd": {
+              "description": "systemd describes the desired state of the systemd units",
+              "type": "object",
+              "properties": {
+                "units": {
+                  "description": "Units is a list of units to be configured",
+                  "type": "array",
+                  "items": {
+                    "description": "Items describes unit configuration",
+                    "type": "object",
+                    "properties": {
+                      "contents": {
+                        "description": "Contents is the contents of the unit",
+                        "type": "string"
+                      },
+                      "dropins": {
+                        "description": "Dropins is the list of drop-ins for the unit",
+                        "type": "array",
+                        "items": {
+                          "description": "Items describes unit dropin",
+                          "type": "object",
+                          "properties": {
+                            "contents": {
+                              "description": "Contents is the contents of the drop-in",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the drop-in. This must be suffixed with '.conf'",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "enabled": {
+                        "description": "Enabled describes whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section",
+                        "type": "boolean"
+                      },
+                      "mask": {
+                        "description": "Mask describes whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null\"",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name is the name of the unit. This must be suffixed with a valid unit type (e.g. 'thing.service')",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "extensions": {
+          "description": "List of additional features that can be enabled on host",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true
+        },
+        "fips": {
+          "description": "FIPS controls FIPS mode",
+          "type": "boolean"
+        },
+        "kernelArguments": {
+          "description": "KernelArguments contains a list of kernel arguments to be added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true
+        },
+        "kernelType": {
+          "description": "Contains which kernel we want to be running like default (traditional), realtime",
+          "type": "string"
+        },
+        "osImageURL": {
+          "description": "OSImageURL specifies the remote location that will be used to fetch the OS",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.11-strict/machineconfigpool_v1.json
+++ b/openshift/v4.11-strict/machineconfigpool_v1.json
@@ -1,0 +1,346 @@
+{
+  "description": "MachineConfigPool describes a pool of MachineConfigs.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineConfigPoolSpec is the spec for MachineConfigPool resource.",
+      "type": "object",
+      "properties": {
+        "configuration": {
+          "description": "The targeted MachineConfig object for the machine config pool.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "source": {
+              "description": "source is the list of MachineConfig objects that were used to generate the single MachineConfig object specified in `content`.",
+              "type": "array",
+              "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "machineConfigSelector": {
+          "description": "machineConfigSelector specifies a label selector for MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ on how label and selectors work.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "maxUnavailable": {
+          "description": "maxUnavailable defines either an integer number or percentage of nodes in the corresponding pool that can go Unavailable during an update. This includes nodes Unavailable for any reason, including user initiated cordons, failing nodes, etc. The default value is 1. A value larger than 1 will mean multiple nodes going unavailable during the update, which may affect your workload stress on the remaining nodes. You cannot set this value to 0 to stop updates (it will default back to 1); to stop updates, use the 'paused' property instead. Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum guards, even if maxUnavailable is greater than one.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        },
+        "nodeSelector": {
+          "description": "nodeSelector specifies a label selector for Machines",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "paused specifies whether or not changes to this machine config pool should be stopped. This includes generating new desiredMachineConfig and update of machines.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineConfigPoolStatus is the status for MachineConfigPool resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "MachineConfigPoolCondition contains condition information for an MachineConfigPool.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message is a human readable description of the details of the last transition, complementing reason.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is a brief machine readable explanation for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of ('True', 'False', 'Unknown').",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of the condition, currently ('Done', 'Updating', 'Failed').",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "configuration": {
+          "description": "configuration represents the current MachineConfig object for the machine config pool.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "source": {
+              "description": "source is the list of MachineConfig objects that were used to generate the single MachineConfig object specified in `content`.",
+              "type": "array",
+              "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "degradedMachineCount": {
+          "description": "degradedMachineCount represents the total number of machines marked degraded (or unreconcilable). A node is marked degraded if applying a configuration failed..",
+          "type": "integer",
+          "format": "int32"
+        },
+        "machineCount": {
+          "description": "machineCount represents the total number of machines in the machine config pool.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "readyMachineCount": {
+          "description": "readyMachineCount represents the total number of ready machines targeted by the pool.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "unavailableMachineCount": {
+          "description": "unavailableMachineCount represents the total number of unavailable (non-ready) machines targeted by the pool. A node is marked unavailable if it is in updating state or NodeReady condition is false.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "updatedMachineCount": {
+          "description": "updatedMachineCount represents the total number of machines targeted by the pool that have the CurrentMachineConfig as their config.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the following CRDs for the
"machineconfiguration.openshift.io" group:

* ContainerRuntimeConfig
* KubeletConfig
* MachineConfig
* MachineConfigPool

The schemas were extracted with:

```
cd openshift/v4.11-strict/
git clone git@github.com:openshift/machine-config-operator.git
cd machine-config-operator/ && git checkout release-4.11 && cd ..
find machine-config-operator/ -wholename '*/install/*.crd.yaml' -exec python3 ../../openapi2jsonschema.py {} \;
```