### PR TITLE
update cloud.google.com

### DIFF
--- a/cloud.google.com/backendconfig_v1.json
+++ b/cloud.google.com/backendconfig_v1.json
@@ -174,6 +174,20 @@
           "type": "object",
           "additionalProperties": false
         },
+        "customResponseHeaders": {
+          "description": "CustomResponseHeadersConfig contains configuration for custom response headers",
+          "properties": {
+            "headers": {
+              "items": {
+                "default": "",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
         "healthCheck": {
           "description": "HealthCheckConfig contains configuration for the health check.",
           "properties": {
@@ -284,7 +298,7 @@
           "additionalProperties": false
         },
         "sessionAffinity": {
-          "description": "SessionAffinityConfig contains configuration for stickyness parameters.",
+          "description": "SessionAffinityConfig contains configuration for stickiness parameters.",
           "properties": {
             "affinityCookieTtlSec": {
               "format": "int64",

--- a/cloud.google.com/backendconfig_v1beta1.json
+++ b/cloud.google.com/backendconfig_v1beta1.json
@@ -182,7 +182,7 @@
           "additionalProperties": false
         },
         "sessionAffinity": {
-          "description": "SessionAffinityConfig contains configuration for stickyness parameters.",
+          "description": "SessionAffinityConfig contains configuration for stickiness parameters.",
           "properties": {
             "affinityCookieTtlSec": {
               "format": "int64",


### PR DESCRIPTION
We had some issue because `customRequestHeaders` was missing in the schema.
https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration

Here is an update with `crd-extractor.sh` from some GKE cluster I have running.
