### PR TITLE
feat(argocd): update schemas for the 2.9.0 release

### DIFF
--- a/argoproj.io/application_v1alpha1.json
+++ b/argoproj.io/application_v1alpha1.json
@@ -332,6 +332,13 @@
                       "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                       "type": "object"
                     },
+                    "components": {
+                      "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "forceCommonAnnotations": {
                       "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                       "type": "boolean"
@@ -359,6 +366,55 @@
                     "namespace": {
                       "description": "Namespace sets the namespace that Kustomize adds to all resources",
                       "type": "string"
+                    },
+                    "patches": {
+                      "description": "Patches is a list of Kustomize patches",
+                      "items": {
+                        "properties": {
+                          "options": {
+                            "additionalProperties": {
+                              "type": "boolean"
+                            },
+                            "type": "object"
+                          },
+                          "patch": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "annotationSelector": {
+                                "type": "string"
+                              },
+                              "group": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "labelSelector": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
                     },
                     "replicas": {
                       "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -681,6 +737,13 @@
                         "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                         "type": "object"
                       },
+                      "components": {
+                        "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "forceCommonAnnotations": {
                         "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                         "type": "boolean"
@@ -708,6 +771,55 @@
                       "namespace": {
                         "description": "Namespace sets the namespace that Kustomize adds to all resources",
                         "type": "string"
+                      },
+                      "patches": {
+                        "description": "Patches is a list of Kustomize patches",
+                        "items": {
+                          "properties": {
+                            "options": {
+                              "additionalProperties": {
+                                "type": "boolean"
+                              },
+                              "type": "object"
+                            },
+                            "patch": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "properties": {
+                                "annotationSelector": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "labelSelector": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "replicas": {
                         "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -1170,6 +1282,13 @@
                   "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                   "type": "object"
                 },
+                "components": {
+                  "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
                 "forceCommonAnnotations": {
                   "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                   "type": "boolean"
@@ -1197,6 +1316,55 @@
                 "namespace": {
                   "description": "Namespace sets the namespace that Kustomize adds to all resources",
                   "type": "string"
+                },
+                "patches": {
+                  "description": "Patches is a list of Kustomize patches",
+                  "items": {
+                    "properties": {
+                      "options": {
+                        "additionalProperties": {
+                          "type": "boolean"
+                        },
+                        "type": "object"
+                      },
+                      "patch": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "properties": {
+                          "annotationSelector": {
+                            "type": "string"
+                          },
+                          "group": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "labelSelector": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
                 },
                 "replicas": {
                   "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -1519,6 +1687,13 @@
                     "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                     "type": "object"
                   },
+                  "components": {
+                    "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
                   "forceCommonAnnotations": {
                     "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                     "type": "boolean"
@@ -1546,6 +1721,55 @@
                   "namespace": {
                     "description": "Namespace sets the namespace that Kustomize adds to all resources",
                     "type": "string"
+                  },
+                  "patches": {
+                    "description": "Patches is a list of Kustomize patches",
+                    "items": {
+                      "properties": {
+                        "options": {
+                          "additionalProperties": {
+                            "type": "boolean"
+                          },
+                          "type": "object"
+                        },
+                        "patch": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "target": {
+                          "properties": {
+                            "annotationSelector": {
+                              "type": "string"
+                            },
+                            "group": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
                   },
                   "replicas": {
                     "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -2041,6 +2265,13 @@
                         "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                         "type": "object"
                       },
+                      "components": {
+                        "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "forceCommonAnnotations": {
                         "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                         "type": "boolean"
@@ -2068,6 +2299,55 @@
                       "namespace": {
                         "description": "Namespace sets the namespace that Kustomize adds to all resources",
                         "type": "string"
+                      },
+                      "patches": {
+                        "description": "Patches is a list of Kustomize patches",
+                        "items": {
+                          "properties": {
+                            "options": {
+                              "additionalProperties": {
+                                "type": "boolean"
+                              },
+                              "type": "object"
+                            },
+                            "patch": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "properties": {
+                                "annotationSelector": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "labelSelector": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "replicas": {
                         "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -2390,6 +2670,13 @@
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
                         },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                           "type": "boolean"
@@ -2417,6 +2704,55 @@
                         "namespace": {
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
+                        },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -2892,6 +3228,13 @@
                               "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                               "type": "object"
                             },
+                            "components": {
+                              "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "forceCommonAnnotations": {
                               "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                               "type": "boolean"
@@ -2919,6 +3262,55 @@
                             "namespace": {
                               "description": "Namespace sets the namespace that Kustomize adds to all resources",
                               "type": "string"
+                            },
+                            "patches": {
+                              "description": "Patches is a list of Kustomize patches",
+                              "items": {
+                                "properties": {
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "patch": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "target": {
+                                    "properties": {
+                                      "annotationSelector": {
+                                        "type": "string"
+                                      },
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "labelSelector": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "replicas": {
                               "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -3241,6 +3633,13 @@
                                 "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                                 "type": "object"
                               },
+                              "components": {
+                                "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
                               "forceCommonAnnotations": {
                                 "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                                 "type": "boolean"
@@ -3268,6 +3667,55 @@
                               "namespace": {
                                 "description": "Namespace sets the namespace that Kustomize adds to all resources",
                                 "type": "string"
+                              },
+                              "patches": {
+                                "description": "Patches is a list of Kustomize patches",
+                                "items": {
+                                  "properties": {
+                                    "options": {
+                                      "additionalProperties": {
+                                        "type": "boolean"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "patch": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "properties": {
+                                        "annotationSelector": {
+                                          "type": "string"
+                                        },
+                                        "group": {
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "labelSelector": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "version": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
                               },
                               "replicas": {
                                 "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -3739,6 +4187,13 @@
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
                         },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                           "type": "boolean"
@@ -3766,6 +4221,55 @@
                         "namespace": {
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
+                        },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -4088,6 +4592,13 @@
                             "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                             "type": "object"
                           },
+                          "components": {
+                            "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "forceCommonAnnotations": {
                             "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                             "type": "boolean"
@@ -4115,6 +4626,55 @@
                           "namespace": {
                             "description": "Namespace sets the namespace that Kustomize adds to all resources",
                             "type": "string"
+                          },
+                          "patches": {
+                            "description": "Patches is a list of Kustomize patches",
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -4620,6 +5180,13 @@
                           "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                           "type": "object"
                         },
+                        "components": {
+                          "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                           "type": "boolean"
@@ -4647,6 +5214,55 @@
                         "namespace": {
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
+                        },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -4969,6 +5585,13 @@
                             "description": "CommonLabels is a list of additional labels to add to rendered manifests",
                             "type": "object"
                           },
+                          "components": {
+                            "description": "Components specifies a list of kustomize components to add to the kustomization before building",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "forceCommonAnnotations": {
                             "description": "ForceCommonAnnotations specifies whether to force applying common annotations to resources for Kustomize apps",
                             "type": "boolean"
@@ -4996,6 +5619,55 @@
                           "namespace": {
                             "description": "Namespace sets the namespace that Kustomize adds to all resources",
                             "type": "string"
+                          },
+                          "patches": {
+                            "description": "Patches is a list of Kustomize patches",
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "description": "Replicas is a list of Kustomize Replicas override specifications",

--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -343,6 +343,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -363,6 +369,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -633,6 +687,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -653,6 +713,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -1180,6 +1288,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -1200,6 +1314,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -1470,6 +1632,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -1490,6 +1658,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -2023,6 +2239,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -2043,6 +2265,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -2313,6 +2583,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -2333,6 +2609,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -2833,6 +3157,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -2853,6 +3183,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -3123,6 +3501,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -3143,6 +3527,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -3679,6 +4111,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -3699,6 +4137,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -3969,6 +4455,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -3989,6 +4481,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -4516,6 +5056,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -4536,6 +5082,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -4806,6 +5400,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -4826,6 +5426,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -5359,6 +6007,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -5379,6 +6033,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -5649,6 +6351,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -5669,6 +6377,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -6169,6 +6925,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -6189,6 +6951,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -6459,6 +7269,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -6479,6 +7295,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -6997,6 +7861,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -7017,6 +7887,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -7287,6 +8205,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -7307,6 +8231,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -8109,6 +9081,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -8129,6 +9107,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -8399,6 +9425,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -8419,6 +9451,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -8922,6 +10002,9 @@
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "topic": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
@@ -9211,6 +10294,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -9231,6 +10320,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -9501,6 +10638,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -9521,6 +10664,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -10049,6 +11240,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -10069,6 +11266,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -10339,6 +11584,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -10359,6 +11610,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -10895,6 +12194,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -10915,6 +12220,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -11185,6 +12538,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -11205,6 +12564,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -11732,6 +13139,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -11752,6 +13165,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -12022,6 +13483,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -12042,6 +13509,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -12575,6 +14090,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -12595,6 +14116,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -12865,6 +14434,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -12885,6 +14460,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -13385,6 +15008,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -13405,6 +15034,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -13675,6 +15352,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -13695,6 +15378,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -14213,6 +15944,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -14233,6 +15970,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -14503,6 +16288,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -14523,6 +16314,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -15325,6 +17164,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -15345,6 +17190,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -15615,6 +17508,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -15635,6 +17534,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -16138,6 +18085,9 @@
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "topic": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
@@ -16427,6 +18377,12 @@
                                               },
                                               "type": "object"
                                             },
+                                            "components": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            },
                                             "forceCommonAnnotations": {
                                               "type": "boolean"
                                             },
@@ -16447,6 +18403,54 @@
                                             },
                                             "namespace": {
                                               "type": "string"
+                                            },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
                                             },
                                             "replicas": {
                                               "items": {
@@ -16717,6 +18721,12 @@
                                                 },
                                                 "type": "object"
                                               },
+                                              "components": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
                                               "forceCommonAnnotations": {
                                                 "type": "boolean"
                                               },
@@ -16737,6 +18747,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -17271,6 +19329,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -17291,6 +19355,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -17561,6 +19673,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -17581,6 +19699,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -18094,6 +20260,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -18114,6 +20286,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -18384,6 +20604,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -18404,6 +20630,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -19206,6 +21480,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -19226,6 +21506,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -19496,6 +21824,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -19516,6 +21850,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -20019,6 +22401,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "topic": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -20308,6 +22693,12 @@
                                     },
                                     "type": "object"
                                   },
+                                  "components": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
                                   "forceCommonAnnotations": {
                                     "type": "boolean"
                                   },
@@ -20328,6 +22719,54 @@
                                   },
                                   "namespace": {
                                     "type": "string"
+                                  },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
                                   },
                                   "replicas": {
                                     "items": {
@@ -20598,6 +23037,12 @@
                                       },
                                       "type": "object"
                                     },
+                                    "components": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
                                     "forceCommonAnnotations": {
                                       "type": "boolean"
                                     },
@@ -20618,6 +23063,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -20878,9 +23371,39 @@
           },
           "type": "array"
         },
+        "ignoreApplicationDifferences": {
+          "items": {
+            "properties": {
+              "jqPathExpressions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "jsonPointers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "preservedFields": {
           "properties": {
             "annotations": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labels": {
               "items": {
                 "type": "string"
               },
@@ -21241,6 +23764,12 @@
                           },
                           "type": "object"
                         },
+                        "components": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "forceCommonAnnotations": {
                           "type": "boolean"
                         },
@@ -21261,6 +23790,54 @@
                         },
                         "namespace": {
                           "type": "string"
+                        },
+                        "patches": {
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "replicas": {
                           "items": {
@@ -21531,6 +24108,12 @@
                             },
                             "type": "object"
                           },
+                          "components": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "forceCommonAnnotations": {
                             "type": "boolean"
                           },
@@ -21551,6 +24134,54 @@
                           },
                           "namespace": {
                             "type": "string"
+                          },
+                          "patches": {
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "items": {


### PR DESCRIPTION
3 days ago argocd released 2.9.0: https://github.com/argoproj/argo-cd/releases/tag/v2.9.0 which included some changes to the CRDS: kustomize patches, and a new ignoreApplicationDifferences field: https://github.com/argoproj/argo-cd/issues/5114 and https://github.com/argoproj/argo-cd/issues/9101

2 days ago the argo-helm repo updated their charts to deploy version 2.9.0 of Argo CD: https://github.com/argoproj/argo-helm/pull/2318

Today I had a build fail in my CI system that uses kubeconform against this repo's schemas.

I updated the CRDs using the provided script.