### PR TITLE
Update to latest CRD

### DIFF
--- a/vault.banzaicloud.com/vault_v1alpha1.json
+++ b/vault.banzaicloud.com/vault_v1alpha1.json
@@ -40,8 +40,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -65,15 +64,13 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "weight": {
                         "format": "int32",
@@ -84,8 +81,7 @@
                       "preference",
                       "weight"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -114,8 +110,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -139,15 +134,13 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "type": "array"
                     }
@@ -156,12 +149,10 @@
                     "nodeSelectorTerms"
                   ],
                   "type": "object",
-                  "x-kubernetes-map-type": "atomic",
-                  "additionalProperties": false
+                  "x-kubernetes-map-type": "atomic"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "podAffinity": {
               "properties": {
@@ -192,8 +183,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -205,8 +195,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -230,8 +219,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -243,8 +231,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -259,8 +246,7 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "weight": {
                         "format": "int32",
@@ -271,8 +257,7 @@
                       "podAffinityTerm",
                       "weight"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -301,8 +286,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -314,8 +298,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "namespaceSelector": {
                         "properties": {
@@ -339,8 +322,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -352,8 +334,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "namespaces": {
                         "items": {
@@ -368,14 +349,12 @@
                     "required": [
                       "topologyKey"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "podAntiAffinity": {
               "properties": {
@@ -406,8 +385,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -419,8 +397,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -444,8 +421,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -457,8 +433,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -473,8 +448,7 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "weight": {
                         "format": "int32",
@@ -485,8 +459,7 @@
                       "podAffinityTerm",
                       "weight"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -515,8 +488,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -528,8 +500,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "namespaceSelector": {
                         "properties": {
@@ -553,8 +524,7 @@
                                 "key",
                                 "operator"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -566,8 +536,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "namespaces": {
                         "items": {
@@ -582,18 +551,15 @@
                     "required": [
                       "topologyKey"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "annotations": {
           "additionalProperties": {
@@ -630,8 +596,7 @@
               "mountPath",
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -661,8 +626,7 @@
             "path",
             "secretName"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "envsConfig": {
           "items": {
@@ -691,8 +655,7 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "fieldRef": {
                     "properties": {
@@ -707,8 +670,7 @@
                       "fieldPath"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "resourceFieldRef": {
                     "properties": {
@@ -735,8 +697,7 @@
                       "resource"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -754,19 +715,16 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -823,8 +781,7 @@
                         "name"
                       ],
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     },
                     "service": {
                       "properties": {
@@ -841,19 +798,16 @@
                               "type": "integer"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "ingressClassName": {
                   "type": "string"
@@ -888,8 +842,7 @@
                                         "name"
                                       ],
                                       "type": "object",
-                                      "x-kubernetes-map-type": "atomic",
-                                      "additionalProperties": false
+                                      "x-kubernetes-map-type": "atomic"
                                     },
                                     "service": {
                                       "properties": {
@@ -906,19 +859,16 @@
                                               "type": "integer"
                                             }
                                           },
-                                          "type": "object",
-                                          "additionalProperties": false
+                                          "type": "object"
                                         }
                                       },
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     }
                                   },
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "path": {
                                   "type": "string"
@@ -931,8 +881,7 @@
                                 "backend",
                                 "pathType"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array",
                             "x-kubernetes-list-type": "atomic"
@@ -941,12 +890,10 @@
                         "required": [
                           "paths"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
@@ -965,19 +912,16 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-type": "atomic"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "istioEnabled": {
           "type": "boolean"
@@ -1012,8 +956,7 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -1037,15 +980,13 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "weight": {
                     "format": "int32",
@@ -1056,8 +997,7 @@
                   "preference",
                   "weight"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -1086,8 +1026,7 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -1111,15 +1050,13 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "type": "array"
                 }
@@ -1128,12 +1065,10 @@
                 "nodeSelectorTerms"
               ],
               "type": "object",
-              "x-kubernetes-map-type": "atomic",
-              "additionalProperties": false
+              "x-kubernetes-map-type": "atomic"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "nodeSelector": {
           "additionalProperties": {
@@ -1161,8 +1096,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -1201,8 +1135,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "fluentd": {
               "properties": {
@@ -1216,8 +1149,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -1256,8 +1188,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "hsmDaemon": {
               "properties": {
@@ -1271,8 +1202,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -1311,8 +1241,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "prometheusExporter": {
               "properties": {
@@ -1326,8 +1255,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -1366,8 +1294,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "vault": {
               "properties": {
@@ -1381,8 +1308,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -1421,12 +1347,10 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "securityContext": {
           "properties": {
@@ -1463,8 +1387,7 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "seccompProfile": {
               "properties": {
@@ -1478,8 +1401,7 @@
               "required": [
                 "type"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "supplementalGroups": {
               "items": {
@@ -1502,8 +1424,7 @@
                   "name",
                   "value"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -1522,12 +1443,10 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "serviceAccount": {
           "type": "string"
@@ -1575,8 +1494,7 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "fieldRef": {
                     "properties": {
@@ -1591,8 +1509,7 @@
                       "fieldPath"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "resourceFieldRef": {
                     "properties": {
@@ -1619,8 +1536,7 @@
                       "resource"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -1638,19 +1554,16 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -1696,8 +1609,7 @@
                 "type": "string"
               }
             },
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -1728,8 +1640,7 @@
                 "ossEndpoint",
                 "ossPrefix"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "aws": {
               "properties": {
@@ -1760,8 +1671,7 @@
                 "s3Bucket",
                 "s3Prefix"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "azure": {
               "properties": {
@@ -1772,8 +1682,7 @@
               "required": [
                 "keyVaultName"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "google": {
               "properties": {
@@ -1800,8 +1709,7 @@
                 "kmsProject",
                 "storageBucket"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "hsm": {
               "properties": {
@@ -1829,8 +1737,7 @@
                 "modulePath",
                 "pin"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "kubernetes": {
               "properties": {
@@ -1841,8 +1748,7 @@
                   "type": "string"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "options": {
               "properties": {
@@ -1859,8 +1765,7 @@
                   "type": "boolean"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "vault": {
               "properties": {
@@ -1887,12 +1792,10 @@
                 "address",
                 "unsealKeysPath"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "vaultAnnotations": {
           "additionalProperties": {
@@ -1947,8 +1850,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -1972,15 +1874,13 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "weight": {
                             "format": "int32",
@@ -1991,8 +1891,7 @@
                           "preference",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -2021,8 +1920,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2046,15 +1944,13 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "type": "array"
                         }
@@ -2063,12 +1959,10 @@
                         "nodeSelectorTerms"
                       ],
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "podAffinity": {
                   "properties": {
@@ -2099,8 +1993,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -2112,8 +2005,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2137,8 +2029,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -2150,8 +2041,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
@@ -2166,8 +2056,7 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "weight": {
                             "format": "int32",
@@ -2178,8 +2067,7 @@
                           "podAffinityTerm",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -2208,8 +2096,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2221,8 +2108,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -2246,8 +2132,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2259,8 +2144,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -2275,14 +2159,12 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "podAntiAffinity": {
                   "properties": {
@@ -2313,8 +2195,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -2326,8 +2207,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -2351,8 +2231,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -2364,8 +2243,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
@@ -2380,8 +2258,7 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "weight": {
                             "format": "int32",
@@ -2392,8 +2269,7 @@
                           "podAffinityTerm",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -2422,8 +2298,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2435,8 +2310,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -2460,8 +2334,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2473,8 +2346,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -2489,18 +2361,15 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "automountServiceAccountToken": {
               "type": "boolean"
@@ -2547,8 +2416,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -2563,8 +2431,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -2591,8 +2458,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -2610,19 +2476,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -2639,8 +2502,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -2655,12 +2517,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -2683,8 +2543,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -2705,8 +2564,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2731,8 +2589,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -2754,12 +2611,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -2772,8 +2627,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -2794,8 +2648,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -2820,8 +2673,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -2843,16 +2695,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -2865,8 +2714,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -2885,8 +2733,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -2907,8 +2754,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -2933,8 +2779,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -2968,8 +2813,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -2980,8 +2824,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -3011,8 +2854,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -3032,8 +2874,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -3052,8 +2893,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -3074,8 +2914,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -3100,8 +2939,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -3135,8 +2973,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -3147,8 +2984,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -3164,8 +3000,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -3182,8 +3017,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -3222,8 +3056,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -3245,8 +3078,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -3283,8 +3115,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -3298,8 +3129,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -3316,12 +3146,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -3334,8 +3162,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -3354,8 +3181,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -3376,8 +3202,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -3402,8 +3227,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -3437,8 +3261,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -3449,8 +3272,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -3481,8 +3303,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -3512,8 +3333,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -3524,8 +3344,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -3547,8 +3366,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -3559,8 +3377,7 @@
                   "type": "array"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "dnsPolicy": {
               "type": "string"
@@ -3610,8 +3427,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -3626,8 +3442,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -3654,8 +3469,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -3673,19 +3487,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -3702,8 +3513,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -3718,12 +3528,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -3746,8 +3554,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -3768,8 +3575,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -3794,8 +3600,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -3817,12 +3622,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -3835,8 +3638,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -3857,8 +3659,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -3883,8 +3684,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -3906,16 +3706,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -3928,8 +3725,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -3948,8 +3744,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -3970,8 +3765,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -3996,8 +3790,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -4031,8 +3824,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -4043,8 +3835,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -4074,8 +3865,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -4095,8 +3885,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -4115,8 +3904,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -4137,8 +3925,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -4163,8 +3950,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -4198,8 +3984,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -4210,8 +3995,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -4227,8 +4011,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -4245,8 +4028,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -4285,8 +4067,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -4308,8 +4089,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -4346,8 +4126,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -4361,8 +4140,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -4379,12 +4157,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -4397,8 +4173,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -4417,8 +4192,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -4439,8 +4213,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -4465,8 +4238,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -4500,8 +4272,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -4512,8 +4283,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -4547,8 +4317,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -4578,8 +4347,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -4590,8 +4358,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -4608,8 +4375,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -4636,8 +4402,7 @@
                   }
                 },
                 "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
+                "x-kubernetes-map-type": "atomic"
               },
               "type": "array"
             },
@@ -4683,8 +4448,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -4699,8 +4463,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -4727,8 +4490,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -4746,19 +4508,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -4775,8 +4534,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -4791,12 +4549,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -4819,8 +4575,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -4841,8 +4596,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -4867,8 +4621,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -4890,12 +4643,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -4908,8 +4659,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -4930,8 +4680,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -4956,8 +4705,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -4979,16 +4727,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -5001,8 +4746,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -5021,8 +4765,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -5043,8 +4786,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -5069,8 +4811,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -5104,8 +4845,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -5116,8 +4856,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -5147,8 +4886,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -5168,8 +4906,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -5188,8 +4925,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -5210,8 +4946,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -5236,8 +4971,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -5271,8 +5005,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -5283,8 +5016,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -5300,8 +5032,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -5318,8 +5049,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -5358,8 +5088,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -5381,8 +5110,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -5419,8 +5147,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -5434,8 +5161,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -5452,12 +5178,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -5470,8 +5194,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -5490,8 +5213,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -5512,8 +5234,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -5538,8 +5259,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -5573,8 +5293,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -5585,8 +5304,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -5617,8 +5335,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -5648,8 +5365,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -5660,8 +5376,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -5684,8 +5399,7 @@
               "required": [
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "overhead": {
               "additionalProperties": {
@@ -5722,8 +5436,7 @@
                 "required": [
                   "conditionType"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -5742,15 +5455,13 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -5777,8 +5488,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -5821,8 +5531,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "seccompProfile": {
                   "properties": {
@@ -5836,8 +5545,7 @@
                   "required": [
                     "type"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "supplementalGroups": {
                   "items": {
@@ -5860,8 +5568,7 @@
                       "name",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -5880,12 +5587,10 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "serviceAccount": {
               "type": "string"
@@ -5926,8 +5631,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -5956,8 +5660,7 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -5969,8 +5672,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "matchLabelKeys": {
                     "items": {
@@ -6005,8 +5707,7 @@
                   "topologyKey",
                   "whenUnsatisfiable"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -6037,8 +5738,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "azureDisk": {
                     "properties": {
@@ -6065,8 +5765,7 @@
                       "diskName",
                       "diskURI"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "azureFile": {
                     "properties": {
@@ -6084,8 +5783,7 @@
                       "secretName",
                       "shareName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "cephfs": {
                     "properties": {
@@ -6111,8 +5809,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "user": {
                         "type": "string"
@@ -6121,8 +5818,7 @@
                     "required": [
                       "monitors"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "cinder": {
                     "properties": {
@@ -6139,8 +5835,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "volumeID": {
                         "type": "string"
@@ -6149,8 +5844,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "configMap": {
                     "properties": {
@@ -6176,8 +5870,7 @@
                             "key",
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -6189,8 +5882,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "csi": {
                     "properties": {
@@ -6207,8 +5899,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "readOnly": {
                         "type": "boolean"
@@ -6223,8 +5914,7 @@
                     "required": [
                       "driver"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "downwardAPI": {
                     "properties": {
@@ -6248,8 +5938,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "mode": {
                               "format": "int32",
@@ -6283,21 +5972,18 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
                           "required": [
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "emptyDir": {
                     "properties": {
@@ -6317,8 +6003,7 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "ephemeral": {
                     "properties": {
@@ -6352,8 +6037,7 @@
                                   "name"
                                 ],
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "dataSourceRef": {
                                 "properties": {
@@ -6374,8 +6058,7 @@
                                   "kind",
                                   "name"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "resources": {
                                 "properties": {
@@ -6389,8 +6072,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -6429,8 +6111,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "selector": {
                                 "properties": {
@@ -6454,8 +6135,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -6467,8 +6147,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "storageClassName": {
                                 "type": "string"
@@ -6480,19 +6159,16 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "spec"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "fc": {
                     "properties": {
@@ -6519,8 +6195,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "flexVolume": {
                     "properties": {
@@ -6546,15 +6221,13 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       }
                     },
                     "required": [
                       "driver"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "flocker": {
                     "properties": {
@@ -6565,8 +6238,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "gcePersistentDisk": {
                     "properties": {
@@ -6587,8 +6259,7 @@
                     "required": [
                       "pdName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "gitRepo": {
                     "properties": {
@@ -6605,8 +6276,7 @@
                     "required": [
                       "repository"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "glusterfs": {
                     "properties": {
@@ -6624,8 +6294,7 @@
                       "endpoints",
                       "path"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "hostPath": {
                     "properties": {
@@ -6639,8 +6308,7 @@
                     "required": [
                       "path"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "iscsi": {
                     "properties": {
@@ -6682,8 +6350,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "targetPortal": {
                         "type": "string"
@@ -6694,8 +6361,7 @@
                       "lun",
                       "targetPortal"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -6716,8 +6382,7 @@
                       "path",
                       "server"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "persistentVolumeClaim": {
                     "properties": {
@@ -6731,8 +6396,7 @@
                     "required": [
                       "claimName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "photonPersistentDisk": {
                     "properties": {
@@ -6746,8 +6410,7 @@
                     "required": [
                       "pdID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "portworxVolume": {
                     "properties": {
@@ -6764,8 +6427,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "projected": {
                     "properties": {
@@ -6796,8 +6458,7 @@
                                       "key",
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 },
@@ -6809,8 +6470,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "downwardAPI": {
                               "properties": {
@@ -6830,8 +6490,7 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "mode": {
                                         "format": "int32",
@@ -6865,21 +6524,18 @@
                                           "resource"
                                         ],
                                         "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     },
                                     "required": [
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "secret": {
                               "properties": {
@@ -6901,8 +6557,7 @@
                                       "key",
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 },
@@ -6914,8 +6569,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "serviceAccountToken": {
                               "properties": {
@@ -6933,18 +6587,15 @@
                               "required": [
                                 "path"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "quobyte": {
                     "properties": {
@@ -6971,8 +6622,7 @@
                       "registry",
                       "volume"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "rbd": {
                     "properties": {
@@ -7004,8 +6654,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "user": {
                         "type": "string"
@@ -7015,8 +6664,7 @@
                       "image",
                       "monitors"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "scaleIO": {
                     "properties": {
@@ -7039,8 +6687,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "sslEnabled": {
                         "type": "boolean"
@@ -7063,8 +6710,7 @@
                       "secretRef",
                       "system"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "secret": {
                     "properties": {
@@ -7090,8 +6736,7 @@
                             "key",
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -7102,8 +6747,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "storageos": {
                     "properties": {
@@ -7120,8 +6764,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "volumeName": {
                         "type": "string"
@@ -7130,8 +6773,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "vsphereVolume": {
                     "properties": {
@@ -7151,21 +6793,18 @@
                     "required": [
                       "volumePath"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "vaultContainerSpec": {
           "properties": {
@@ -7208,8 +6847,7 @@
                           "key"
                         ],
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "fieldRef": {
                         "properties": {
@@ -7224,8 +6862,7 @@
                           "fieldPath"
                         ],
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "resourceFieldRef": {
                         "properties": {
@@ -7252,8 +6889,7 @@
                           "resource"
                         ],
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "secretKeyRef": {
                         "properties": {
@@ -7271,19 +6907,16 @@
                           "key"
                         ],
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -7300,8 +6933,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "prefix": {
                     "type": "string"
@@ -7316,12 +6948,10 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -7344,8 +6974,7 @@
                           "type": "array"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "httpGet": {
                       "properties": {
@@ -7366,8 +6995,7 @@
                               "name",
                               "value"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "type": "array"
                         },
@@ -7392,8 +7020,7 @@
                       "required": [
                         "port"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "tcpSocket": {
                       "properties": {
@@ -7415,12 +7042,10 @@
                       "required": [
                         "port"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "preStop": {
                   "properties": {
@@ -7433,8 +7058,7 @@
                           "type": "array"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "httpGet": {
                       "properties": {
@@ -7455,8 +7079,7 @@
                               "name",
                               "value"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "type": "array"
                         },
@@ -7481,8 +7104,7 @@
                       "required": [
                         "port"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "tcpSocket": {
                       "properties": {
@@ -7504,16 +7126,13 @@
                       "required": [
                         "port"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "livenessProbe": {
               "properties": {
@@ -7526,8 +7145,7 @@
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "failureThreshold": {
                   "format": "int32",
@@ -7546,8 +7164,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "httpGet": {
                   "properties": {
@@ -7568,8 +7185,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -7594,8 +7210,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "initialDelaySeconds": {
                   "format": "int32",
@@ -7629,8 +7244,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "terminationGracePeriodSeconds": {
                   "format": "int64",
@@ -7641,8 +7255,7 @@
                   "type": "integer"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "name": {
               "type": "string"
@@ -7672,8 +7285,7 @@
                 "required": [
                   "containerPort"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -7693,8 +7305,7 @@
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "failureThreshold": {
                   "format": "int32",
@@ -7713,8 +7324,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "httpGet": {
                   "properties": {
@@ -7735,8 +7345,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -7761,8 +7370,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "initialDelaySeconds": {
                   "format": "int32",
@@ -7796,8 +7404,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "terminationGracePeriodSeconds": {
                   "format": "int64",
@@ -7808,8 +7415,7 @@
                   "type": "integer"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "resizePolicy": {
               "items": {
@@ -7825,8 +7431,7 @@
                   "resourceName",
                   "restartPolicy"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-type": "atomic"
@@ -7843,8 +7448,7 @@
                     "required": [
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array",
                   "x-kubernetes-list-map-keys": [
@@ -7883,8 +7487,7 @@
                   "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "securityContext": {
               "properties": {
@@ -7906,8 +7509,7 @@
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "privileged": {
                   "type": "boolean"
@@ -7944,8 +7546,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "seccompProfile": {
                   "properties": {
@@ -7959,8 +7560,7 @@
                   "required": [
                     "type"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "windowsOptions": {
                   "properties": {
@@ -7977,12 +7577,10 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "startupProbe": {
               "properties": {
@@ -7995,8 +7593,7 @@
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "failureThreshold": {
                   "format": "int32",
@@ -8015,8 +7612,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "httpGet": {
                   "properties": {
@@ -8037,8 +7633,7 @@
                           "name",
                           "value"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -8063,8 +7658,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "initialDelaySeconds": {
                   "format": "int32",
@@ -8098,8 +7692,7 @@
                   "required": [
                     "port"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "terminationGracePeriodSeconds": {
                   "format": "int64",
@@ -8110,8 +7703,7 @@
                   "type": "integer"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "stdin": {
               "type": "boolean"
@@ -8142,8 +7734,7 @@
                   "devicePath",
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -8173,8 +7764,7 @@
                   "mountPath",
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -8185,8 +7775,7 @@
           "required": [
             "name"
           ],
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "vaultContainers": {
           "items": {
@@ -8230,8 +7819,7 @@
                             "key"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "fieldRef": {
                           "properties": {
@@ -8246,8 +7834,7 @@
                             "fieldPath"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "resourceFieldRef": {
                           "properties": {
@@ -8274,8 +7861,7 @@
                             "resource"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "secretKeyRef": {
                           "properties": {
@@ -8293,19 +7879,16 @@
                             "key"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -8322,8 +7905,7 @@
                         }
                       },
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     },
                     "prefix": {
                       "type": "string"
@@ -8338,12 +7920,10 @@
                         }
                       },
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -8366,8 +7946,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -8388,8 +7967,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -8414,8 +7992,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "tcpSocket": {
                         "properties": {
@@ -8437,12 +8014,10 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "preStop": {
                     "properties": {
@@ -8455,8 +8030,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -8477,8 +8051,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -8503,8 +8076,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "tcpSocket": {
                         "properties": {
@@ -8526,16 +8098,13 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "livenessProbe": {
                 "properties": {
@@ -8548,8 +8117,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -8568,8 +8136,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -8590,8 +8157,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -8616,8 +8182,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -8651,8 +8216,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -8663,8 +8227,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "name": {
                 "type": "string"
@@ -8694,8 +8257,7 @@
                   "required": [
                     "containerPort"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array",
                 "x-kubernetes-list-map-keys": [
@@ -8715,8 +8277,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -8735,8 +8296,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -8757,8 +8317,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -8783,8 +8342,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -8818,8 +8376,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -8830,8 +8387,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "resizePolicy": {
                 "items": {
@@ -8847,8 +8403,7 @@
                     "resourceName",
                     "restartPolicy"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array",
                 "x-kubernetes-list-type": "atomic"
@@ -8865,8 +8420,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -8905,8 +8459,7 @@
                     "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "securityContext": {
                 "properties": {
@@ -8928,8 +8481,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "privileged": {
                     "type": "boolean"
@@ -8966,8 +8518,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "seccompProfile": {
                     "properties": {
@@ -8981,8 +8532,7 @@
                     "required": [
                       "type"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "windowsOptions": {
                     "properties": {
@@ -8999,12 +8549,10 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "startupProbe": {
                 "properties": {
@@ -9017,8 +8565,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -9037,8 +8584,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -9059,8 +8605,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -9085,8 +8630,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -9120,8 +8664,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -9132,8 +8675,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "stdin": {
                 "type": "boolean"
@@ -9164,8 +8706,7 @@
                     "devicePath",
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -9195,8 +8736,7 @@
                     "mountPath",
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -9207,8 +8747,7 @@
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -9239,8 +8778,7 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "fieldRef": {
                     "properties": {
@@ -9255,8 +8793,7 @@
                       "fieldPath"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "resourceFieldRef": {
                     "properties": {
@@ -9283,8 +8820,7 @@
                       "resource"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "secretKeyRef": {
                     "properties": {
@@ -9302,19 +8838,16 @@
                       "key"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -9360,8 +8893,7 @@
                             "key"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "fieldRef": {
                           "properties": {
@@ -9376,8 +8908,7 @@
                             "fieldPath"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "resourceFieldRef": {
                           "properties": {
@@ -9404,8 +8935,7 @@
                             "resource"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "secretKeyRef": {
                           "properties": {
@@ -9423,19 +8953,16 @@
                             "key"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     }
                   },
                   "required": [
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -9452,8 +8979,7 @@
                         }
                       },
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     },
                     "prefix": {
                       "type": "string"
@@ -9468,12 +8994,10 @@
                         }
                       },
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -9496,8 +9020,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -9518,8 +9041,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -9544,8 +9066,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "tcpSocket": {
                         "properties": {
@@ -9567,12 +9088,10 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "preStop": {
                     "properties": {
@@ -9585,8 +9104,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -9607,8 +9125,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -9633,8 +9150,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "tcpSocket": {
                         "properties": {
@@ -9656,16 +9172,13 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "livenessProbe": {
                 "properties": {
@@ -9678,8 +9191,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -9698,8 +9210,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -9720,8 +9231,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -9746,8 +9256,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -9781,8 +9290,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -9793,8 +9301,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "name": {
                 "type": "string"
@@ -9824,8 +9331,7 @@
                   "required": [
                     "containerPort"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array",
                 "x-kubernetes-list-map-keys": [
@@ -9845,8 +9351,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -9865,8 +9370,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -9887,8 +9391,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -9913,8 +9416,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -9948,8 +9450,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -9960,8 +9461,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "resizePolicy": {
                 "items": {
@@ -9977,8 +9477,7 @@
                     "resourceName",
                     "restartPolicy"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array",
                 "x-kubernetes-list-type": "atomic"
@@ -9995,8 +9494,7 @@
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -10035,8 +9533,7 @@
                     "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "securityContext": {
                 "properties": {
@@ -10058,8 +9555,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "privileged": {
                     "type": "boolean"
@@ -10096,8 +9592,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "seccompProfile": {
                     "properties": {
@@ -10111,8 +9606,7 @@
                     "required": [
                       "type"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "windowsOptions": {
                     "properties": {
@@ -10129,12 +9623,10 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "startupProbe": {
                 "properties": {
@@ -10147,8 +9639,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "failureThreshold": {
                     "format": "int32",
@@ -10167,8 +9658,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "httpGet": {
                     "properties": {
@@ -10189,8 +9679,7 @@
                             "name",
                             "value"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -10215,8 +9704,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "initialDelaySeconds": {
                     "format": "int32",
@@ -10250,8 +9738,7 @@
                     "required": [
                       "port"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "terminationGracePeriodSeconds": {
                     "format": "int64",
@@ -10262,8 +9749,7 @@
                     "type": "integer"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "stdin": {
                 "type": "boolean"
@@ -10294,8 +9780,7 @@
                     "devicePath",
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -10325,8 +9810,7 @@
                     "mountPath",
                     "name"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "type": "array"
               },
@@ -10337,8 +9821,7 @@
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -10383,8 +9866,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10408,15 +9890,13 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "weight": {
                             "format": "int32",
@@ -10427,8 +9907,7 @@
                           "preference",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -10457,8 +9936,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10482,15 +9960,13 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "type": "array"
                         }
@@ -10499,12 +9975,10 @@
                         "nodeSelectorTerms"
                       ],
                       "type": "object",
-                      "x-kubernetes-map-type": "atomic",
-                      "additionalProperties": false
+                      "x-kubernetes-map-type": "atomic"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "podAffinity": {
                   "properties": {
@@ -10535,8 +10009,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -10548,8 +10021,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -10573,8 +10045,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -10586,8 +10057,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
@@ -10602,8 +10072,7 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "weight": {
                             "format": "int32",
@@ -10614,8 +10083,7 @@
                           "podAffinityTerm",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -10644,8 +10112,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10657,8 +10124,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -10682,8 +10148,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10695,8 +10160,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -10711,14 +10175,12 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "podAntiAffinity": {
                   "properties": {
@@ -10749,8 +10211,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -10762,8 +10223,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "properties": {
@@ -10787,8 +10247,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -10800,8 +10259,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "namespaces": {
                                 "items": {
@@ -10816,8 +10274,7 @@
                             "required": [
                               "topologyKey"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "weight": {
                             "format": "int32",
@@ -10828,8 +10285,7 @@
                           "podAffinityTerm",
                           "weight"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     },
@@ -10858,8 +10314,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10871,8 +10326,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaceSelector": {
                             "properties": {
@@ -10896,8 +10350,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -10909,8 +10362,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "namespaces": {
                             "items": {
@@ -10925,18 +10377,15 @@
                         "required": [
                           "topologyKey"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "type": "array"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "automountServiceAccountToken": {
               "type": "boolean"
@@ -10983,8 +10432,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -10999,8 +10447,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -11027,8 +10474,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -11046,19 +10492,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -11075,8 +10518,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -11091,12 +10533,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -11119,8 +10559,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -11141,8 +10580,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -11167,8 +10605,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -11190,12 +10627,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -11208,8 +10643,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -11230,8 +10664,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -11256,8 +10689,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -11279,16 +10711,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -11301,8 +10730,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -11321,8 +10749,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -11343,8 +10770,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -11369,8 +10795,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -11404,8 +10829,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -11416,8 +10840,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -11447,8 +10870,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -11468,8 +10890,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -11488,8 +10909,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -11510,8 +10930,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -11536,8 +10955,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -11571,8 +10989,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -11583,8 +11000,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -11600,8 +11016,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -11618,8 +11033,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -11658,8 +11072,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -11681,8 +11094,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -11719,8 +11131,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -11734,8 +11145,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -11752,12 +11162,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -11770,8 +11178,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -11790,8 +11197,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -11812,8 +11218,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -11838,8 +11243,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -11873,8 +11277,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -11885,8 +11288,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -11917,8 +11319,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -11948,8 +11349,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -11960,8 +11360,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -11983,8 +11382,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -11995,8 +11393,7 @@
                   "type": "array"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "dnsPolicy": {
               "type": "string"
@@ -12046,8 +11443,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -12062,8 +11458,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -12090,8 +11485,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -12109,19 +11503,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -12138,8 +11529,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -12154,12 +11544,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -12182,8 +11570,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -12204,8 +11591,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -12230,8 +11616,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -12253,12 +11638,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -12271,8 +11654,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -12293,8 +11675,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -12319,8 +11700,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -12342,16 +11722,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -12364,8 +11741,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -12384,8 +11760,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -12406,8 +11781,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -12432,8 +11806,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -12467,8 +11840,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -12479,8 +11851,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -12510,8 +11881,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -12531,8 +11901,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -12551,8 +11920,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -12573,8 +11941,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -12599,8 +11966,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -12634,8 +12000,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -12646,8 +12011,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -12663,8 +12027,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -12681,8 +12044,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -12721,8 +12083,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -12744,8 +12105,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -12782,8 +12142,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -12797,8 +12156,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -12815,12 +12173,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -12833,8 +12189,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -12853,8 +12208,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -12875,8 +12229,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -12901,8 +12254,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -12936,8 +12288,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -12948,8 +12299,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -12983,8 +12333,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -13014,8 +12363,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -13026,8 +12374,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -13044,8 +12391,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -13072,8 +12418,7 @@
                   }
                 },
                 "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
+                "x-kubernetes-map-type": "atomic"
               },
               "type": "array"
             },
@@ -13119,8 +12464,7 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "fieldRef": {
                               "properties": {
@@ -13135,8 +12479,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "resourceFieldRef": {
                               "properties": {
@@ -13163,8 +12506,7 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "secretKeyRef": {
                               "properties": {
@@ -13182,19 +12524,16 @@
                                 "key"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
                       "required": [
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -13211,8 +12550,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "prefix": {
                           "type": "string"
@@ -13227,12 +12565,10 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -13255,8 +12591,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -13277,8 +12612,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -13303,8 +12637,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -13326,12 +12659,10 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "preStop": {
                         "properties": {
@@ -13344,8 +12675,7 @@
                                 "type": "array"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "httpGet": {
                             "properties": {
@@ -13366,8 +12696,7 @@
                                     "name",
                                     "value"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -13392,8 +12721,7 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "tcpSocket": {
                             "properties": {
@@ -13415,16 +12743,13 @@
                             "required": [
                               "port"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "livenessProbe": {
                     "properties": {
@@ -13437,8 +12762,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -13457,8 +12781,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -13479,8 +12802,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -13505,8 +12827,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -13540,8 +12861,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -13552,8 +12872,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -13583,8 +12902,7 @@
                       "required": [
                         "containerPort"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-map-keys": [
@@ -13604,8 +12922,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -13624,8 +12941,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -13646,8 +12962,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -13672,8 +12987,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -13707,8 +13021,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -13719,8 +13032,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resizePolicy": {
                     "items": {
@@ -13736,8 +13048,7 @@
                         "resourceName",
                         "restartPolicy"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array",
                     "x-kubernetes-list-type": "atomic"
@@ -13754,8 +13065,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -13794,8 +13104,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "securityContext": {
                     "properties": {
@@ -13817,8 +13126,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "privileged": {
                         "type": "boolean"
@@ -13855,8 +13163,7 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "seccompProfile": {
                         "properties": {
@@ -13870,8 +13177,7 @@
                         "required": [
                           "type"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "windowsOptions": {
                         "properties": {
@@ -13888,12 +13194,10 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "startupProbe": {
                     "properties": {
@@ -13906,8 +13210,7 @@
                             "type": "array"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "failureThreshold": {
                         "format": "int32",
@@ -13926,8 +13229,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "httpGet": {
                         "properties": {
@@ -13948,8 +13250,7 @@
                                 "name",
                                 "value"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "type": "array"
                           },
@@ -13974,8 +13275,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "initialDelaySeconds": {
                         "format": "int32",
@@ -14009,8 +13309,7 @@
                         "required": [
                           "port"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       },
                       "terminationGracePeriodSeconds": {
                         "format": "int64",
@@ -14021,8 +13320,7 @@
                         "type": "integer"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "stdin": {
                     "type": "boolean"
@@ -14053,8 +13351,7 @@
                         "devicePath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -14084,8 +13381,7 @@
                         "mountPath",
                         "name"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -14096,8 +13392,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -14120,8 +13415,7 @@
               "required": [
                 "name"
               ],
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "overhead": {
               "additionalProperties": {
@@ -14158,8 +13452,7 @@
                 "required": [
                   "conditionType"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -14178,15 +13471,13 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -14213,8 +13504,7 @@
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -14257,8 +13547,7 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "seccompProfile": {
                   "properties": {
@@ -14272,8 +13561,7 @@
                   "required": [
                     "type"
                   ],
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 },
                 "supplementalGroups": {
                   "items": {
@@ -14296,8 +13584,7 @@
                       "name",
                       "value"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "type": "array"
                 },
@@ -14316,12 +13603,10 @@
                       "type": "string"
                     }
                   },
-                  "type": "object",
-                  "additionalProperties": false
+                  "type": "object"
                 }
               },
-              "type": "object",
-              "additionalProperties": false
+              "type": "object"
             },
             "serviceAccount": {
               "type": "string"
@@ -14362,8 +13647,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             },
@@ -14392,8 +13676,7 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -14405,8 +13688,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "matchLabelKeys": {
                     "items": {
@@ -14441,8 +13723,7 @@
                   "topologyKey",
                   "whenUnsatisfiable"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array",
               "x-kubernetes-list-map-keys": [
@@ -14473,8 +13754,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "azureDisk": {
                     "properties": {
@@ -14501,8 +13781,7 @@
                       "diskName",
                       "diskURI"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "azureFile": {
                     "properties": {
@@ -14520,8 +13799,7 @@
                       "secretName",
                       "shareName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "cephfs": {
                     "properties": {
@@ -14547,8 +13825,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "user": {
                         "type": "string"
@@ -14557,8 +13834,7 @@
                     "required": [
                       "monitors"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "cinder": {
                     "properties": {
@@ -14575,8 +13851,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "volumeID": {
                         "type": "string"
@@ -14585,8 +13860,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "configMap": {
                     "properties": {
@@ -14612,8 +13886,7 @@
                             "key",
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -14625,8 +13898,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "csi": {
                     "properties": {
@@ -14643,8 +13915,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "readOnly": {
                         "type": "boolean"
@@ -14659,8 +13930,7 @@
                     "required": [
                       "driver"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "downwardAPI": {
                     "properties": {
@@ -14684,8 +13954,7 @@
                                 "fieldPath"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "mode": {
                               "format": "int32",
@@ -14719,21 +13988,18 @@
                                 "resource"
                               ],
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             }
                           },
                           "required": [
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "emptyDir": {
                     "properties": {
@@ -14753,8 +14019,7 @@
                         "x-kubernetes-int-or-string": true
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "ephemeral": {
                     "properties": {
@@ -14788,8 +14053,7 @@
                                   "name"
                                 ],
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "dataSourceRef": {
                                 "properties": {
@@ -14810,8 +14074,7 @@
                                   "kind",
                                   "name"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "resources": {
                                 "properties": {
@@ -14825,8 +14088,7 @@
                                       "required": [
                                         "name"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array",
                                     "x-kubernetes-list-map-keys": [
@@ -14865,8 +14127,7 @@
                                     "type": "object"
                                   }
                                 },
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "selector": {
                                 "properties": {
@@ -14890,8 +14151,7 @@
                                         "key",
                                         "operator"
                                       ],
-                                      "type": "object",
-                                      "additionalProperties": false
+                                      "type": "object"
                                     },
                                     "type": "array"
                                   },
@@ -14903,8 +14163,7 @@
                                   }
                                 },
                                 "type": "object",
-                                "x-kubernetes-map-type": "atomic",
-                                "additionalProperties": false
+                                "x-kubernetes-map-type": "atomic"
                               },
                               "storageClassName": {
                                 "type": "string"
@@ -14916,19 +14175,16 @@
                                 "type": "string"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           }
                         },
                         "required": [
                           "spec"
                         ],
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "fc": {
                     "properties": {
@@ -14955,8 +14211,7 @@
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "flexVolume": {
                     "properties": {
@@ -14982,15 +14237,13 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       }
                     },
                     "required": [
                       "driver"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "flocker": {
                     "properties": {
@@ -15001,8 +14254,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "gcePersistentDisk": {
                     "properties": {
@@ -15023,8 +14275,7 @@
                     "required": [
                       "pdName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "gitRepo": {
                     "properties": {
@@ -15041,8 +14292,7 @@
                     "required": [
                       "repository"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "glusterfs": {
                     "properties": {
@@ -15060,8 +14310,7 @@
                       "endpoints",
                       "path"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "hostPath": {
                     "properties": {
@@ -15075,8 +14324,7 @@
                     "required": [
                       "path"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "iscsi": {
                     "properties": {
@@ -15118,8 +14366,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "targetPortal": {
                         "type": "string"
@@ -15130,8 +14377,7 @@
                       "lun",
                       "targetPortal"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "name": {
                     "type": "string"
@@ -15152,8 +14398,7 @@
                       "path",
                       "server"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "persistentVolumeClaim": {
                     "properties": {
@@ -15167,8 +14412,7 @@
                     "required": [
                       "claimName"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "photonPersistentDisk": {
                     "properties": {
@@ -15182,8 +14426,7 @@
                     "required": [
                       "pdID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "portworxVolume": {
                     "properties": {
@@ -15200,8 +14443,7 @@
                     "required": [
                       "volumeID"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "projected": {
                     "properties": {
@@ -15232,8 +14474,7 @@
                                       "key",
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 },
@@ -15245,8 +14486,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "downwardAPI": {
                               "properties": {
@@ -15266,8 +14506,7 @@
                                           "fieldPath"
                                         ],
                                         "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
+                                        "x-kubernetes-map-type": "atomic"
                                       },
                                       "mode": {
                                         "format": "int32",
@@ -15301,21 +14540,18 @@
                                           "resource"
                                         ],
                                         "type": "object",
-                                        "x-kubernetes-map-type": "atomic",
-                                        "additionalProperties": false
+                                        "x-kubernetes-map-type": "atomic"
                                       }
                                     },
                                     "required": [
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 }
                               },
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             },
                             "secret": {
                               "properties": {
@@ -15337,8 +14573,7 @@
                                       "key",
                                       "path"
                                     ],
-                                    "type": "object",
-                                    "additionalProperties": false
+                                    "type": "object"
                                   },
                                   "type": "array"
                                 },
@@ -15350,8 +14585,7 @@
                                 }
                               },
                               "type": "object",
-                              "x-kubernetes-map-type": "atomic",
-                              "additionalProperties": false
+                              "x-kubernetes-map-type": "atomic"
                             },
                             "serviceAccountToken": {
                               "properties": {
@@ -15369,18 +14603,15 @@
                               "required": [
                                 "path"
                               ],
-                              "type": "object",
-                              "additionalProperties": false
+                              "type": "object"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "quobyte": {
                     "properties": {
@@ -15407,8 +14638,7 @@
                       "registry",
                       "volume"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "rbd": {
                     "properties": {
@@ -15440,8 +14670,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "user": {
                         "type": "string"
@@ -15451,8 +14680,7 @@
                       "image",
                       "monitors"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "scaleIO": {
                     "properties": {
@@ -15475,8 +14703,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "sslEnabled": {
                         "type": "boolean"
@@ -15499,8 +14726,7 @@
                       "secretRef",
                       "system"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "secret": {
                     "properties": {
@@ -15526,8 +14752,7 @@
                             "key",
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -15538,8 +14763,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "storageos": {
                     "properties": {
@@ -15556,8 +14780,7 @@
                           }
                         },
                         "type": "object",
-                        "x-kubernetes-map-type": "atomic",
-                        "additionalProperties": false
+                        "x-kubernetes-map-type": "atomic"
                       },
                       "volumeName": {
                         "type": "string"
@@ -15566,8 +14789,7 @@
                         "type": "string"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "vsphereVolume": {
                     "properties": {
@@ -15587,21 +14809,18 @@
                     "required": [
                       "volumePath"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
                 "required": [
                   "name"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "type": "array"
             }
           },
-          "type": "object",
-          "additionalProperties": false
+          "type": "object"
         },
         "veleroEnabled": {
           "type": "boolean"
@@ -15636,8 +14855,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "spec": {
                 "properties": {
@@ -15664,8 +14882,7 @@
                       "name"
                     ],
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "dataSourceRef": {
                     "properties": {
@@ -15686,8 +14903,7 @@
                       "kind",
                       "name"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "resources": {
                     "properties": {
@@ -15701,8 +14917,7 @@
                           "required": [
                             "name"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array",
                         "x-kubernetes-list-map-keys": [
@@ -15741,8 +14956,7 @@
                         "type": "object"
                       }
                     },
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   },
                   "selector": {
                     "properties": {
@@ -15766,8 +14980,7 @@
                             "key",
                             "operator"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "type": "array"
                       },
@@ -15779,8 +14992,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "storageClassName": {
                     "type": "string"
@@ -15792,12 +15004,10 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -15827,8 +15037,7 @@
               "mountPath",
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -15854,8 +15063,7 @@
                 "required": [
                   "volumeID"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "azureDisk": {
                 "properties": {
@@ -15882,8 +15090,7 @@
                   "diskName",
                   "diskURI"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "azureFile": {
                 "properties": {
@@ -15901,8 +15108,7 @@
                   "secretName",
                   "shareName"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "cephfs": {
                 "properties": {
@@ -15928,8 +15134,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "user": {
                     "type": "string"
@@ -15938,8 +15143,7 @@
                 "required": [
                   "monitors"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "cinder": {
                 "properties": {
@@ -15956,8 +15160,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "volumeID": {
                     "type": "string"
@@ -15966,8 +15169,7 @@
                 "required": [
                   "volumeID"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "configMap": {
                 "properties": {
@@ -15993,8 +15195,7 @@
                         "key",
                         "path"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -16006,8 +15207,7 @@
                   }
                 },
                 "type": "object",
-                "x-kubernetes-map-type": "atomic",
-                "additionalProperties": false
+                "x-kubernetes-map-type": "atomic"
               },
               "csi": {
                 "properties": {
@@ -16024,8 +15224,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "readOnly": {
                     "type": "boolean"
@@ -16040,8 +15239,7 @@
                 "required": [
                   "driver"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "downwardAPI": {
                 "properties": {
@@ -16065,8 +15263,7 @@
                             "fieldPath"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "mode": {
                           "format": "int32",
@@ -16100,21 +15297,18 @@
                             "resource"
                           ],
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         }
                       },
                       "required": [
                         "path"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "emptyDir": {
                 "properties": {
@@ -16134,8 +15328,7 @@
                     "x-kubernetes-int-or-string": true
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "ephemeral": {
                 "properties": {
@@ -16169,8 +15362,7 @@
                               "name"
                             ],
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "dataSourceRef": {
                             "properties": {
@@ -16191,8 +15383,7 @@
                               "kind",
                               "name"
                             ],
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "resources": {
                             "properties": {
@@ -16206,8 +15397,7 @@
                                   "required": [
                                     "name"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array",
                                 "x-kubernetes-list-map-keys": [
@@ -16246,8 +15436,7 @@
                                 "type": "object"
                               }
                             },
-                            "type": "object",
-                            "additionalProperties": false
+                            "type": "object"
                           },
                           "selector": {
                             "properties": {
@@ -16271,8 +15460,7 @@
                                     "key",
                                     "operator"
                                   ],
-                                  "type": "object",
-                                  "additionalProperties": false
+                                  "type": "object"
                                 },
                                 "type": "array"
                               },
@@ -16284,8 +15472,7 @@
                               }
                             },
                             "type": "object",
-                            "x-kubernetes-map-type": "atomic",
-                            "additionalProperties": false
+                            "x-kubernetes-map-type": "atomic"
                           },
                           "storageClassName": {
                             "type": "string"
@@ -16297,19 +15484,16 @@
                             "type": "string"
                           }
                         },
-                        "type": "object",
-                        "additionalProperties": false
+                        "type": "object"
                       }
                     },
                     "required": [
                       "spec"
                     ],
-                    "type": "object",
-                    "additionalProperties": false
+                    "type": "object"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "fc": {
                 "properties": {
@@ -16336,8 +15520,7 @@
                     "type": "array"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "flexVolume": {
                 "properties": {
@@ -16363,15 +15546,13 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   }
                 },
                 "required": [
                   "driver"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "flocker": {
                 "properties": {
@@ -16382,8 +15563,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "gcePersistentDisk": {
                 "properties": {
@@ -16404,8 +15584,7 @@
                 "required": [
                   "pdName"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "gitRepo": {
                 "properties": {
@@ -16422,8 +15601,7 @@
                 "required": [
                   "repository"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "glusterfs": {
                 "properties": {
@@ -16441,8 +15619,7 @@
                   "endpoints",
                   "path"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "hostPath": {
                 "properties": {
@@ -16456,8 +15633,7 @@
                 "required": [
                   "path"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "iscsi": {
                 "properties": {
@@ -16499,8 +15675,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "targetPortal": {
                     "type": "string"
@@ -16511,8 +15686,7 @@
                   "lun",
                   "targetPortal"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "name": {
                 "type": "string"
@@ -16533,8 +15707,7 @@
                   "path",
                   "server"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "persistentVolumeClaim": {
                 "properties": {
@@ -16548,8 +15721,7 @@
                 "required": [
                   "claimName"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "photonPersistentDisk": {
                 "properties": {
@@ -16563,8 +15735,7 @@
                 "required": [
                   "pdID"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "portworxVolume": {
                 "properties": {
@@ -16581,8 +15752,7 @@
                 "required": [
                   "volumeID"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "projected": {
                 "properties": {
@@ -16613,8 +15783,7 @@
                                   "key",
                                   "path"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "type": "array"
                             },
@@ -16626,8 +15795,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "downwardAPI": {
                           "properties": {
@@ -16647,8 +15815,7 @@
                                       "fieldPath"
                                     ],
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   },
                                   "mode": {
                                     "format": "int32",
@@ -16682,21 +15849,18 @@
                                       "resource"
                                     ],
                                     "type": "object",
-                                    "x-kubernetes-map-type": "atomic",
-                                    "additionalProperties": false
+                                    "x-kubernetes-map-type": "atomic"
                                   }
                                 },
                                 "required": [
                                   "path"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "type": "array"
                             }
                           },
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         },
                         "secret": {
                           "properties": {
@@ -16718,8 +15882,7 @@
                                   "key",
                                   "path"
                                 ],
-                                "type": "object",
-                                "additionalProperties": false
+                                "type": "object"
                               },
                               "type": "array"
                             },
@@ -16731,8 +15894,7 @@
                             }
                           },
                           "type": "object",
-                          "x-kubernetes-map-type": "atomic",
-                          "additionalProperties": false
+                          "x-kubernetes-map-type": "atomic"
                         },
                         "serviceAccountToken": {
                           "properties": {
@@ -16750,18 +15912,15 @@
                           "required": [
                             "path"
                           ],
-                          "type": "object",
-                          "additionalProperties": false
+                          "type": "object"
                         }
                       },
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "quobyte": {
                 "properties": {
@@ -16788,8 +15947,7 @@
                   "registry",
                   "volume"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "rbd": {
                 "properties": {
@@ -16821,8 +15979,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "user": {
                     "type": "string"
@@ -16832,8 +15989,7 @@
                   "image",
                   "monitors"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "scaleIO": {
                 "properties": {
@@ -16856,8 +16012,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "sslEnabled": {
                     "type": "boolean"
@@ -16880,8 +16035,7 @@
                   "secretRef",
                   "system"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "secret": {
                 "properties": {
@@ -16907,8 +16061,7 @@
                         "key",
                         "path"
                       ],
-                      "type": "object",
-                      "additionalProperties": false
+                      "type": "object"
                     },
                     "type": "array"
                   },
@@ -16919,8 +16072,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "storageos": {
                 "properties": {
@@ -16937,8 +16089,7 @@
                       }
                     },
                     "type": "object",
-                    "x-kubernetes-map-type": "atomic",
-                    "additionalProperties": false
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "volumeName": {
                     "type": "string"
@@ -16947,8 +16098,7 @@
                     "type": "string"
                   }
                 },
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               },
               "vsphereVolume": {
                 "properties": {
@@ -16968,15 +16118,13 @@
                 "required": [
                   "volumePath"
                 ],
-                "type": "object",
-                "additionalProperties": false
+                "type": "object"
               }
             },
             "required": [
               "name"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -17002,8 +16150,7 @@
       "required": [
         "config"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     },
     "status": {
       "properties": {
@@ -17027,8 +16174,7 @@
               "status",
               "type"
             ],
-            "type": "object",
-            "additionalProperties": false
+            "type": "object"
           },
           "type": "array"
         },
@@ -17046,8 +16192,7 @@
         "leader",
         "nodes"
       ],
-      "type": "object",
-      "additionalProperties": false
+      "type": "object"
     }
   },
   "type": "object"


### PR DESCRIPTION
Running into validation issues with the latest config of vault. This updates to the latest CRD from: https://github.com/bank-vaults/vault-operator/tree/0a176c4b2144fb714d687f42111f19184b7a8ca7/deploy/crd

Generated with: `kustomize build deploy/crd | yq '.spec.versions[]?.schema.openAPIV3Schema' -o json`