### PR TITLE
Update platform.confluent.io

### DIFF
--- a/platform.confluent.io/connect_v1beta1.json
+++ b/platform.confluent.io/connect_v1beta1.json
@@ -148,7 +148,7 @@
                       "type": "array"
                     },
                     "locationType": {
-                      "description": "locationType specifies where to get connector plugins. Valid options are `confluentHub` and `url`.",
+                      "description": "This field is deprecated and will be ignored if set.",
                       "enum": [
                         "confluentHub",
                         "url"
@@ -187,9 +187,6 @@
                       "type": "array"
                     }
                   },
-                  "required": [
-                    "locationType"
-                  ],
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -1176,6 +1173,14 @@
                   "pattern": "^https?://.*",
                   "type": "string"
                 },
+                "ssoProtocol": {
+                  "description": "sso protocol, valid options are ldap and oidc.",
+                  "enum": [
+                    "ldap",
+                    "oidc"
+                  ],
+                  "type": "string"
+                },
                 "tls": {
                   "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
                   "properties": {
@@ -1230,6 +1235,10 @@
                       "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
                       "minLength": 1,
                       "type": "string"
+                    },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
                     },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",
@@ -1545,14 +1554,14 @@
               "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
               "properties": {
                 "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1699,11 +1708,11 @@
                   "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1836,6 +1845,25 @@
             "route": {
               "description": "route specifies the configuration to create a route service in OpenShift.",
               "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"

--- a/platform.confluent.io/kafka_v1beta1.json
+++ b/platform.confluent.io/kafka_v1beta1.json
@@ -84,6 +84,147 @@
         "dependencies": {
           "description": "dependencies specify the Kafka dependencies, such as Zookeeper and centralized MDS.",
           "properties": {
+            "kRaftController": {
+              "description": "kRaftController specifies the dependency configuration for the KRaftController cluster. You cannot configure both zookeeper and kRaftController dependencies.",
+              "properties": {
+                "clusterRef": {
+                  "description": "clusterRef specifies the name of the KRaft Controller cluster.",
+                  "properties": {
+                    "name": {
+                      "description": "name specifies the name of the Confluent Platform component cluster.",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "namespace specifies the namespace where the Confluent Platform component cluster is running.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "controllerListener": {
+                  "description": "controllerListener specifies the controller listener which must match the controller listener on the referenced KRaft Controller cluster.",
+                  "properties": {
+                    "authentication": {
+                      "description": "authentication specifies the authentication configuration for the listener.",
+                      "properties": {
+                        "jaasConfig": {
+                          "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "jaasConfigPassThrough": {
+                          "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "principalMappingRules": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "type": {
+                          "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                          "enum": [
+                            "plain",
+                            "digest",
+                            "mtls",
+                            "ldap"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "tls": {
+                      "description": "tls specifies the TLS configuration for the listener.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "ignoreTrustStoreConfig": {
+                          "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                          "type": "boolean"
+                        },
+                        "jksPassword": {
+                          "description": "jksPassword references the secret containing the JKS password.",
+                          "properties": {
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretRef"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "enabled"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
             "kafkaRest": {
               "description": "kafkaRest provides the REST client configuration for the MDS when RBAC is enabled.",
               "properties": {
@@ -468,6 +609,10 @@
                       "minLength": 1,
                       "type": "string"
                     },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
+                    },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",
                       "maxLength": 30,
@@ -608,7 +753,7 @@
               "additionalProperties": false
             },
             "zookeeper": {
-              "description": "zookeeper specifies the dependency configuration for Zookeeper.",
+              "description": "zookeeper specifies the dependency configuration for Zookeeper. You cannot configure both zookeeper and kRaftController dependencies.",
               "properties": {
                 "authentication": {
                   "description": "authentication specifies the client side authentication configuration of Zookeeper for Kafka cluster.",
@@ -987,17 +1132,106 @@
               "type": "object",
               "additionalProperties": false
             },
-            "type": {
-              "description": "type defines the identity provider type. The valid option is `ldap`.",
-              "enum": [
-                "ldap"
+            "oidc": {
+              "description": "oidc defines the OIDC service configuration.",
+              "properties": {
+                "clientCredentials": {
+                  "description": "clientCredentials define the IDP clientID and clientSecret.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the credentials.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configurations": {
+                  "description": "configurations defines the OIDC configurations.",
+                  "properties": {
+                    "authorizeBaseEndpointUri": {
+                      "description": "authorizeBaseEndpointUri specifies the base uri for authorize endpoint.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupsClaimName": {
+                      "description": "groupsClaimName specifies the name of claim in token for identifying the groups of subject in the JWT payload.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupsClaimScope": {
+                      "description": "groupsClaimScope specifies additional scope needed for the token to contain groups claim (field). Leave this field empty (or null) if id token always contains the claims identified as groups.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "issuer": {
+                      "description": "issuer specifies the authorization server's URL. This value should match the issuer claim (\"iss\") in id tokens issued by Authorization Server?",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwksEndpointUri": {
+                      "description": "jwksEndpointUri specifies the uri for the JSON Web Key Set (JWKS). It is used to get set of keys containing the public keys used to verify any JWT issued by the IdP's Authorization Server.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "refreshToken": {
+                      "description": "refreshToken specifies whether offline_access scope should be requested in the authorization URI.",
+                      "type": "boolean"
+                    },
+                    "sessionMaxTimeout": {
+                      "description": "sessionMaxTimeout specifies the maximum expiration time for a user's session.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "sessionTokenExpiry": {
+                      "description": "sessionTokenExpiry specifies the validity of cookie issued by Confluent.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "subClaimName": {
+                      "description": "subClaimName specifies name of claim in JWT to use for the subject.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "tokenBaseEndpointUri": {
+                      "description": "tokenBaseEndpointUri specifies the base uri for token endpoint.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "authorizeBaseEndpointUri",
+                    "issuer",
+                    "jwksEndpointUri",
+                    "refreshToken",
+                    "tokenBaseEndpointUri"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "clientCredentials",
+                "configurations"
               ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "This field has been deprecated and its value will be ignored if set.",
               "type": "string"
             }
           },
           "required": [
-            "ldap",
-            "type"
+            "ldap"
           ],
           "type": "object",
           "additionalProperties": false
@@ -1299,11 +1533,11 @@
                             "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                             "properties": {
                               "enabled": {
-                                "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                                "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                                 "type": "boolean"
                               },
                               "prefix": {
-                                "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                                "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                                 "minLength": 1,
                                 "type": "string"
                               }
@@ -1829,11 +2063,11 @@
                           "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                           "properties": {
                             "enabled": {
-                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                               "type": "boolean"
                             },
                             "prefix": {
-                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                               "minLength": 1,
                               "type": "string"
                             }
@@ -2183,6 +2417,517 @@
                         "digest",
                         "mtls",
                         "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replication": {
+              "description": "replication specifies the Kafka replication listener.",
+              "properties": {
+                "authentication": {
+                  "description": "authentication specifies the authentication configuration for the listener.",
+                  "properties": {
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "principalMappingRules": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                      "enum": [
+                        "plain",
+                        "digest",
+                        "mtls",
+                        "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "externalAccess": {
+                  "description": "externalAccess defines the external access configuration for the Kafka cluster.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create Kubernetes load balancer services.",
+                      "properties": {
+                        "advertisedPort": {
+                          "description": "advertisedPort specifies the advertised port for Kafka external access. If not configured, it will be the same as the listener port. Information about the advertised port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "bootstrapPrefix": {
+                          "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create Kubernetes node port services.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create route services in OpenShift.",
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "bootstrapPrefix": {
+                          "description": "bootstrapPrefix specifies the prefix for the Kafka bootstrap advertised endpoint and will be added as `bootstrapPrefix.domain`. The default value is the Kafka cluster name.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the Kafka broker advertised endpoint and will be added as `brokerPrefix.domain`. The default value is `b`, such as `b#.domain` where `#` starts from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "staticForHostBasedRouting": {
+                      "description": "staticForHostBasedRouting enables external access by doing host based routing through the SNI capability. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                      "properties": {
+                        "brokerPrefix": {
+                          "description": "brokerPrefix specifies the prefix for the broker advertised endpoints and are added as `brokerPrefix.domain`. If not configured, it will add `b` as a prefix, such as `b#.domain` where `#` will start from `0` to the replicas count.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name for the Kafka cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "port specifies the port to be used in the advertised listener for a broker.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "domain",
+                        "port"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "staticForPortBasedRouting": {
+                      "description": "staticForPortBasedRouting enables external access by port routing. With this schema, CFK only configures Kafka advertised listeners, and no Kubernetes external service is created.",
+                      "properties": {
+                        "host": {
+                          "description": "host defines the host name to be used in the advertised listener for a broker.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "portOffset": {
+                          "description": "portOffset specifies the starting port number. The port numbers go in ascending order with respect to the replicas count.",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "portOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes service for external access. Valid options are `loadBalancer`, `nodePort`, `route`, `staticForPortBasedRouting`, and `staticForHostBasedRouting`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route",
+                        "staticForPortBasedRouting",
+                        "staticForHostBasedRouting"
                       ],
                       "type": "string"
                     }
@@ -5437,14 +6182,14 @@
                       "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
                       "properties": {
                         "advertisedURL": {
-                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                           "properties": {
                             "enabled": {
-                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                               "type": "boolean"
                             },
                             "prefix": {
-                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                               "minLength": 1,
                               "type": "string"
                             }
@@ -5591,11 +6336,11 @@
                           "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                           "properties": {
                             "enabled": {
-                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                               "type": "boolean"
                             },
                             "prefix": {
-                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                               "minLength": 1,
                               "type": "string"
                             }
@@ -5728,6 +6473,25 @@
                     "route": {
                       "description": "route specifies the configuration to create a route service in OpenShift.",
                       "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
@@ -5786,8 +6550,504 @@
                   "type": "object",
                   "additionalProperties": false
                 },
+                "listeners": {
+                  "description": "listeners specify the listeners configurations for embedded REST API server.",
+                  "properties": {
+                    "external": {
+                      "description": "external specifies the Confluent component external listener.",
+                      "properties": {
+                        "externalAccess": {
+                          "description": "externalAccess defines the external access configuration for the Confluent component.",
+                          "properties": {
+                            "loadBalancer": {
+                              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "domain": {
+                                  "description": "domain is the domain name of the component cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "externalTrafficPolicy": {
+                                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                                  "enum": [
+                                    "Local",
+                                    "Cluster"
+                                  ],
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "loadBalancerSourceRanges": {
+                                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "port": {
+                                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "prefix": {
+                                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "servicePorts": {
+                                  "description": "servicePorts specify the user-provided service port(s).",
+                                  "items": {
+                                    "description": "ServicePort contains information on service's port.",
+                                    "properties": {
+                                      "appProtocol": {
+                                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                        "type": "string"
+                                      },
+                                      "nodePort": {
+                                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "port": {
+                                        "description": "The port that will be exposed by this service.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "default": "TCP",
+                                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                        "type": "string"
+                                      },
+                                      "targetPort": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "sessionAffinity": {
+                                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                                  "enum": [
+                                    "ClientIP",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                },
+                                "sessionAffinityConfig": {
+                                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                                  "properties": {
+                                    "clientIP": {
+                                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                      "properties": {
+                                        "timeoutSeconds": {
+                                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "domain"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "nodePort": {
+                              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "externalTrafficPolicy": {
+                                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                                  "enum": [
+                                    "Local",
+                                    "Cluster"
+                                  ],
+                                  "type": "string"
+                                },
+                                "host": {
+                                  "description": "host defines the host name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "nodePortOffset": {
+                                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "servicePorts": {
+                                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                                  "items": {
+                                    "description": "ServicePort contains information on service's port.",
+                                    "properties": {
+                                      "appProtocol": {
+                                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                        "type": "string"
+                                      },
+                                      "nodePort": {
+                                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "port": {
+                                        "description": "The port that will be exposed by this service.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "default": "TCP",
+                                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                        "type": "string"
+                                      },
+                                      "targetPort": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "sessionAffinity": {
+                                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                                  "enum": [
+                                    "ClientIP",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                },
+                                "sessionAffinityConfig": {
+                                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                                  "properties": {
+                                    "clientIP": {
+                                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                      "properties": {
+                                        "timeoutSeconds": {
+                                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "host",
+                                "nodePortOffset"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "route": {
+                              "description": "route specifies the configuration to create a route service in OpenShift.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "domain": {
+                                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "prefix": {
+                                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "wildcardPolicy": {
+                                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                                  "enum": [
+                                    "Subdomain",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "domain"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": {
+                              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                              "enum": [
+                                "loadBalancer",
+                                "nodePort",
+                                "route"
+                              ],
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tls": {
+                          "description": "tls specifies the TLS configuration for the listener.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "ignoreTrustStoreConfig": {
+                              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "jksPassword": {
+                              "description": "jksPassword references the secret containing the JKS password.",
+                              "properties": {
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "secretRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "internal": {
+                      "description": "internal specifies the Confluent component's internal listener. This internal listener is for intra-communication between the pods.",
+                      "properties": {
+                        "port": {
+                          "description": "port binds the given port to the internal listener. If not configured, it will be defaulted to the component-specific internal port. Port numbers lower than `9093` are reserved by CFK.",
+                          "format": "int32",
+                          "minimum": 9093,
+                          "type": "integer"
+                        },
+                        "tls": {
+                          "description": "tls specifies the TLS configuration for the listener.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "ignoreTrustStoreConfig": {
+                              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "jksPassword": {
+                              "description": "jksPassword references the secret containing the JKS password.",
+                              "properties": {
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "secretRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "tls": {
-                  "description": "tls specifies the TLS configuration.",
+                  "description": "tls specifies the TLS configuration for embedded REST API server.",
                   "properties": {
                     "directoryPathInContainer": {
                       "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
@@ -5864,14 +7124,14 @@
                       "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
                       "properties": {
                         "advertisedURL": {
-                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                           "properties": {
                             "enabled": {
-                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                               "type": "boolean"
                             },
                             "prefix": {
-                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                               "minLength": 1,
                               "type": "string"
                             }
@@ -6018,11 +7278,11 @@
                           "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                           "properties": {
                             "enabled": {
-                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                               "type": "boolean"
                             },
                             "prefix": {
-                              "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                               "minLength": 1,
                               "type": "string"
                             }
@@ -6155,6 +7415,25 @@
                     "route": {
                       "description": "route specifies the configuration to create a route service in OpenShift.",
                       "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
@@ -6210,6 +7489,502 @@
                   "required": [
                     "type"
                   ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "listeners": {
+                  "description": "listeners specify the listeners configurations for MDS server.",
+                  "properties": {
+                    "external": {
+                      "description": "external specifies the Confluent component external listener.",
+                      "properties": {
+                        "externalAccess": {
+                          "description": "externalAccess defines the external access configuration for the Confluent component.",
+                          "properties": {
+                            "loadBalancer": {
+                              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "domain": {
+                                  "description": "domain is the domain name of the component cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "externalTrafficPolicy": {
+                                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                                  "enum": [
+                                    "Local",
+                                    "Cluster"
+                                  ],
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "loadBalancerSourceRanges": {
+                                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "port": {
+                                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "prefix": {
+                                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "servicePorts": {
+                                  "description": "servicePorts specify the user-provided service port(s).",
+                                  "items": {
+                                    "description": "ServicePort contains information on service's port.",
+                                    "properties": {
+                                      "appProtocol": {
+                                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                        "type": "string"
+                                      },
+                                      "nodePort": {
+                                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "port": {
+                                        "description": "The port that will be exposed by this service.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "default": "TCP",
+                                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                        "type": "string"
+                                      },
+                                      "targetPort": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "sessionAffinity": {
+                                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                                  "enum": [
+                                    "ClientIP",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                },
+                                "sessionAffinityConfig": {
+                                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                                  "properties": {
+                                    "clientIP": {
+                                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                      "properties": {
+                                        "timeoutSeconds": {
+                                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "domain"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "nodePort": {
+                              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "externalTrafficPolicy": {
+                                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                                  "enum": [
+                                    "Local",
+                                    "Cluster"
+                                  ],
+                                  "type": "string"
+                                },
+                                "host": {
+                                  "description": "host defines the host name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "nodePortOffset": {
+                                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                                  "format": "int32",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "servicePorts": {
+                                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                                  "items": {
+                                    "description": "ServicePort contains information on service's port.",
+                                    "properties": {
+                                      "appProtocol": {
+                                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                        "type": "string"
+                                      },
+                                      "nodePort": {
+                                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "port": {
+                                        "description": "The port that will be exposed by this service.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "protocol": {
+                                        "default": "TCP",
+                                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                        "type": "string"
+                                      },
+                                      "targetPort": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "required": [
+                                      "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "sessionAffinity": {
+                                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                                  "enum": [
+                                    "ClientIP",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                },
+                                "sessionAffinityConfig": {
+                                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                                  "properties": {
+                                    "clientIP": {
+                                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                                      "properties": {
+                                        "timeoutSeconds": {
+                                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                          "format": "int32",
+                                          "type": "integer"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "required": [
+                                "host",
+                                "nodePortOffset"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "route": {
+                              "description": "route specifies the configuration to create a route service in OpenShift.",
+                              "properties": {
+                                "advertisedURL": {
+                                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                                  "properties": {
+                                    "enabled": {
+                                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                                      "type": "boolean"
+                                    },
+                                    "prefix": {
+                                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "enabled"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "annotations": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "domain": {
+                                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "labels": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "granular"
+                                },
+                                "prefix": {
+                                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "wildcardPolicy": {
+                                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                                  "enum": [
+                                    "Subdomain",
+                                    "None"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "domain"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": {
+                              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                              "enum": [
+                                "loadBalancer",
+                                "nodePort",
+                                "route"
+                              ],
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "tls": {
+                          "description": "tls specifies the TLS configuration for the listener.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "ignoreTrustStoreConfig": {
+                              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "jksPassword": {
+                              "description": "jksPassword references the secret containing the JKS password.",
+                              "properties": {
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "secretRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "internal": {
+                      "description": "internal specifies the Confluent component's internal listener. This internal listener is for intra-communication between the pods.",
+                      "properties": {
+                        "port": {
+                          "description": "port binds the given port to the internal listener. If not configured, it will be defaulted to the component-specific internal port. Port numbers lower than `9093` are reserved by CFK.",
+                          "format": "int32",
+                          "minimum": 9093,
+                          "type": "integer"
+                        },
+                        "tls": {
+                          "description": "tls specifies the TLS configuration for the listener.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "enabled": {
+                              "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "ignoreTrustStoreConfig": {
+                              "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                              "type": "boolean"
+                            },
+                            "jksPassword": {
+                              "description": "jksPassword references the secret containing the JKS password.",
+                              "properties": {
+                                "secretRef": {
+                                  "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                                  "maxLength": 30,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "secretRef"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
                   "type": "object",
                   "additionalProperties": false
                 },
@@ -6388,23 +8163,112 @@
                       "type": "object",
                       "additionalProperties": false
                     },
-                    "type": {
-                      "description": "type defines the identity provider type. The valid option is `ldap`.",
-                      "enum": [
-                        "ldap"
+                    "oidc": {
+                      "description": "oidc defines the OIDC service configuration.",
+                      "properties": {
+                        "clientCredentials": {
+                          "description": "clientCredentials define the IDP clientID and clientSecret.",
+                          "properties": {
+                            "directoryPathInContainer": {
+                              "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references the name of the secret that contains the credentials.",
+                              "maxLength": 30,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "configurations": {
+                          "description": "configurations defines the OIDC configurations.",
+                          "properties": {
+                            "authorizeBaseEndpointUri": {
+                              "description": "authorizeBaseEndpointUri specifies the base uri for authorize endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupsClaimName": {
+                              "description": "groupsClaimName specifies the name of claim in token for identifying the groups of subject in the JWT payload.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "groupsClaimScope": {
+                              "description": "groupsClaimScope specifies additional scope needed for the token to contain groups claim (field). Leave this field empty (or null) if id token always contains the claims identified as groups.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "issuer": {
+                              "description": "issuer specifies the authorization server's URL. This value should match the issuer claim (\"iss\") in id tokens issued by Authorization Server?",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "jwksEndpointUri": {
+                              "description": "jwksEndpointUri specifies the uri for the JSON Web Key Set (JWKS). It is used to get set of keys containing the public keys used to verify any JWT issued by the IdP's Authorization Server.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "refreshToken": {
+                              "description": "refreshToken specifies whether offline_access scope should be requested in the authorization URI.",
+                              "type": "boolean"
+                            },
+                            "sessionMaxTimeout": {
+                              "description": "sessionMaxTimeout specifies the maximum expiration time for a user's session.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "sessionTokenExpiry": {
+                              "description": "sessionTokenExpiry specifies the validity of cookie issued by Confluent.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "subClaimName": {
+                              "description": "subClaimName specifies name of claim in JWT to use for the subject.",
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "tokenBaseEndpointUri": {
+                              "description": "tokenBaseEndpointUri specifies the base uri for token endpoint.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "authorizeBaseEndpointUri",
+                            "issuer",
+                            "jwksEndpointUri",
+                            "refreshToken",
+                            "tokenBaseEndpointUri"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "clientCredentials",
+                        "configurations"
                       ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "This field has been deprecated and its value will be ignored if set.",
                       "type": "string"
                     }
                   },
                   "required": [
-                    "ldap",
-                    "type"
+                    "ldap"
                   ],
                   "type": "object",
                   "additionalProperties": false
                 },
                 "tls": {
-                  "description": "tls specifies the TLS configuration.",
+                  "description": "tls specifies the TLS configuration for MDS server.",
                   "properties": {
                     "directoryPathInContainer": {
                       "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
@@ -6457,6 +8321,10 @@
                       "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
                       "minLength": 1,
                       "type": "string"
+                    },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
                     },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",

--- a/platform.confluent.io/kafkarestproxy_v1beta1.json
+++ b/platform.confluent.io/kafkarestproxy_v1beta1.json
@@ -688,6 +688,14 @@
                   "pattern": "^https?://.*",
                   "type": "string"
                 },
+                "ssoProtocol": {
+                  "description": "sso protocol, valid options are ldap and oidc.",
+                  "enum": [
+                    "ldap",
+                    "oidc"
+                  ],
+                  "type": "string"
+                },
                 "tls": {
                   "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
                   "properties": {
@@ -742,6 +750,10 @@
                       "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
                       "minLength": 1,
                       "type": "string"
+                    },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
                     },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",
@@ -893,14 +905,14 @@
               "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
               "properties": {
                 "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1047,11 +1059,11 @@
                   "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1184,6 +1196,25 @@
             "route": {
               "description": "route specifies the configuration to create a route service in OpenShift.",
               "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"

--- a/platform.confluent.io/kraftcontroller_v1beta1.json
+++ b/platform.confluent.io/kraftcontroller_v1beta1.json
@@ -1,5 +1,5 @@
 {
-  "description": "ControlCenter is the schema for the Control Center API.",
+  "description": "KRaftController is the schema for the KRaft Controller API.",
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -13,97 +13,23 @@
       "type": "object"
     },
     "spec": {
-      "description": "spec defines the desired state of the Control Center cluster.",
+      "description": "spec defines the desired state of the KRaft Controller cluster.",
       "properties": {
-        "authentication": {
-          "description": "authentication specifies the authentication configurations.",
+        "authorization": {
+          "description": "authorization specifies the authorization configuration.",
           "properties": {
-            "basic": {
-              "description": "basic specifies the configuration for basic authentication.",
-              "properties": {
-                "debug": {
-                  "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                  "type": "boolean"
-                },
-                "directoryPathInContainer": {
-                  "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "restrictedRoles": {
-                  "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "minItems": 1,
-                  "type": "array"
-                },
-                "roles": {
-                  "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "secretRef": {
-                  "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                  "maxLength": 30,
-                  "minLength": 1,
-                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                  "type": "string"
-                }
+            "superUsers": {
+              "description": "superUsers specify the super users to give the admin privilege on the Kafka Cluster. This list takes the format as `User:<user-name>`",
+              "items": {
+                "type": "string"
               },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "ldap": {
-              "description": "ldap specifies the configuration for Control Center LDAP authentication.",
-              "properties": {
-                "debug": {
-                  "description": "debug enables basic authentication debug logs for JaaS configuration.",
-                  "type": "boolean"
-                },
-                "property": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "property is a map of string key and value pairs that specifies the LDAP configuration. Use a secret object to pass username/password.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "restrictedRoles": {
-                  "description": "restrictedRoles specify the restricted access roles.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "minItems": 1,
-                  "type": "array"
-                },
-                "roles": {
-                  "description": "roles specify the roles on the server side only.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "minItems": 1,
-                  "type": "array"
-                },
-                "secretRef": {
-                  "description": "secretRef references the secret to pass required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#ldap-authentication-for-c3",
-                  "maxLength": 30,
-                  "minLength": 1,
-                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                  "type": "string"
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
+              "type": "array"
             },
             "type": {
-              "description": "type specifies the authentication type of the Control Center. Valid options are `basic`, `ldap`, and `mtls`.",
+              "description": "type specifies the authorization type. The valid options are `rbac` and `simple`.",
               "enum": [
-                "basic",
-                "ldap",
-                "mtls"
+                "rbac",
+                "simple"
               ],
               "type": "string"
             }
@@ -114,44 +40,15 @@
           "type": "object",
           "additionalProperties": false
         },
-        "authorization": {
-          "description": "authorization specifies the authorization configurations.",
-          "properties": {
-            "kafkaRestClassRef": {
-              "description": "kafkaRestClassRef references the KafkaRestClass which specifies the Kafka REST API connection configuration.",
-              "properties": {
-                "name": {
-                  "description": "name specifies the name of the KafkaRestClass application resource.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "namespace": {
-                  "description": "namespace specifies the namespace of the KafkaRestClass.",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": {
-              "description": "type specifies the client-side authorization type. The valid option is `rbac`.",
-              "enum": [
-                "rbac"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "type"
-          ],
-          "type": "object",
-          "additionalProperties": false
+        "clusterID": {
+          "description": "clusterID specifies the ID of the KRaft Controller cluster. It must contain only alphanumeric characters and the hyphen character and be of length 22. If omitted, a clusterID will be autogenerated. In the case of attaching to existing Persistent Volumes, you must match the old clusterID.",
+          "maxLength": 22,
+          "minLength": 22,
+          "pattern": "^[a-zA-Z0-9\\-]*$",
+          "type": "string"
         },
         "configOverrides": {
-          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the Control Center.",
+          "description": "configOverrides specifies the configs to override the server, JVM, Log4j properties for the KRaft Controller cluster.",
           "properties": {
             "jvm": {
               "description": "jvm is a list of JVM configuration supported by the Confluent Platform component. This will either add or update the existing configuration.",
@@ -187,1194 +84,20 @@
               "type": "string"
             }
           ],
-          "description": "dataVolumeCapacity specifies the data size for the persistent volume.",
+          "description": "dataVolumeCapacity specifies the persistent volume capacity for the KRaft Controller cluster.",
           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
           "x-kubernetes-int-or-string": true
         },
-        "dependencies": {
-          "description": "dependencies specify the dependencies configurations.",
+        "fips": {
+          "description": "fips specifies the configuration of FIPS compliant Bouncy Castle type Java Keystores for the KRaft Controller cluster's TLS settings. TLS Secrets must have the keys keystore.bcfks, truststore.bcfks, and jksPassword.txt",
           "properties": {
-            "connect": {
-              "description": "connect defines the Connect worker dependency configurations.",
-              "items": {
-                "description": "ControlCenterConnectDependency defines the Connect dependency settings.",
-                "properties": {
-                  "authentication": {
-                    "description": "authentication specifies the authentication configuration for the Connect cluster.",
-                    "properties": {
-                      "basic": {
-                        "description": "basic specifies the configuration for basic authentication.",
-                        "properties": {
-                          "debug": {
-                            "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                            "type": "boolean"
-                          },
-                          "directoryPathInContainer": {
-                            "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "restrictedRoles": {
-                            "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "minItems": 1,
-                            "type": "array"
-                          },
-                          "roles": {
-                            "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "secretRef": {
-                            "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                            "maxLength": 30,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": {
-                        "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
-                        "enum": [
-                          "basic",
-                          "mtls"
-                        ],
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "name": {
-                    "description": "name specifies the Connect cluster name.",
-                    "minLength": 1,
-                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                    "type": "string"
-                  },
-                  "tls": {
-                    "description": "tls specifies the client-side TLS setting for the Connect cluster.",
-                    "properties": {
-                      "directoryPathInContainer": {
-                        "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "enabled": {
-                        "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                        "type": "boolean"
-                      },
-                      "ignoreTrustStoreConfig": {
-                        "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                        "type": "boolean"
-                      },
-                      "jksPassword": {
-                        "description": "jksPassword references the secret containing the JKS password.",
-                        "properties": {
-                          "secretRef": {
-                            "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                            "maxLength": 30,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "secretRef"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "secretRef": {
-                        "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "enabled"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "url": {
-                    "description": "url specifies the URL endpoint of the Connect cluster.",
-                    "minLength": 1,
-                    "pattern": "^https?://.*",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "url"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "type": "array"
-            },
-            "kafka": {
-              "description": "kafka defines the Kafka dependency configurations.",
-              "properties": {
-                "authentication": {
-                  "description": "authentication defines the authentication for the Kafka cluster.",
-                  "properties": {
-                    "jaasConfig": {
-                      "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
-                      "properties": {
-                        "secretRef": {
-                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "secretRef"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "jaasConfigPassThrough": {
-                      "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
-                      "properties": {
-                        "directoryPathInContainer": {
-                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                          "minLength": 1,
-                          "type": "string"
-                        },
-                        "secretRef": {
-                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "oauthbearer": {
-                      "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
-                      "properties": {
-                        "directoryPathInContainer": {
-                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
-                          "minLength": 1,
-                          "type": "string"
-                        },
-                        "secretRef": {
-                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": {
-                      "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
-                      "enum": [
-                        "plain",
-                        "oauthbearer",
-                        "digest",
-                        "mtls"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "bootstrapEndpoint": {
-                  "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
-                  "minLength": 1,
-                  "pattern": ".+:[0-9]+",
-                  "type": "string"
-                },
-                "discovery": {
-                  "description": "discovery specifies the capability to discover the Kafka cluster.",
-                  "properties": {
-                    "name": {
-                      "description": "name is the name of the Confluent Platform component cluster.",
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
-                      "type": "string"
-                    },
-                    "secretRef": {
-                      "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
-                      "maxLength": 30,
-                      "minLength": 1,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "name"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "tls": {
-                  "description": "tls defines the client-side TLS setting for the Kafka cluster.",
-                  "properties": {
-                    "directoryPathInContainer": {
-                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "enabled": {
-                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "ignoreTrustStoreConfig": {
-                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "jksPassword": {
-                      "description": "jksPassword references the secret containing the JKS password.",
-                      "properties": {
-                        "secretRef": {
-                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "secretRef"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "secretRef": {
-                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                      "maxLength": 30,
-                      "minLength": 1,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "type": "object",
-              "additionalProperties": false
-            },
-            "ksqldb": {
-              "description": "ksqldb defines the ksqlDB dependency configurations.",
-              "items": {
-                "description": "ControlCenterKSQLDependency defines the ksqlDB dependency settings.",
-                "properties": {
-                  "advertisedUrl": {
-                    "description": "advertisedUrl specifies the advertised URL to use in the browser.",
-                    "minLength": 1,
-                    "pattern": "^https?://.*",
-                    "type": "string"
-                  },
-                  "authentication": {
-                    "description": "authentication specifies the authentication for the ksqlDB cluster.",
-                    "properties": {
-                      "basic": {
-                        "description": "basic specifies the configuration for basic authentication.",
-                        "properties": {
-                          "debug": {
-                            "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                            "type": "boolean"
-                          },
-                          "directoryPathInContainer": {
-                            "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "restrictedRoles": {
-                            "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "minItems": 1,
-                            "type": "array"
-                          },
-                          "roles": {
-                            "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                            "items": {
-                              "type": "string"
-                            },
-                            "type": "array"
-                          },
-                          "secretRef": {
-                            "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                            "maxLength": 30,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          }
-                        },
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "type": {
-                        "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
-                        "enum": [
-                          "basic",
-                          "mtls"
-                        ],
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "name": {
-                    "description": "name specifies the ksqlDB cluster name.",
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "tls": {
-                    "description": "tls specifies the client-side TLS setting for the ksqlDB cluster.",
-                    "properties": {
-                      "directoryPathInContainer": {
-                        "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "enabled": {
-                        "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                        "type": "boolean"
-                      },
-                      "ignoreTrustStoreConfig": {
-                        "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                        "type": "boolean"
-                      },
-                      "jksPassword": {
-                        "description": "jksPassword references the secret containing the JKS password.",
-                        "properties": {
-                          "secretRef": {
-                            "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                            "maxLength": 30,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "secretRef"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "secretRef": {
-                        "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "enabled"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "url": {
-                    "description": "url specifies the URL endpoint of the ksqlDB cluster.",
-                    "minLength": 1,
-                    "pattern": "^https?://.*",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "url"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "type": "array"
-            },
-            "mds": {
-              "description": "mds defines the RBAC dependency configurations.",
-              "properties": {
-                "authentication": {
-                  "description": "authentication specifies the client side authentication configuration for the MDS.",
-                  "properties": {
-                    "bearer": {
-                      "description": "bearer specifies the bearer authentication settings.",
-                      "properties": {
-                        "directoryPathInContainer": {
-                          "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
-                          "minLength": 1,
-                          "type": "string"
-                        },
-                        "secretRef": {
-                          "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": {
-                      "description": "type specifies the authentication method for the MDS. The valid option is `bearer`.",
-                      "enum": [
-                        "bearer"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "bearer",
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "endpoint": {
-                  "description": "endpoint specifies the MDS endpoint.",
-                  "minLength": 1,
-                  "pattern": "^https?://.*",
-                  "type": "string"
-                },
-                "ssoProtocol": {
-                  "description": "sso protocol, valid options are ldap and oidc.",
-                  "enum": [
-                    "ldap",
-                    "oidc"
-                  ],
-                  "type": "string"
-                },
-                "tls": {
-                  "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
-                  "properties": {
-                    "directoryPathInContainer": {
-                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "enabled": {
-                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "ignoreTrustStoreConfig": {
-                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "jksPassword": {
-                      "description": "jksPassword references the secret containing the JKS password.",
-                      "properties": {
-                        "secretRef": {
-                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "secretRef"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "secretRef": {
-                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                      "maxLength": 30,
-                      "minLength": 1,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "tokenKeyPair": {
-                  "description": "tokenKeyPair specifies the token keypair to configure the MDS.",
-                  "properties": {
-                    "directoryPathInContainer": {
-                      "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "encryptedTokenKey": {
-                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
-                      "type": "boolean"
-                    },
-                    "secretRef": {
-                      "description": "secretRef references the name of the secret that contains the MDS token key pair.",
-                      "maxLength": 30,
-                      "minLength": 1,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                      "type": "string"
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "required": [
-                "authentication",
-                "endpoint",
-                "tokenKeyPair"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "schemaRegistry": {
-              "description": "schemaRegistry defines the Schema Registry dependency configurations.",
-              "properties": {
-                "authentication": {
-                  "description": "authentication specifies the authentication for the Schema Registry cluster.",
-                  "properties": {
-                    "basic": {
-                      "description": "basic specifies the configuration for basic authentication.",
-                      "properties": {
-                        "debug": {
-                          "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                          "type": "boolean"
-                        },
-                        "directoryPathInContainer": {
-                          "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                          "minLength": 1,
-                          "type": "string"
-                        },
-                        "restrictedRoles": {
-                          "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "minItems": 1,
-                          "type": "array"
-                        },
-                        "roles": {
-                          "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "type": "array"
-                        },
-                        "secretRef": {
-                          "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "type": {
-                      "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
-                      "enum": [
-                        "basic",
-                        "mtls"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "type"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "clusters": {
-                  "items": {
-                    "description": "ControlCenterMultiSchemaRegistryDependency defines the Schema Registry dependency List.",
-                    "properties": {
-                      "authentication": {
-                        "description": "authentication specifies the authentication for the Schema Registry cluster.",
-                        "properties": {
-                          "basic": {
-                            "description": "basic specifies the configuration for basic authentication.",
-                            "properties": {
-                              "debug": {
-                                "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                                "type": "boolean"
-                              },
-                              "directoryPathInContainer": {
-                                "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                                "minLength": 1,
-                                "type": "string"
-                              },
-                              "restrictedRoles": {
-                                "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "minItems": 1,
-                                "type": "array"
-                              },
-                              "roles": {
-                                "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "type": "array"
-                              },
-                              "secretRef": {
-                                "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
-                                "maxLength": 30,
-                                "minLength": 1,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                                "type": "string"
-                              }
-                            },
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "type": {
-                            "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
-                            "enum": [
-                              "basic",
-                              "mtls"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "type"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "name": {
-                        "description": "name defines the Schema Registry cluster name.",
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      },
-                      "tls": {
-                        "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
-                        "properties": {
-                          "directoryPathInContainer": {
-                            "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                            "minLength": 1,
-                            "type": "string"
-                          },
-                          "enabled": {
-                            "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                            "type": "boolean"
-                          },
-                          "ignoreTrustStoreConfig": {
-                            "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                            "type": "boolean"
-                          },
-                          "jksPassword": {
-                            "description": "jksPassword references the secret containing the JKS password.",
-                            "properties": {
-                              "secretRef": {
-                                "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                                "maxLength": 30,
-                                "minLength": 1,
-                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "secretRef"
-                            ],
-                            "type": "object",
-                            "additionalProperties": false
-                          },
-                          "secretRef": {
-                            "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                            "maxLength": 30,
-                            "minLength": 1,
-                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "enabled"
-                        ],
-                        "type": "object",
-                        "additionalProperties": false
-                      },
-                      "url": {
-                        "description": "url specifies the URL endpoint of the Schema Registry cluster.",
-                        "minLength": 1,
-                        "pattern": "^https?://.*",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "url"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "tls": {
-                  "description": "tls defines the client-side TLS setting for the Schema Registry cluster.",
-                  "properties": {
-                    "directoryPathInContainer": {
-                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                      "minLength": 1,
-                      "type": "string"
-                    },
-                    "enabled": {
-                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "ignoreTrustStoreConfig": {
-                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                      "type": "boolean"
-                    },
-                    "jksPassword": {
-                      "description": "jksPassword references the secret containing the JKS password.",
-                      "properties": {
-                        "secretRef": {
-                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                          "maxLength": 30,
-                          "minLength": 1,
-                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "secretRef"
-                      ],
-                      "type": "object",
-                      "additionalProperties": false
-                    },
-                    "secretRef": {
-                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                      "maxLength": 30,
-                      "minLength": 1,
-                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "url": {
-                  "description": "url specifies the URL endpoint of the Schema Registry cluster.",
-                  "minLength": 1,
-                  "pattern": "^https?://.*",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "url"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
-        "externalAccess": {
-          "description": "externalAccess specifies the external access configuration for the Control Center cluster.",
-          "properties": {
-            "loadBalancer": {
-              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
-              "properties": {
-                "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
-                  "properties": {
-                    "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
-                      "type": "boolean"
-                    },
-                    "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
-                      "minLength": 1,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "annotations": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "domain": {
-                  "description": "domain is the domain name of the component cluster.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "externalTrafficPolicy": {
-                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
-                  "enum": [
-                    "Local",
-                    "Cluster"
-                  ],
-                  "type": "string"
-                },
-                "labels": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "loadBalancerSourceRanges": {
-                  "description": "loadBalancerSourceRanges specify the source ranges.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "port": {
-                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
-                  "format": "int32",
-                  "type": "integer"
-                },
-                "prefix": {
-                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "servicePorts": {
-                  "description": "servicePorts specify the user-provided service port(s).",
-                  "items": {
-                    "description": "ServicePort contains information on service's port.",
-                    "properties": {
-                      "appProtocol": {
-                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
-                        "type": "string"
-                      },
-                      "nodePort": {
-                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "port": {
-                        "description": "The port that will be exposed by this service.",
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "protocol": {
-                        "default": "TCP",
-                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
-                        "type": "string"
-                      },
-                      "targetPort": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
-                        "x-kubernetes-int-or-string": true
-                      }
-                    },
-                    "required": [
-                      "port"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "sessionAffinity": {
-                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
-                  "enum": [
-                    "ClientIP",
-                    "None"
-                  ],
-                  "type": "string"
-                },
-                "sessionAffinityConfig": {
-                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
-                  "properties": {
-                    "clientIP": {
-                      "description": "clientIP contains the configurations of Client IP based session affinity.",
-                      "properties": {
-                        "timeoutSeconds": {
-                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
-                          "format": "int32",
-                          "type": "integer"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "required": [
-                "domain"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "nodePort": {
-              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
-              "properties": {
-                "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
-                  "properties": {
-                    "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
-                      "type": "boolean"
-                    },
-                    "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
-                      "minLength": 1,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "annotations": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "externalTrafficPolicy": {
-                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
-                  "enum": [
-                    "Local",
-                    "Cluster"
-                  ],
-                  "type": "string"
-                },
-                "host": {
-                  "description": "host defines the host name of the cluster.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "labels": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "nodePortOffset": {
-                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
-                  "format": "int32",
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "servicePorts": {
-                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
-                  "items": {
-                    "description": "ServicePort contains information on service's port.",
-                    "properties": {
-                      "appProtocol": {
-                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
-                        "type": "string"
-                      },
-                      "nodePort": {
-                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "port": {
-                        "description": "The port that will be exposed by this service.",
-                        "format": "int32",
-                        "type": "integer"
-                      },
-                      "protocol": {
-                        "default": "TCP",
-                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
-                        "type": "string"
-                      },
-                      "targetPort": {
-                        "anyOf": [
-                          {
-                            "type": "integer"
-                          },
-                          {
-                            "type": "string"
-                          }
-                        ],
-                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
-                        "x-kubernetes-int-or-string": true
-                      }
-                    },
-                    "required": [
-                      "port"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": "array"
-                },
-                "sessionAffinity": {
-                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
-                  "enum": [
-                    "ClientIP",
-                    "None"
-                  ],
-                  "type": "string"
-                },
-                "sessionAffinityConfig": {
-                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
-                  "properties": {
-                    "clientIP": {
-                      "description": "clientIP contains the configurations of Client IP based session affinity.",
-                      "properties": {
-                        "timeoutSeconds": {
-                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
-                          "format": "int32",
-                          "type": "integer"
-                        }
-                      },
-                      "type": "object",
-                      "additionalProperties": false
-                    }
-                  },
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "required": [
-                "host",
-                "nodePortOffset"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "route": {
-              "description": "route specifies the configuration to create a route service in OpenShift.",
-              "properties": {
-                "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
-                  "properties": {
-                    "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
-                      "type": "boolean"
-                    },
-                    "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
-                      "minLength": 1,
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "enabled"
-                  ],
-                  "type": "object",
-                  "additionalProperties": false
-                },
-                "annotations": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "domain": {
-                  "description": "domain specifies the domain name of the Confluent component cluster.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "labels": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
-                  "type": "object",
-                  "x-kubernetes-map-type": "granular"
-                },
-                "prefix": {
-                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
-                  "minLength": 1,
-                  "type": "string"
-                },
-                "wildcardPolicy": {
-                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
-                  "enum": [
-                    "Subdomain",
-                    "None"
-                  ],
-                  "type": "string"
-                }
-              },
-              "required": [
-                "domain"
-              ],
-              "type": "object",
-              "additionalProperties": false
-            },
-            "type": {
-              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
-              "enum": [
-                "loadBalancer",
-                "nodePort",
-                "route"
-              ],
-              "minLength": 1,
-              "type": "string"
+            "enabled": {
+              "description": "enabled specifies whether to enable the FIPS configuration for Kafka.",
+              "type": "boolean"
             }
           },
           "required": [
-            "type"
+            "enabled"
           ],
           "type": "object",
           "additionalProperties": false
@@ -1406,10 +129,284 @@
           "type": "object",
           "additionalProperties": false
         },
-        "id": {
-          "description": "id specifies the prefix used for this instance of Control Center when multiple instances of Control Center co-exist.",
-          "format": "int32",
-          "type": "integer"
+        "identityProvider": {
+          "description": "identityProvider specifies the identity provider configuration. It is only required for the Kafka authentication type `ldap`.",
+          "properties": {
+            "ldap": {
+              "description": "ldap defines the LDAP service configuration.",
+              "properties": {
+                "address": {
+                  "description": "address defines the LDAP server address.",
+                  "type": "string"
+                },
+                "authentication": {
+                  "description": "LdapAuthentication specifies the LDAP authentication configuration.",
+                  "properties": {
+                    "simple": {
+                      "description": "simple specifies simple authentication configuration for the LDAP.",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret that contains the credentials.",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type defines the authentication method for LDAP. Valid options are `simple` and `mtls`.",
+                      "enum": [
+                        "simple",
+                        "mtls"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configurations": {
+                  "description": "configurations defines the LDAP configurations for Confluent RBAC.",
+                  "properties": {
+                    "groupMemberAttribute": {
+                      "description": "groupMemberAttribute specifies the LDAP group member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupMemberAttributePattern": {
+                      "description": "groupMemberAttributePattern specifies the regular expression pattern for the LDAP group member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupNameAttribute": {
+                      "description": "groupNameAttribute specifies the LDAP group name attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupObjectClass": {
+                      "description": "groupObjectClass specifies the LDAP group object class.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchBase": {
+                      "description": "groupSearchBase specifies the LDAP search base for the group-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchFilter": {
+                      "description": "groupSearchFilter specifies the LDAP search filter for the group-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupSearchScope": {
+                      "description": "groupSearchScope specifies the LDAP search scope for the group-based search.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "userMemberOfAttributePattern": {
+                      "description": "userMemberOfAttributePattern specifies the regular expression pattern for the LDAP user member attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userNameAttribute": {
+                      "description": "userNameAttribute specifies the LDAP username attribute.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userObjectClass": {
+                      "description": "userObjectClass specifies the LDAP user object class.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchBase": {
+                      "description": "userSearchBase specifies the LDAP search base for the user-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchFilter": {
+                      "description": "userSearchFilter specifies the LDAP search filter for the user-based search.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "userSearchScope": {
+                      "description": "userSearchScope specifies the LDAP search scope for the user-based search.",
+                      "format": "int32",
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the LDAP.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "address",
+                "authentication",
+                "configurations"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "oidc": {
+              "description": "oidc defines the OIDC service configuration.",
+              "properties": {
+                "clientCredentials": {
+                  "description": "clientCredentials define the IDP clientID and clientSecret.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer defines the directory path in the container where the credentials are mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret that contains the credentials.",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "configurations": {
+                  "description": "configurations defines the OIDC configurations.",
+                  "properties": {
+                    "authorizeBaseEndpointUri": {
+                      "description": "authorizeBaseEndpointUri specifies the base uri for authorize endpoint.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupsClaimName": {
+                      "description": "groupsClaimName specifies the name of claim in token for identifying the groups of subject in the JWT payload.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "groupsClaimScope": {
+                      "description": "groupsClaimScope specifies additional scope needed for the token to contain groups claim (field). Leave this field empty (or null) if id token always contains the claims identified as groups.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "issuer": {
+                      "description": "issuer specifies the authorization server's URL. This value should match the issuer claim (\"iss\") in id tokens issued by Authorization Server?",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwksEndpointUri": {
+                      "description": "jwksEndpointUri specifies the uri for the JSON Web Key Set (JWKS). It is used to get set of keys containing the public keys used to verify any JWT issued by the IdP's Authorization Server.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "refreshToken": {
+                      "description": "refreshToken specifies whether offline_access scope should be requested in the authorization URI.",
+                      "type": "boolean"
+                    },
+                    "sessionMaxTimeout": {
+                      "description": "sessionMaxTimeout specifies the maximum expiration time for a user's session.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "sessionTokenExpiry": {
+                      "description": "sessionTokenExpiry specifies the validity of cookie issued by Confluent.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "subClaimName": {
+                      "description": "subClaimName specifies name of claim in JWT to use for the subject.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "tokenBaseEndpointUri": {
+                      "description": "tokenBaseEndpointUri specifies the base uri for token endpoint.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "authorizeBaseEndpointUri",
+                    "issuer",
+                    "jwksEndpointUri",
+                    "refreshToken",
+                    "tokenBaseEndpointUri"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "clientCredentials",
+                "configurations"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "This field has been deprecated and its value will be ignored if set.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "ldap"
+          ],
+          "type": "object",
+          "additionalProperties": false
         },
         "image": {
           "description": "image specifies the application and the init docker image configurations. A change to this setting will roll the cluster.",
@@ -1464,11 +461,6 @@
           "type": "object",
           "x-kubernetes-map-type": "granular"
         },
-        "internalTopicReplicatorFactor": {
-          "description": "internalTopicReplicationFactor specifies the replication factor for internal topics.",
-          "format": "int32",
-          "type": "integer"
-        },
         "k8sClusterDomain": {
           "description": "k8sClusterDomain specifies the configuration of the Kubernetes cluster domain. The default is the `cluster.local` domain.",
           "type": "string"
@@ -1496,41 +488,181 @@
           "type": "object",
           "additionalProperties": false
         },
-        "mail": {
-          "description": "mail specifies the settings that control the SMTP server and account used when an alert triggers an email action.",
+        "listeners": {
+          "description": "listeners specify the listeners configurations.",
           "properties": {
-            "authentication": {
-              "description": "authentication specifies the authentication for SMTP. SMP only supports basic authentication. For other types of authentication, use the config overrides capability.",
+            "controller": {
+              "description": "controller specifies the controller listener.",
               "properties": {
-                "basic": {
-                  "description": "basic specifies the configuration for basic authentication.",
+                "authentication": {
+                  "description": "authentication specifies the authentication configuration for the listener.",
                   "properties": {
-                    "debug": {
-                      "description": "debug enables the basic authentication debug logs for JaaS configuration.",
-                      "type": "boolean"
+                    "jaasConfig": {
+                      "description": "jaasConfig specifies the JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
+                    "jaasConfigPassThrough": {
+                      "description": "jaasConfigPassThrough specifies another way to provide JaaS configuration. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "properties": {
+                        "directoryPathInContainer": {
+                          "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "principalMappingRules": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "type": {
+                      "description": "type specifies the Kafka or Zookeeper authentication type. Valid options are `plain`, `digest`, `mtls`, and `ldap`.",
+                      "enum": [
+                        "plain",
+                        "digest",
+                        "mtls",
+                        "ldap"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
                     "directoryPathInContainer": {
-                      "description": "directoryPathInContainer allows to pass the basic credential through a directory path in the container. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
                       "minLength": 1,
                       "type": "string"
                     },
-                    "restrictedRoles": {
-                      "description": "restrictedRoles specify the restricted roles on the server side only. Changes will be only reflected in Control Center. This configuration is ignored on the client side configuration.",
-                      "items": {
-                        "type": "string"
-                      },
-                      "minItems": 1,
-                      "type": "array"
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
                     },
-                    "roles": {
-                      "description": "roles specify the roles on the server side only. This configuration is ignored on the client side configuration.",
-                      "items": {
-                        "type": "string"
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
                       },
-                      "type": "array"
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
                     },
                     "secretRef": {
-                      "description": "secretRef defines secret reference to pass the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html#basic-authentication",
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "metricReporter": {
+          "description": "metricsReporter specifies the configuration of the metric reporter. The metric reporter is enabled by default. If authentication and TLS are not set, the metrics reporter uses internal listener's authentication and TLS .",
+          "properties": {
+            "authentication": {
+              "description": "authentication specifies the Kafka client-side authentication configuration.",
+              "properties": {
+                "jaasConfig": {
+                  "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jaasConfigPassThrough": {
+                  "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "oauthbearer": {
+                  "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
                       "maxLength": 30,
                       "minLength": 1,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
@@ -1541,9 +673,11 @@
                   "additionalProperties": false
                 },
                 "type": {
-                  "description": "type specifies the authentication scheme for the REST API client. Valid options are `basic` and `mtls`.",
+                  "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
                   "enum": [
-                    "basic",
+                    "plain",
+                    "oauthbearer",
+                    "digest",
                     "mtls"
                   ],
                   "type": "string"
@@ -1555,37 +689,69 @@
               "type": "object",
               "additionalProperties": false
             },
-            "checkServerIdentity": {
-              "description": "checkServerIdentity forces validation of server\u2019s certificate when using STARTTLS or SSL.",
+            "bootstrapEndpoint": {
+              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled specifies whether to enable or disable the metric reporter.",
               "type": "boolean"
             },
-            "hostname": {
-              "description": "hostname is the hostname of the outgoing SMTP server.",
-              "minLength": 1,
-              "type": "string"
-            },
-            "mailBounceAddress": {
-              "description": "mailBounceAddress is the override for the `mailFrom` config to send message.",
-              "minLength": 1,
-              "type": "string"
-            },
-            "mailFrom": {
-              "description": "mailFrom is the originating address for emails sent from the Control Center.",
-              "minLength": 1,
-              "type": "string"
-            },
-            "port": {
-              "description": "port is the SMTP port open on the hostname.",
+            "replicationFactor": {
+              "description": "replicationFactor specifies the number of replicas in the metric topic.",
               "format": "int32",
               "type": "integer"
             },
-            "startTLSRequired": {
-              "description": "startTLSRequired forces using STARTTLS.",
-              "type": "boolean"
+            "tls": {
+              "description": "tls specifies the Kafka client-side TLS configuration.",
+              "properties": {
+                "directoryPathInContainer": {
+                  "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "enabled": {
+                  "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "ignoreTrustStoreConfig": {
+                  "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                  "type": "boolean"
+                },
+                "jksPassword": {
+                  "description": "jksPassword references the secret containing the JKS password.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "secretRef": {
+                  "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                  "maxLength": 30,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "enabled"
+              ],
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "required": [
-            "hostname"
+            "enabled"
           ],
           "type": "object",
           "additionalProperties": false
@@ -1735,179 +901,6 @@
           },
           "type": "object",
           "additionalProperties": false
-        },
-        "monitoringKafkaClusters": {
-          "description": "monitoringKafkaClusters specify the configurations for the Kafka clusters that this Control Center monitors.",
-          "items": {
-            "description": "MonitoringKafkaClusters defines the configuration of the additional Kafka clusters the Control Center monitors.",
-            "properties": {
-              "authentication": {
-                "description": "authentication defines the authentication for the Kafka cluster.",
-                "properties": {
-                  "jaasConfig": {
-                    "description": "jaasConfig specifies the Kafka client-side JaaS configuration.",
-                    "properties": {
-                      "secretRef": {
-                        "description": "secretRef references the secret containing the required credentials. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "secretRef"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "jaasConfigPassThrough": {
-                    "description": "jaasConfigPassThrough specifies another way to provide the Kafka client-side JaaS configuration.",
-                    "properties": {
-                      "directoryPathInContainer": {
-                        "description": "directoryPathInContainer specifies the directory path in the container where required credentials are mounted. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "secretRef": {
-                        "description": "secretRef references the secret containing the required credentials for authentication. More info: https://docs.confluent.io/operator/current/co-authenticate.html",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "oauthbearer": {
-                    "description": "oauthbearer is the authentication mechanism to provider principals. Only supported in RBAC deployment.",
-                    "properties": {
-                      "directoryPathInContainer": {
-                        "description": "directoryPathInContainer specifies the directory path in the container where the credential is mounted.",
-                        "minLength": 1,
-                        "type": "string"
-                      },
-                      "secretRef": {
-                        "description": "secretRef specifies the name of the secret that contains the credential. More info: https://docs.confluent.io/operator/current/co-authenticate.html#bearer-authentication",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "type": {
-                    "description": "type specifies the Kafka client authentication type. Valid options are `plain`, `oauthbearer`, `digest`, and `mtls`.",
-                    "enum": [
-                      "plain",
-                      "oauthbearer",
-                      "digest",
-                      "mtls"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "type"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "bootstrapEndpoint": {
-                "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
-                "minLength": 1,
-                "pattern": ".+:[0-9]+",
-                "type": "string"
-              },
-              "discovery": {
-                "description": "discovery specifies the capability to discover the Kafka cluster.",
-                "properties": {
-                  "name": {
-                    "description": "name is the name of the Confluent Platform component cluster.",
-                    "type": "string"
-                  },
-                  "namespace": {
-                    "description": "namespace is where the Confluent Platform component is running. The default value is the namespace where CFK is running.",
-                    "type": "string"
-                  },
-                  "secretRef": {
-                    "description": "secretRef is the name of the secret used to discover the Confluent Platform component.",
-                    "maxLength": 30,
-                    "minLength": 1,
-                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              },
-              "name": {
-                "description": "name defines the Kafka cluster name.",
-                "minLength": 1,
-                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                "type": "string"
-              },
-              "tls": {
-                "description": "tls defines the client-side TLS setting for the Kafka cluster.",
-                "properties": {
-                  "directoryPathInContainer": {
-                    "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
-                    "minLength": 1,
-                    "type": "string"
-                  },
-                  "enabled": {
-                    "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
-                    "type": "boolean"
-                  },
-                  "ignoreTrustStoreConfig": {
-                    "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
-                    "type": "boolean"
-                  },
-                  "jksPassword": {
-                    "description": "jksPassword references the secret containing the JKS password.",
-                    "properties": {
-                      "secretRef": {
-                        "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                        "maxLength": 30,
-                        "minLength": 1,
-                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "secretRef"
-                    ],
-                    "type": "object",
-                    "additionalProperties": false
-                  },
-                  "secretRef": {
-                    "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
-                    "maxLength": 30,
-                    "minLength": 1,
-                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "enabled"
-                ],
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "required": [
-              "name"
-            ],
-            "type": "object",
-            "additionalProperties": false
-          },
-          "type": "array"
         },
         "mountedSecrets": {
           "description": "mountedSecrets list the secrets injected to the underlying statefulset configuration. The secret reference is mounted in the default path `/mnt/secrets/<secret-name>`. The underlying resources will follow the secret as a file configuration. More info: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod. A change to this setting will roll the cluster.",
@@ -3371,10 +2364,6 @@
           "type": "object",
           "additionalProperties": false
         },
-        "name": {
-          "description": "name is the Control Center cluster name.",
-          "type": "string"
-        },
         "oneReplicaPerNode": {
           "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
           "type": "boolean"
@@ -4705,7 +3694,7 @@
           "type": "integer"
         },
         "storageClass": {
-          "description": "storageClass references the user-provided storage class.",
+          "description": "storageClass specifies the user-provided storage class. If not configured, it will use the default storage class.",
           "properties": {
             "name": {
               "description": "name is the storage class name.",
@@ -4732,7 +3721,7 @@
           "additionalProperties": false
         },
         "tls": {
-          "description": "tls specifies the TLS configurations.",
+          "description": "tls specifies the global-level TLS configuration which can be used by listeners and services.",
           "properties": {
             "autoGeneratedCerts": {
               "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
@@ -4785,7 +3774,7 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "status defines the observed state of the Control Center cluster.",
+      "description": "status defines the observed state of the KRaft Controller cluster.",
       "properties": {
         "arbitraryData": {
           "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
@@ -4793,6 +3782,15 @@
         },
         "authorizationType": {
           "description": "authorizationType is the authorization type for this Confluent component.",
+          "type": "string"
+        },
+        "brokerIdOffset": {
+          "description": "brokerIdOffset is the broker id offset of the KRaft Controller cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "clusterID": {
+          "description": "clusterID is the ID of the KRaft Controller cluster.",
           "type": "string"
         },
         "clusterName": {
@@ -4840,17 +3838,32 @@
           },
           "type": "array"
         },
-        "controlCenterName": {
-          "description": "name is the name of the Control Center cluster.",
-          "type": "string"
+        "controllerQuorumVoters": {
+          "description": "controllerQuorumVoters is the list KRaft Controller Quorum Voters.",
+          "items": {
+            "description": "ControllerQuorumVoter defines the KRaft controller quorum voter.",
+            "properties": {
+              "brokerEndpoint": {
+                "description": "brokerEndpoint is the endpoint of the KRaft Controller.",
+                "type": "string"
+              },
+              "nodeId": {
+                "description": "nodeId is the nodeId of the KRaft Controller.",
+                "format": "int32",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "brokerEndpoint",
+              "nodeId"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
         },
         "currentReplicas": {
           "description": "currentReplicas is the number of currently running replicas.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "id": {
-          "description": "id is the identifier of the Control Center cluster.",
           "format": "int32",
           "type": "integer"
         },
@@ -4868,25 +3881,6 @@
           },
           "type": "array"
         },
-        "kafka": {
-          "description": "kafka is the Kafka client side status for the Control Center cluster.",
-          "properties": {
-            "authenticationType": {
-              "description": "authenticationType describes the authentication method for the Kafka cluster.",
-              "type": "string"
-            },
-            "bootstrapEndpoint": {
-              "description": "bootstrapEndpoint specifies the Kafka bootstrap endpoint.",
-              "type": "string"
-            },
-            "tls": {
-              "description": "tls indicates whether TLS is enabled for the Kafka dependency.",
-              "type": "boolean"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
         "observedGeneration": {
           "description": "observedGeneration is the most recent generation observed for this Confluent component.",
           "format": "int64",
@@ -4900,24 +3894,6 @@
           "description": "phase describes the state of the Confluent Platform component. This can either be 'PROVISIONING' or 'RUNNING' 'PROVISIONING' means the Confluent Platform component is currently getting deployed and not ready yet. 'RUNNING' means the Confluent Platform component has been successfully deployed.",
           "type": "string"
         },
-        "rbac": {
-          "description": "rbac contains the RBAC-related status when RBAC is enabled.",
-          "properties": {
-            "clusterID": {
-              "description": "clusterID specifies the id of the cluster.",
-              "type": "string"
-            },
-            "internalRolebindings": {
-              "description": "internalRolebindings specifies the internal rolebindings.",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
-        },
         "readyReplicas": {
           "description": "readyReplicas is the number of currently ready replicas.",
           "format": "int32",
@@ -4927,40 +3903,6 @@
           "description": "replicas is the number of replicas.",
           "format": "int32",
           "type": "integer"
-        },
-        "restConfig": {
-          "description": "restConfig is the REST API configuration of the Control Center cluster.",
-          "properties": {
-            "advertisedExternalEndpoints": {
-              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "authenticationType": {
-              "description": "authenticationType shows the authentication type configured by the listener.",
-              "type": "string"
-            },
-            "externalAccessType": {
-              "description": "externalAccessType shows the external access type used for the listener.",
-              "type": "string"
-            },
-            "externalEndpoint": {
-              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
-              "type": "string"
-            },
-            "internalEndpoint": {
-              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
-              "type": "string"
-            },
-            "tls": {
-              "description": "tls shows whether TLS is configured for the listener.",
-              "type": "boolean"
-            }
-          },
-          "type": "object",
-          "additionalProperties": false
         },
         "selector": {
           "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",

--- a/platform.confluent.io/ksqldb_v1beta1.json
+++ b/platform.confluent.io/ksqldb_v1beta1.json
@@ -820,6 +820,14 @@
                   "pattern": "^https?://.*",
                   "type": "string"
                 },
+                "ssoProtocol": {
+                  "description": "sso protocol, valid options are ldap and oidc.",
+                  "enum": [
+                    "ldap",
+                    "oidc"
+                  ],
+                  "type": "string"
+                },
                 "tls": {
                   "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
                   "properties": {
@@ -874,6 +882,10 @@
                       "description": "directoryPathInContainer defines the directory path in the container where the MDS token key pair are mounted.",
                       "minLength": 1,
                       "type": "string"
+                    },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
                     },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",
@@ -1019,20 +1031,20 @@
           "additionalProperties": false
         },
         "externalAccess": {
-          "description": "externalAccess specifies the configurations for the endpoints and services to make the ksqlDB accessible from outside the cluster.",
+          "description": "externalAccess specifies the configurations for the endpoints and services to make the ksqlDB accessible from outside the cluster. When `spec.listeners` is configured, configuring `spec.externalAccess` is not allowed. Please configure `spec.listeners.external.externalAccess` instead\".",
           "properties": {
             "loadBalancer": {
               "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
               "properties": {
                 "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1179,11 +1191,11 @@
                   "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -1316,6 +1328,25 @@
             "route": {
               "description": "route specifies the configuration to create a route service in OpenShift.",
               "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
@@ -1481,6 +1512,502 @@
               "minLength": 1,
               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
               "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "listeners": {
+          "description": "listeners specify the listeners configurations.",
+          "properties": {
+            "external": {
+              "description": "external specifies the Confluent component external listener.",
+              "properties": {
+                "externalAccess": {
+                  "description": "externalAccess defines the external access configuration for the Confluent component.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "port": {
+                          "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "prefix": {
+                          "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create a route service in OpenShift.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "prefix": {
+                          "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route"
+                      ],
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "internal": {
+              "description": "internal specifies the Confluent component's internal listener. This internal listener is for intra-communication between the pods.",
+              "properties": {
+                "port": {
+                  "description": "port binds the given port to the internal listener. If not configured, it will be defaulted to the component-specific internal port. Port numbers lower than `9093` are reserved by CFK.",
+                  "format": "int32",
+                  "minimum": 9093,
+                  "type": "integer"
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -4451,7 +4978,7 @@
           "additionalProperties": false
         },
         "tls": {
-          "description": "tls specifies the TLS configurations for the ksqlDB cluster.",
+          "description": "tls specifies the global TLS configurations for the ksqlDB cluster.",
           "properties": {
             "autoGeneratedCerts": {
               "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
@@ -4596,6 +5123,45 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "listeners": {
+          "additionalProperties": {
+            "description": "ListenerStatus describes general information about the listeners.",
+            "properties": {
+              "advertisedExternalEndpoints": {
+                "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "authenticationType": {
+                "description": "authenticationType shows the authentication type configured by the listener.",
+                "type": "string"
+              },
+              "externalAccessType": {
+                "description": "externalAccessType shows the external access type used for the listener.",
+                "type": "string"
+              },
+              "externalEndpoint": {
+                "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "internalEndpoint": {
+                "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "tls shows whether TLS is configured for the listener.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "listeners is a map of listener type and the status of KsqlDB Listeners.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
         },
         "observedGeneration": {
           "description": "observedGeneration is the most recent generation observed for this Confluent component.",

--- a/platform.confluent.io/schema_v1beta1.json
+++ b/platform.confluent.io/schema_v1beta1.json
@@ -53,12 +53,25 @@
           "type": "object",
           "additionalProperties": false
         },
+        "mode": {
+          "description": "Mode specifies the schema registry mode for the schemas under the specified subject. Valid options are `IMPORT`, `READONLY`, `READWRITE`.",
+          "enum": [
+            "IMPORT",
+            "READONLY",
+            "READWRITE"
+          ],
+          "type": "string"
+        },
         "name": {
           "description": "name specifies the subject name of schema. If not configured, the Schema CR name is used as the subject name.",
           "maxLength": 255,
           "minLength": 1,
           "pattern": "^[^\\\\]*$",
           "type": "string"
+        },
+        "normalize": {
+          "description": "Normalize specifies whether to normalize the schema at the time of registering to schema registry. more info: https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#schema-normalization",
+          "type": "boolean"
         },
         "schemaReferences": {
           "description": "schemaReferences defines the schema references in the schema data.",
@@ -367,6 +380,14 @@
           "description": "id is the id of the latest schema for the subject.",
           "format": "int32",
           "type": "integer"
+        },
+        "mode": {
+          "description": "Mode specifies the operating mode of schema under the subject.",
+          "type": "string"
+        },
+        "normalize": {
+          "description": "Normalize specifies whether schema has been normalized at the time of registering.",
+          "type": "boolean"
         },
         "observedGeneration": {
           "description": "observedGeneration is the most recent generation observed for this Confluent component.",

--- a/platform.confluent.io/schemaregistry_v1beta1.json
+++ b/platform.confluent.io/schemaregistry_v1beta1.json
@@ -344,6 +344,14 @@
                   "pattern": "^https?://.*",
                   "type": "string"
                 },
+                "ssoProtocol": {
+                  "description": "sso protocol, valid options are ldap and oidc.",
+                  "enum": [
+                    "ldap",
+                    "oidc"
+                  ],
+                  "type": "string"
+                },
                 "tls": {
                   "description": "ClientTLSConfig specifies the TLS configuration for the Confluent component (dependencies, listeners).",
                   "properties": {
@@ -399,6 +407,10 @@
                       "minLength": 1,
                       "type": "string"
                     },
+                    "encryptedTokenKey": {
+                      "description": "EncryptedTokenKey boolean value indicating whether the tokenKeypair(private used for signing) is encrypted using a passphrase. If true, cfk operator will look for a file named mdsTokenKeyPassphrase.txt containing key value pair mdsTokenKeyPassphrase=<passphrase>. Relevant only for mds server. Ignored if set for a client configuration.",
+                      "type": "boolean"
+                    },
                     "secretRef": {
                       "description": "secretRef references the name of the secret that contains the MDS token key pair.",
                       "maxLength": 30,
@@ -428,20 +440,20 @@
           "type": "boolean"
         },
         "externalAccess": {
-          "description": "externalAccess specifies the external access configuration.",
+          "description": "externalAccess specifies the external access configuration. When `spec.listeners` is configured, configuring `spec.externalAccess` is not allowed. Please configure `spec.listeners.external.externalAccess` instead\".",
           "properties": {
             "loadBalancer": {
               "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
               "properties": {
                 "advertisedURL": {
-                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -588,11 +600,11 @@
                   "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
                   "properties": {
                     "enabled": {
-                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker.",
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
                       "type": "boolean"
                     },
                     "prefix": {
-                      "description": "prefix specifies the broker prefix for MDS advertised endpoint if using loadBalancer external access. If not configured, it uses `b` as default prefix, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`.",
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
                       "minLength": 1,
                       "type": "string"
                     }
@@ -725,6 +737,25 @@
             "route": {
               "description": "route specifies the configuration to create a route service in OpenShift.",
               "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
                 "annotations": {
                   "additionalProperties": {
                     "type": "string"
@@ -891,6 +922,502 @@
               "minLength": 1,
               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
               "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "listeners": {
+          "description": "listeners specify the listeners configurations.",
+          "properties": {
+            "external": {
+              "description": "external specifies the Confluent component external listener.",
+              "properties": {
+                "externalAccess": {
+                  "description": "externalAccess defines the external access configuration for the Confluent component.",
+                  "properties": {
+                    "loadBalancer": {
+                      "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain is the domain name of the component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "loadBalancerSourceRanges": {
+                          "description": "loadBalancerSourceRanges specify the source ranges.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "port": {
+                          "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                          "format": "int32",
+                          "type": "integer"
+                        },
+                        "prefix": {
+                          "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify the user-provided service port(s).",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "nodePort": {
+                      "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "externalTrafficPolicy": {
+                          "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                          "enum": [
+                            "Local",
+                            "Cluster"
+                          ],
+                          "type": "string"
+                        },
+                        "host": {
+                          "description": "host defines the host name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "nodePortOffset": {
+                          "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                          "format": "int32",
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "servicePorts": {
+                          "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                          "items": {
+                            "description": "ServicePort contains information on service's port.",
+                            "properties": {
+                              "appProtocol": {
+                                "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                                "type": "string"
+                              },
+                              "nodePort": {
+                                "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "port": {
+                                "description": "The port that will be exposed by this service.",
+                                "format": "int32",
+                                "type": "integer"
+                              },
+                              "protocol": {
+                                "default": "TCP",
+                                "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                                "type": "string"
+                              },
+                              "targetPort": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "required": [
+                              "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "sessionAffinity": {
+                          "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                          "enum": [
+                            "ClientIP",
+                            "None"
+                          ],
+                          "type": "string"
+                        },
+                        "sessionAffinityConfig": {
+                          "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                          "properties": {
+                            "clientIP": {
+                              "description": "clientIP contains the configurations of Client IP based session affinity.",
+                              "properties": {
+                                "timeoutSeconds": {
+                                  "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                                  "format": "int32",
+                                  "type": "integer"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "host",
+                        "nodePortOffset"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "route": {
+                      "description": "route specifies the configuration to create a route service in OpenShift.",
+                      "properties": {
+                        "advertisedURL": {
+                          "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                          "properties": {
+                            "enabled": {
+                              "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                              "type": "boolean"
+                            },
+                            "prefix": {
+                              "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "enabled"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "domain": {
+                          "description": "domain specifies the domain name of the Confluent component cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                          "type": "object",
+                          "x-kubernetes-map-type": "granular"
+                        },
+                        "prefix": {
+                          "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "wildcardPolicy": {
+                          "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                          "enum": [
+                            "Subdomain",
+                            "None"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "domain"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": {
+                      "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+                      "enum": [
+                        "loadBalancer",
+                        "nodePort",
+                        "route"
+                      ],
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "internal": {
+              "description": "internal specifies the Confluent component's internal listener. This internal listener is for intra-communication between the pods.",
+              "properties": {
+                "port": {
+                  "description": "port binds the given port to the internal listener. If not configured, it will be defaulted to the component-specific internal port. Port numbers lower than `9093` are reserved by CFK.",
+                  "format": "int32",
+                  "minimum": 9093,
+                  "type": "integer"
+                },
+                "tls": {
+                  "description": "tls specifies the TLS configuration for the listener.",
+                  "properties": {
+                    "directoryPathInContainer": {
+                      "description": "directoryPathInContainer specifies the directory path in the container where `keystore.jks`, `truststore.jks`, and `jksPassword.txt` keys are mounted. `truststore.jks` is not configured and can be ignored when the `ignoreTrustStoreConfig` field is set to `true`.",
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "enabled specifies to enable the TLS configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "ignoreTrustStoreConfig": {
+                      "description": "ignoreTrustStoreConfig indicates whether to ignore the truststore configuration for the Confluent component.",
+                      "type": "boolean"
+                    },
+                    "jksPassword": {
+                      "description": "jksPassword references the secret containing the JKS password.",
+                      "properties": {
+                        "secretRef": {
+                          "description": "secretRef references the name of the secret containing the JKS password. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                          "maxLength": 30,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "secretRef"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "secretRef": {
+                      "description": "secretRef references the secret containing the certificates. More info: https://docs.confluent.io/operator/current/co-network-encryption.html#configure-user-provided-tls-certificates",
+                      "maxLength": 30,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
             }
           },
           "type": "object",
@@ -3863,7 +4390,7 @@
           "additionalProperties": false
         },
         "tls": {
-          "description": "tls specifies the TLS configurations for the REST API endpoint.",
+          "description": "tls specifies the global TLS configurations for the REST API endpoint.",
           "properties": {
             "autoGeneratedCerts": {
               "description": "autoGeneratedCerts specifies that the certificates are auto-generated based on the CA key pair provided.",
@@ -4011,6 +4538,45 @@
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "listeners": {
+          "additionalProperties": {
+            "description": "ListenerStatus describes general information about the listeners.",
+            "properties": {
+              "advertisedExternalEndpoints": {
+                "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "authenticationType": {
+                "description": "authenticationType shows the authentication type configured by the listener.",
+                "type": "string"
+              },
+              "externalAccessType": {
+                "description": "externalAccessType shows the external access type used for the listener.",
+                "type": "string"
+              },
+              "externalEndpoint": {
+                "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "internalEndpoint": {
+                "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+                "type": "string"
+              },
+              "tls": {
+                "description": "tls shows whether TLS is configured for the listener.",
+                "type": "boolean"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "description": "listeners is a map of listener type and the status of Schema Registry Listeners.",
+          "type": "object",
+          "x-kubernetes-map-type": "granular"
         },
         "metricPrefix": {
           "description": "metricPrefix is the prefix for the JMX metric of the Schema Registry cluster.",

--- a/platform.confluent.io/zookeeper_v1beta1.json
+++ b/platform.confluent.io/zookeeper_v1beta1.json
@@ -125,6 +125,381 @@
           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
           "x-kubernetes-int-or-string": true
         },
+        "externalAccess": {
+          "description": "externalAccess specifies the external access configuration. Should only be specified when Zookeeper peers are on another network.",
+          "properties": {
+            "loadBalancer": {
+              "description": "loadBalancer specifies the configuration to create a Kubernetes load balancer service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix><podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain is the domain name of the component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "loadBalancerSourceRanges": {
+                  "description": "loadBalancerSourceRanges specify the source ranges.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "port": {
+                  "description": "port specifies the external port for the client consumption. If not configured, the same internal/external port is configured for the component. Information about the port can be retrieved through the status API.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "prefix": {
+                  "description": "prefix specify the prefix for the given domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify the user-provided service port(s).",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "nodePort": {
+              "description": "nodePort specifies the configuration to create a Kubernetes node port service.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to `<httpSchema>://<host>:<nodePortOffset + podId + 1>, where`podId` starts from `0` to `replicaCount - 1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "externalTrafficPolicy": {
+                  "description": "externalTrafficPolicy specifies the external traffic policy for the service. Valid options are `Local` and `Cluster`.",
+                  "enum": [
+                    "Local",
+                    "Cluster"
+                  ],
+                  "type": "string"
+                },
+                "host": {
+                  "description": "host defines the host name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "nodePortOffset": {
+                  "description": "nodePortOffset specifies the starting offset of the node ports. The port numbers go in ascending order with respect to the replicas count. NodePort service creation fails if the node port is not in the range supported by the Kubernetes API server. The default Kubernetes Node Port range is `30000` - `32762`.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "servicePorts": {
+                  "description": "servicePorts specify user-provided service port(s). For Kafka with the nodePort type, this setting is only applied to Kafka bootstrap service.",
+                  "items": {
+                    "description": "ServicePort contains information on service's port.",
+                    "properties": {
+                      "appProtocol": {
+                        "description": "The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.",
+                        "type": "string"
+                      },
+                      "nodePort": {
+                        "description": "The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "port": {
+                        "description": "The port that will be exposed by this service.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "default": "TCP",
+                        "description": "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+                        "type": "string"
+                      },
+                      "targetPort": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "sessionAffinity": {
+                  "description": "sessionAffinity defines the Kubernetes session affinity. The valid options are `ClientIP` and `None`. `ClientIP` enables the client IP-based session affinity. The default value is `None`. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies.",
+                  "enum": [
+                    "ClientIP",
+                    "None"
+                  ],
+                  "type": "string"
+                },
+                "sessionAffinityConfig": {
+                  "description": "SessionAffinityConfig contains the configurations of the session affinity.",
+                  "properties": {
+                    "clientIP": {
+                      "description": "clientIP contains the configurations of Client IP based session affinity.",
+                      "properties": {
+                        "timeoutSeconds": {
+                          "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
+                          "format": "int32",
+                          "type": "integer"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "host",
+                "nodePortOffset"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "route": {
+              "description": "route specifies the configuration to create a route service in OpenShift.",
+              "properties": {
+                "advertisedURL": {
+                  "description": "advertisedURL specifies the configuration for advertised listener per pod. It is only supported for MDS currently. If it is enabled, instead of using internal endpoint, the MDS advertised listener for each broker will be set to: `<httpSchema>://<advertisedUrl.prefix>-http-external<podId>.<domain>` where podId starts from `0` to `replicaCount -1`. This is only recommended if you cannot add internal SANs to the TLS certificates for MDS and the external DNS must be resolved inside the Kubernetes cluster. This configuration will not take effect if MDS enabled dual listener setup.",
+                  "properties": {
+                    "enabled": {
+                      "description": "enabled indicates whether to set the MDS advertised listener url with external endpoint for each broker. Has no effect with Zookeeper, which will always create a listener per pod.",
+                      "type": "boolean"
+                    },
+                    "prefix": {
+                      "description": "prefix specifies the broker prefix for MDS/Zookeeper advertised endpoint. If not configured, it uses `b` as default prefix for MDS, such as `b#.domain` where `#` will start from `0` to `replicaCount -1`. It uses 'zookeeper' as default prefix for Zookeeper in the same way.",
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enabled"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "annotations is a map of string key and value pairs. It specifies Kubernetes annotations for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "domain": {
+                  "description": "domain specifies the domain name of the Confluent component cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "labels is a map of string key and value pairs. It specifies Kubernetes labels for this service.",
+                  "type": "object",
+                  "x-kubernetes-map-type": "granular"
+                },
+                "prefix": {
+                  "description": "prefix specifies the component prefix when configured for the domain. The default value is the name of the cluster.",
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "wildcardPolicy": {
+                  "description": "wildcardPolicy allows you to define a route that covers all hosts within a domain. Valid options are `Subdomain` and `None`. The default value is `None`.",
+                  "enum": [
+                    "Subdomain",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "domain"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "type": {
+              "description": "type specifies the Kubernetes external service for the component. Valid options are `loadBalancer`, `nodePort`, and `route`.",
+              "enum": [
+                "loadBalancer",
+                "nodePort",
+                "route"
+              ],
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
         "headlessService": {
           "description": "headlessService specifies the configuration of the Kubernetes headless service.",
           "properties": {
@@ -1857,6 +2232,13 @@
           "description": "oneReplicaPerNode controls whether to run 1 pod per node using the pod anti-affinity capability. Enabling this configuration in an existing cluster will roll the cluster.",
           "type": "boolean"
         },
+        "peers": {
+          "description": "peers specify a list of dynamic peer configurations for the Zookeeper cluster. This is only required when deploying stretch Zookeeper for MRC deployments and should include all the Zookeeper peers in other DCs that form the ensemble. This will either add or update the existing configuration.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "podTemplate": {
           "description": "podTemplate specifies the statefulset pod template configuration.",
           "properties": {
@@ -3259,10 +3641,6 @@
           "description": "arbitraryData is the map for any arbitrary data associated with this Confluent component.",
           "x-kubernetes-preserve-unknown-fields": true
         },
-        "authenticationType": {
-          "description": "authenticationType is the authentication method for the Zookeeper cluster.",
-          "type": "string"
-        },
         "authorizationType": {
           "description": "authorizationType is the authorization type for this Confluent component.",
           "type": "string"
@@ -3317,10 +3695,6 @@
           "format": "int32",
           "type": "integer"
         },
-        "endpoint": {
-          "description": "endpoint is the Zookeeper cluster endpoint.",
-          "type": "string"
-        },
         "internalSecrets": {
           "description": "internalSecrets are internal secrets created by CFK for this Confluent component.",
           "items": {
@@ -3363,13 +3737,43 @@
           "format": "int32",
           "type": "integer"
         },
+        "restConfig": {
+          "description": "restConfig is the REST API configuration of the Zookeeper cluster.",
+          "properties": {
+            "advertisedExternalEndpoints": {
+              "description": "advertisedExternalEndpoints specifies other advertised endpoints used, especially for Kafka.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "authenticationType": {
+              "description": "authenticationType shows the authentication type configured by the listener.",
+              "type": "string"
+            },
+            "externalAccessType": {
+              "description": "externalAccessType shows the external access type used for the listener.",
+              "type": "string"
+            },
+            "externalEndpoint": {
+              "description": "externalEndpoint specifies the external endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "internalEndpoint": {
+              "description": "internalEndpoint specifies the internal endpoint to connect to the Confluent component cluster.",
+              "type": "string"
+            },
+            "tls": {
+              "description": "tls shows whether TLS is configured for the listener.",
+              "type": "boolean"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "selector": {
           "description": "selector gets the label selector of the child pod. The Horizontal Pod Autoscaler(HPA) will scale using the label selector of the child pod.",
           "type": "string"
-        },
-        "tls": {
-          "description": "tls shows whether TLS is configured for the Zookeeper cluster.",
-          "type": "boolean"
         }
       },
       "type": "object",


### PR DESCRIPTION
This PR updates all the `platform.confluent.io` CRDs to their latest versions. The `apiVersion` is still `v1beta1` for all of the CRDs as can also be found [here](https://docs.confluent.io/operator/current/co-api.html).

The `KRaftController` resource is new, the others only received backwards compatible changes it seems.