### PR TITLE
chore: update actions.summerwind.dev to master branch state

### DIFF
--- a/actions.summerwind.dev/horizontalrunnerautoscaler_v1alpha1.json
+++ b/actions.summerwind.dev/horizontalrunnerautoscaler_v1alpha1.json
@@ -115,7 +115,7 @@
           "type": "integer"
         },
         "scaleTargetRef": {
-          "description": "ScaleTargetRef sis the reference to scaled resource like RunnerDeployment",
+          "description": "ScaleTargetRef is the reference to scaled resource like RunnerDeployment",
           "properties": {
             "kind": {
               "description": "Kind is the type of resource being referenced",

--- a/actions.summerwind.dev/runner_v1alpha1.json
+++ b/actions.summerwind.dev/runner_v1alpha1.json
@@ -2064,6 +2064,18 @@
         "dockerRegistryMirror": {
           "type": "string"
         },
+        "dockerVarRunVolumeSizeLimit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
         "dockerVolumeMounts": {
           "items": {
             "description": "VolumeMount describes a mounting of a Volume within a container.",

--- a/actions.summerwind.dev/runnerdeployment_v1alpha1.json
+++ b/actions.summerwind.dev/runnerdeployment_v1alpha1.json
@@ -2154,6 +2154,18 @@
                 "dockerRegistryMirror": {
                   "type": "string"
                 },
+                "dockerVarRunVolumeSizeLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
                 "dockerVolumeMounts": {
                   "items": {
                     "description": "VolumeMount describes a mounting of a Volume within a container.",

--- a/actions.summerwind.dev/runnerreplicaset_v1alpha1.json
+++ b/actions.summerwind.dev/runnerreplicaset_v1alpha1.json
@@ -2154,6 +2154,18 @@
                 "dockerRegistryMirror": {
                   "type": "string"
                 },
+                "dockerVarRunVolumeSizeLimit": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
                 "dockerVolumeMounts": {
                   "items": {
                     "description": "VolumeMount describes a mounting of a Volume within a container.",

--- a/actions.summerwind.dev/runnerset_v1alpha1.json
+++ b/actions.summerwind.dev/runnerset_v1alpha1.json
@@ -28,6 +28,18 @@
         "dockerRegistryMirror": {
           "type": "string"
         },
+        "dockerVarRunVolumeSizeLimit": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "x-kubernetes-int-or-string": true
+        },
         "dockerdWithinRunnerContainer": {
           "type": "boolean"
         },


### PR DESCRIPTION
The GitHub Actions Controller hasn't released in 3+ months but the master branch contains important updates to the CRDs, which are crucial to actually running the GitHub Actions Controller.

`dockerVarRunVolumeSizeLimit` was added that allows to increase the `/run` volume on self-hosted runners for Docker usage.

Would love to see it merged soon as my pipeline is failing that validates our resources.