### PR TITLE
feat: :sparkles: adding apache flink operators crds

### DIFF
--- a/flink.apache.org/flinkdeployment_v1beta1.json
+++ b/flink.apache.org/flinkdeployment_v1beta1.json
@@ -1,0 +1,15967 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "flinkConfiguration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "flinkVersion": {
+          "enum": [
+            "v1_13",
+            "v1_14",
+            "v1_15",
+            "v1_16",
+            "v1_17",
+            "v1_18"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string"
+        },
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "className": {
+              "type": "string"
+            },
+            "template": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "savepoint",
+                "last-state",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "jobManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "properties": {
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "claims": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logConfiguration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "mode": {
+          "enum": [
+            "native",
+            "standalone"
+          ],
+          "type": "string"
+        },
+        "podTemplate": {
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "type": "integer"
+                },
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "automountServiceAccountToken": {
+                  "type": "boolean"
+                },
+                "containers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "dnsConfig": {
+                  "properties": {
+                    "nameservers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "options": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "searches": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsPolicy": {
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "type": "boolean"
+                },
+                "ephemeralContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostAliases": {
+                  "items": {
+                    "properties": {
+                      "hostnames": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIPC": {
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "type": "boolean"
+                },
+                "hostUsers": {
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "type": "string"
+                },
+                "imagePullSecrets": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "os": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "overhead": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "preemptionPolicy": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "priorityClassName": {
+                  "type": "string"
+                },
+                "readinessGates": {
+                  "items": {
+                    "properties": {
+                      "conditionType": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceClaims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "properties": {
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "restartPolicy": {
+                  "type": "string"
+                },
+                "runtimeClassName": {
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "type": "string"
+                },
+                "schedulingGates": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "securityContext": {
+                  "properties": {
+                    "fsGroup": {
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceAccount": {
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "setHostnameAsFQDN": {
+                  "type": "boolean"
+                },
+                "shareProcessNamespace": {
+                  "type": "boolean"
+                },
+                "subdomain": {
+                  "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "tolerations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "topologySpreadConstraints": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxSkew": {
+                        "type": "integer"
+                      },
+                      "minDomains": {
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "creationTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "deletionGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "deletionTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "generateName": {
+                                    "type": "string"
+                                  },
+                                  "generation": {
+                                    "type": "integer"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "managedFields": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldsType": {
+                                          "type": "string"
+                                        },
+                                        "fieldsV1": {
+                                          "type": "object"
+                                        },
+                                        "manager": {
+                                          "type": "string"
+                                        },
+                                        "operation": {
+                                          "type": "string"
+                                        },
+                                        "subresource": {
+                                          "type": "string"
+                                        },
+                                        "time": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "ownerReferences": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "blockOwnerDeletion": {
+                                          "type": "boolean"
+                                        },
+                                        "controller": {
+                                          "type": "boolean"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "uid": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resourceVersion": {
+                                    "type": "string"
+                                  },
+                                  "selfLink": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "taskManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "properties": {
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "claims": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "clusterInfo": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "error": {
+          "type": "string"
+        },
+        "jobManagerDeploymentStatus": {
+          "enum": [
+            "READY",
+            "DEPLOYED_NOT_READY",
+            "DEPLOYING",
+            "MISSING",
+            "ERROR"
+          ],
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN",
+                    "description"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN",
+                        "description"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UPGRADE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UPGRADE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UPGRADE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UPGRADE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UPGRADE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "SUSPENDED",
+            "UPGRADING",
+            "DEPLOYED",
+            "STABLE",
+            "ROLLING_BACK",
+            "ROLLED_BACK",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "UPGRADING",
+                "ROLLING_BACK",
+                "ROLLED_BACK"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "taskManager": {
+          "properties": {
+            "labelSelector": {
+              "type": "string"
+            },
+            "replicas": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/flink.apache.org/flinksessionjob_v1beta1.json
+++ b/flink.apache.org/flinksessionjob_v1beta1.json
@@ -1,0 +1,300 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "deploymentName": {
+          "type": "string"
+        },
+        "flinkConfiguration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "savepoint",
+                "last-state",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN",
+                    "description"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN",
+                        "description"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UPGRADE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UPGRADE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UPGRADE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UPGRADE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UPGRADE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "SUSPENDED",
+            "UPGRADING",
+            "DEPLOYED",
+            "STABLE",
+            "ROLLING_BACK",
+            "ROLLED_BACK",
+            "FAILED"
+          ],
+          "type": "string"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "UPGRADING",
+                "ROLLING_BACK",
+                "ROLLED_BACK"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
This commit adds the following CRDs for the
"flink.apache.org" group:

flinkdeployments.flink.apache.org     
flinksessionjobs.flink.apache.org

The schemas were extracted with:

(Summary)

- Passing YAML validation: 1/1

- Passing Kubernetes (1.24.0) schema validation: 1/1

- Passing policy check: 1/1

+-----------------------------------+----+
| Enabled rules in policy "Starter" | 34 |
| Configs tested against policy     | 1  |
| Total rules evaluated             | 34 |
| Total rules skipped               | 0  |
| Total rules failed                | 0  |
| Total rules passed                | 34 |
| See all rules in policy           |    |
+-----------------------------------+----+

[INFO] You're running Datree in offline mode%      