### PR TITLE
fix: argoproj.io clusternanalysistemplate schema

### DIFF
--- a/argoproj.io/clusteranalysistemplate_v1alpha1.json
+++ b/argoproj.io/clusteranalysistemplate_v1alpha1.json
@@ -255,22 +255,49 @@
                   },
                   "datadog": {
                     "properties": {
-                      "interval": {
+                      "apiVersion": {
+                        "default": "v1",
+                        "enum": [
+                          "v1",
+                          "v2"
+                        ],
                         "type": "string"
+                      },
+                      "formula": {
+                        "type": "string"
+                      },
+                      "interval": {
+                        "default": "5m",
+                        "type": "string"
+                      },
+                      "queries": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "type": "object"
                       },
                       "query": {
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "query"
-                    ],
                     "type": "object",
                     "additionalProperties": false
                   },
                   "graphite": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "query": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "influxdb": {
+                    "properties": {
+                      "profile": {
                         "type": "string"
                       },
                       "query": {
@@ -324,6 +351,76 @@
                             "format": "int32",
                             "type": "integer"
                           },
+                          "podFailurePolicy": {
+                            "properties": {
+                              "rules": {
+                                "items": {
+                                  "properties": {
+                                    "action": {
+                                      "type": "string"
+                                    },
+                                    "onExitCodes": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "format": "int32",
+                                            "type": "integer"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "set"
+                                        }
+                                      },
+                                      "required": [
+                                        "operator",
+                                        "values"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "onPodConditions": {
+                                      "items": {
+                                        "properties": {
+                                          "status": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "status",
+                                          "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "action",
+                                    "onPodConditions"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "required": [
+                              "rules"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
                           "selector": {
                             "properties": {
                               "matchExpressions": {
@@ -359,6 +456,7 @@
                               }
                             },
                             "type": "object",
+                            "x-kubernetes-map-type": "atomic",
                             "additionalProperties": false
                           },
                           "suspend": {
@@ -451,6 +549,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "weight": {
@@ -524,6 +623,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "type": "array"
@@ -533,6 +633,7 @@
                                               "nodeSelectorTerms"
                                             ],
                                             "type": "object",
+                                            "x-kubernetes-map-type": "atomic",
                                             "additionalProperties": false
                                           }
                                         },
@@ -581,6 +682,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -618,6 +720,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -688,6 +791,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -725,6 +829,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -791,6 +896,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaceSelector": {
@@ -828,6 +934,7 @@
                                                         }
                                                       },
                                                       "type": "object",
+                                                      "x-kubernetes-map-type": "atomic",
                                                       "additionalProperties": false
                                                     },
                                                     "namespaces": {
@@ -898,6 +1005,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaceSelector": {
@@ -935,6 +1043,7 @@
                                                     }
                                                   },
                                                   "type": "object",
+                                                  "x-kubernetes-map-type": "atomic",
                                                   "additionalProperties": false
                                                 },
                                                 "namespaces": {
@@ -1008,6 +1117,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -1023,6 +1133,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -1050,6 +1161,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -1068,6 +1180,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -1096,6 +1209,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -1111,6 +1225,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2002,6 +2117,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -2017,6 +2133,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -2044,6 +2161,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -2062,6 +2180,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -2090,6 +2209,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -2105,6 +2225,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -2945,6 +3066,9 @@
                                   "hostPID": {
                                     "type": "boolean"
                                   },
+                                  "hostUsers": {
+                                    "type": "boolean"
+                                  },
                                   "hostname": {
                                     "type": "string"
                                   },
@@ -2956,6 +3080,7 @@
                                         }
                                       },
                                       "type": "object",
+                                      "x-kubernetes-map-type": "atomic",
                                       "additionalProperties": false
                                     },
                                     "type": "array"
@@ -3002,6 +3127,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "fieldRef": {
@@ -3017,6 +3143,7 @@
                                                       "fieldPath"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "resourceFieldRef": {
@@ -3044,6 +3171,7 @@
                                                       "resource"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   },
                                                   "secretKeyRef": {
@@ -3062,6 +3190,7 @@
                                                       "key"
                                                     ],
                                                     "type": "object",
+                                                    "x-kubernetes-map-type": "atomic",
                                                     "additionalProperties": false
                                                   }
                                                 },
@@ -3090,6 +3219,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               },
                                               "prefix": {
@@ -3105,6 +3235,7 @@
                                                   }
                                                 },
                                                 "type": "object",
+                                                "x-kubernetes-map-type": "atomic",
                                                 "additionalProperties": false
                                               }
                                             },
@@ -4169,11 +4300,29 @@
                                             }
                                           },
                                           "type": "object",
+                                          "x-kubernetes-map-type": "atomic",
                                           "additionalProperties": false
+                                        },
+                                        "matchLabelKeys": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "maxSkew": {
                                           "format": "int32",
                                           "type": "integer"
+                                        },
+                                        "minDomains": {
+                                          "format": "int32",
+                                          "type": "integer"
+                                        },
+                                        "nodeAffinityPolicy": {
+                                          "type": "string"
+                                        },
+                                        "nodeTaintsPolicy": {
+                                          "type": "string"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -4371,9 +4520,96 @@
                     "type": "object",
                     "additionalProperties": false
                   },
+                  "plugin": {
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
                   "prometheus": {
                     "properties": {
                       "address": {
+                        "type": "string"
+                      },
+                      "authentication": {
+                        "properties": {
+                          "oauth2": {
+                            "properties": {
+                              "clientId": {
+                                "type": "string"
+                              },
+                              "clientSecret": {
+                                "type": "string"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenUrl": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sigv4": {
+                            "properties": {
+                              "profile": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleArn": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "headers": {
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "insecure": {
+                        "type": "boolean"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "timeout": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "skywalking": {
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "interval": {
                         "type": "string"
                       },
                       "query": {
@@ -4397,6 +4633,48 @@
                   },
                   "web": {
                     "properties": {
+                      "authentication": {
+                        "properties": {
+                          "oauth2": {
+                            "properties": {
+                              "clientId": {
+                                "type": "string"
+                              },
+                              "clientSecret": {
+                                "type": "string"
+                              },
+                              "scopes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "tokenUrl": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sigv4": {
+                            "properties": {
+                              "profile": {
+                                "type": "string"
+                              },
+                              "region": {
+                                "type": "string"
+                              },
+                              "roleArn": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "body": {
                         "type": "string"
                       },
@@ -4421,6 +4699,10 @@
                       },
                       "insecure": {
                         "type": "boolean"
+                      },
+                      "jsonBody": {
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
                       },
                       "jsonPath": {
                         "type": "string"


### PR DESCRIPTION
Updating argo's clusteranalysistemplate schema to be up to date with the latest version (as of Nov 29, 2023 that's commit [ebf1a3e](https://github.com/argoproj/argo-rollouts/commit/ebf1a3ed24ed08d04f034a13fd780b9771c69be4) of the [argo rollouts repo](https://github.com/argoproj/argo-rollouts/blob/master/manifests/crds/cluster-analysis-template-crd.yaml#L26).

Used [kubeconform's openapi2jsonschema script](https://github.com/yannh/kubeconform#customresourcedefinition-crd-support) to generate the schema:
```
$ python3 ./scripts/openapi2jsonschema.py https://raw.githubusercontent.com/argoproj/argo-rollouts/master/manifests/crds/cluster-analysis-template-crd.yaml
JSON schema written to clusteranalysistemplate_v1alpha1.json
```

I couldn't find any guidelines on contributing, but happy to provide anything else I may be missing.