### PR TITLE
chore: update kyverno/v1 crd schemas as per v1.11.0

### DIFF
--- a/kyverno.io/admissionreport_v1alpha2.json
+++ b/kyverno.io/admissionreport_v1alpha2.json
@@ -34,11 +34,11 @@
               "type": "string"
             },
             "name": {
-              "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             },
             "uid": {
-              "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
               "type": "string"
             }
           },

--- a/kyverno.io/cleanuppolicy_v2beta1.json
+++ b/kyverno.io/cleanuppolicy_v2beta1.json
@@ -1,0 +1,1173 @@
+{
+  "description": "CleanupPolicy defines a rule for resource cleanup.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy behaviors.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
+          "properties": {
+            "all": {
+              "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "context": {
+          "description": "Context defines variables and data sources that can be used during rule execution.",
+          "items": {
+            "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+            "properties": {
+              "apiCall": {
+                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                "properties": {
+                  "data": {
+                    "description": "Data specifies the POST data sent to the server.",
+                    "items": {
+                      "description": "RequestData contains the HTTP POST data",
+                      "properties": {
+                        "key": {
+                          "description": "Key is a unique identifier for the data value",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the data value",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "description": "Method is the HTTP request type (GET or POST).",
+                    "enum": [
+                      "GET",
+                      "POST"
+                    ],
+                    "type": "string"
+                  },
+                  "service": {
+                    "description": "Service is an API call to a JSON web service",
+                    "properties": {
+                      "caBundle": {
+                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "urlPath": {
+                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "ConfigMap is the ConfigMap reference.",
+                "properties": {
+                  "name": {
+                    "description": "Name is the ConfigMap name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the ConfigMap namespace.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageRegistry": {
+                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                "properties": {
+                  "imageRegistryCredentials": {
+                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                    "properties": {
+                      "allowInsecureRegistry": {
+                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                        "type": "boolean"
+                      },
+                      "providers": {
+                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                        "items": {
+                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                          "enum": [
+                            "default",
+                            "amazon",
+                            "azure",
+                            "google",
+                            "github"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reference"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name is the variable name.",
+                "type": "string"
+              },
+              "variable": {
+                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                "properties": {
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "exclude": {
+          "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.",
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "MatchResources defines when cleanuppolicy should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.",
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedule": {
+          "description": "The schedule in Cron format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schedule"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status contains policy runtime data.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastExecutionTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/clusteradmissionreport_v1alpha2.json
+++ b/kyverno.io/clusteradmissionreport_v1alpha2.json
@@ -34,11 +34,11 @@
               "type": "string"
             },
             "name": {
-              "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
               "type": "string"
             },
             "uid": {
-              "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
               "type": "string"
             }
           },

--- a/kyverno.io/clustercleanuppolicy_v2beta1.json
+++ b/kyverno.io/clustercleanuppolicy_v2beta1.json
@@ -1,0 +1,1173 @@
+{
+  "description": "ClusterCleanupPolicy defines rule for resource cleanup.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy behaviors.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions defines the conditions used to select the resources which will be cleaned up.",
+          "properties": {
+            "all": {
+              "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "AnyConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, at least one of the conditions need to pass.",
+              "items": {
+                "properties": {
+                  "key": {
+                    "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "message": {
+                    "description": "Message is an optional display message",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
+                    "enum": [
+                      "Equals",
+                      "NotEquals",
+                      "AnyIn",
+                      "AllIn",
+                      "AnyNotIn",
+                      "AllNotIn",
+                      "GreaterThanOrEquals",
+                      "GreaterThan",
+                      "LessThanOrEquals",
+                      "LessThan",
+                      "DurationGreaterThanOrEquals",
+                      "DurationGreaterThan",
+                      "DurationLessThanOrEquals",
+                      "DurationLessThan"
+                    ],
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is the conditional value, or set of values. The values can be fixed set or can be variables declared using JMESPath.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "context": {
+          "description": "Context defines variables and data sources that can be used during rule execution.",
+          "items": {
+            "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+            "properties": {
+              "apiCall": {
+                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                "properties": {
+                  "data": {
+                    "description": "Data specifies the POST data sent to the server.",
+                    "items": {
+                      "description": "RequestData contains the HTTP POST data",
+                      "properties": {
+                        "key": {
+                          "description": "Key is a unique identifier for the data value",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Value is the data value",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "value"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                    "type": "string"
+                  },
+                  "method": {
+                    "default": "GET",
+                    "description": "Method is the HTTP request type (GET or POST).",
+                    "enum": [
+                      "GET",
+                      "POST"
+                    ],
+                    "type": "string"
+                  },
+                  "service": {
+                    "description": "Service is an API call to a JSON web service",
+                    "properties": {
+                      "caBundle": {
+                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                        "type": "string"
+                      },
+                      "url": {
+                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "urlPath": {
+                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "configMap": {
+                "description": "ConfigMap is the ConfigMap reference.",
+                "properties": {
+                  "name": {
+                    "description": "Name is the ConfigMap name.",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the ConfigMap namespace.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "imageRegistry": {
+                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                "properties": {
+                  "imageRegistryCredentials": {
+                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                    "properties": {
+                      "allowInsecureRegistry": {
+                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                        "type": "boolean"
+                      },
+                      "providers": {
+                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                        "items": {
+                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                          "enum": [
+                            "default",
+                            "amazon",
+                            "azure",
+                            "google",
+                            "github"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "secrets": {
+                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reference"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Name is the variable name.",
+                "type": "string"
+              },
+              "variable": {
+                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                "properties": {
+                  "default": {
+                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "jmesPath": {
+                    "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "exclude": {
+          "description": "ExcludeResources defines when cleanuppolicy should not be applied. The exclude criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the name or role.",
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "match": {
+          "description": "MatchResources defines when cleanuppolicy should be applied. The match criteria can include resource information (e.g. kind, name, namespace, labels) and admission review request information like the user name or role. At least one kind is required.",
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "schedule": {
+          "description": "The schedule in Cron format",
+          "type": "string"
+        }
+      },
+      "required": [
+        "schedule"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Status contains policy runtime data.",
+      "properties": {
+        "conditions": {
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "lastExecutionTime": {
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/clusterpolicy_v1.json
+++ b/kyverno.io/clusterpolicy_v1.json
@@ -15,6 +15,11 @@
     "spec": {
       "description": "Spec declares policy behaviors.",
       "properties": {
+        "admission": {
+          "default": true,
+          "description": "Admission controls if rules are applied during admission. Optional. Default value is \"true\".",
+          "type": "boolean"
+        },
         "applyRules": {
           "description": "ApplyRules controls how rules in a policy are applied. Rule are processed in the order of declaration. When set to `One` processing stops after a rule has been applied i.e. the rule matches and results in a pass, fail, or error. When set to `All` all rules in the policy are processed. The default is `All`.",
           "enum": [
@@ -53,6 +58,29 @@
           "items": {
             "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
             "properties": {
+              "celPreconditions": {
+                "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                "items": {
+                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
               "context": {
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
@@ -144,6 +172,39 @@
                     "imageRegistry": {
                       "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                       "properties": {
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                           "type": "string"
@@ -888,6 +949,10 @@
                   "synchronize": {
                     "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                     "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
                   }
                 },
                 "type": "object",
@@ -1624,6 +1689,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1904,6 +2002,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1963,6 +2094,10 @@
                         "preconditions": {
                           "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
+                          "type": "string"
                         }
                       },
                       "type": "object",
@@ -1989,6 +2124,170 @@
                   "anyPattern": {
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "cel": {
+                    "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                    "properties": {
+                      "auditAnnotations": {
+                        "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                        "items": {
+                          "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                          "properties": {
+                            "key": {
+                              "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                              "type": "string"
+                            },
+                            "valueExpression": {
+                              "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "valueExpression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "expressions": {
+                        "description": "Expressions is a list of CELExpression types.",
+                        "items": {
+                          "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                              "type": "string"
+                            },
+                            "messageExpression": {
+                              "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "paramKind": {
+                        "description": "ParamKind is a tuple of Group Kind and Version.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind is the API kind the resources belong to. Required.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "paramRef": {
+                        "description": "ParamRef references a parameter resource.",
+                        "properties": {
+                          "name": {
+                            "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                            "type": "string"
+                          },
+                          "parameterNotFoundAction": {
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "variables": {
+                        "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                        "items": {
+                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
                   },
                   "deny": {
                     "description": "Deny defines conditions used to pass or fail a validation rule.",
@@ -2101,6 +2400,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -2304,25 +2636,48 @@
                                     "type": "object"
                                   },
                                   "attestor": {
-                                    "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                    "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
                                   "certificates": {
-                                    "description": "Certificates specifies one or more certificates",
+                                    "description": "Certificates specifies one or more certificates.",
                                     "properties": {
                                       "cert": {
-                                        "description": "Certificate is an optional PEM encoded public certificate.",
+                                        "description": "Cert is an optional PEM-encoded public certificate.",
                                         "type": "string"
                                       },
                                       "certChain": {
-                                        "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                        "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                         "type": "string"
                                       },
-                                      "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                         "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -2346,15 +2701,38 @@
                                         "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                         "type": "object"
                                       },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -2369,7 +2747,7 @@
                                         "type": "string"
                                       },
                                       "subject": {
-                                        "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                        "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
                                       }
                                     },
@@ -2377,8 +2755,23 @@
                                     "additionalProperties": false
                                   },
                                   "keys": {
-                                    "description": "Keys specifies one or more public keys",
+                                    "description": "Keys specifies one or more public keys.",
                                     "properties": {
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "kms": {
                                         "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                         "type": "string"
@@ -2388,10 +2781,18 @@
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -2422,7 +2823,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -2600,14 +3001,14 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                      "description": "Deprecated.",
                       "type": "object"
                     },
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                      "description": "Deprecated. Use annotations per Attestor instead.",
                       "type": "object"
                     },
                     "attestations": {
@@ -2616,7 +3017,7 @@
                         "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                         "properties": {
                           "attestors": {
-                            "description": "Attestors specify the required attestors (i.e. authorities)",
+                            "description": "Attestors specify the required attestors (i.e. authorities).",
                             "items": {
                               "properties": {
                                 "count": {
@@ -2636,25 +3037,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2678,15 +3102,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2701,7 +3148,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -2709,8 +3156,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -2720,10 +3182,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2754,7 +3224,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -2879,13 +3349,14 @@
                             "type": "array"
                           },
                           "predicateType": {
-                            "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                            "description": "Deprecated in favour of 'Type', to be removed soon",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type defines the type of attestation contained within the Statement.",
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "predicateType"
-                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2912,25 +3383,48 @@
                                   "type": "object"
                                 },
                                 "attestor": {
-                                  "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                  "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                   "x-kubernetes-preserve-unknown-fields": true
                                 },
                                 "certificates": {
-                                  "description": "Certificates specifies one or more certificates",
+                                  "description": "Certificates specifies one or more certificates.",
                                   "properties": {
                                     "cert": {
-                                      "description": "Certificate is an optional PEM encoded public certificate.",
+                                      "description": "Cert is an optional PEM-encoded public certificate.",
                                       "type": "string"
                                     },
                                     "certChain": {
-                                      "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                      "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                       "type": "string"
                                     },
-                                    "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                       "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2954,15 +3448,38 @@
                                       "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                       "type": "object"
                                     },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2977,7 +3494,7 @@
                                       "type": "string"
                                     },
                                     "subject": {
-                                      "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                      "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
                                     }
                                   },
@@ -2985,8 +3502,23 @@
                                   "additionalProperties": false
                                 },
                                 "keys": {
-                                  "description": "Keys specifies one or more public keys",
+                                  "description": "Keys specifies one or more public keys.",
                                   "properties": {
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "kms": {
                                       "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                       "type": "string"
@@ -2996,10 +3528,18 @@
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -3030,7 +3570,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -3054,7 +3594,7 @@
                       "type": "array"
                     },
                     "image": {
-                      "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                      "description": "Deprecated. Use ImageReferences instead.",
                       "type": "string"
                     },
                     "imageReferences": {
@@ -3064,12 +3604,45 @@
                       },
                       "type": "array"
                     },
+                    "imageRegistryCredentials": {
+                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                      "properties": {
+                        "allowInsecureRegistry": {
+                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                          "items": {
+                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                            "enum": [
+                              "default",
+                              "amazon",
+                              "azure",
+                              "google",
+                              "github"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secrets": {
+                          "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "issuer": {
-                      "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
                     },
                     "key": {
-                      "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                      "description": "Deprecated. Use StaticKeyAttestor instead.",
                       "type": "string"
                     },
                     "mutateDigest": {
@@ -3087,11 +3660,11 @@
                       "type": "boolean"
                     },
                     "roots": {
-                      "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
                     },
                     "subject": {
-                      "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
                     },
                     "type": {
@@ -3101,6 +3674,11 @@
                         "Notary"
                       ],
                       "type": "string"
+                    },
+                    "useCache": {
+                      "default": true,
+                      "description": "UseCache enables caching of image verify responses for this rule.",
+                      "type": "boolean"
                     },
                     "verifyDigest": {
                       "default": true,
@@ -3114,6 +3692,9 @@
                 "type": "array"
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -3121,6 +3702,10 @@
         },
         "schemaValidation": {
           "description": "SchemaValidation skips validation checks for policies as well as patched resources. Optional. The default value is set to \"true\", it must be set to \"false\" to disable the validation checks.",
+          "type": "boolean"
+        },
+        "useServerSideApply": {
+          "description": "UseServerSideApply controls whether to use server-side apply for generate rules If is set to \"true\" create & update for generate rules will use apply instead of create/update. Defaults to \"false\" if not specified.",
           "type": "boolean"
         },
         "validationFailureAction": {
@@ -3218,13 +3803,36 @@
       "description": "Status contains policy runtime data.",
       "properties": {
         "autogen": {
-          "description": "Autogen contains autogen status information",
+          "description": "AutogenStatus contains autogen status information.",
           "properties": {
             "rules": {
               "description": "Rules is a list of Rule instances. It contains auto generated rules added for pod controllers",
               "items": {
                 "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
                 "properties": {
+                  "celPreconditions": {
+                    "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                    "items": {
+                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "properties": {
+                        "expression": {
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "expression",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "context": {
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
@@ -3316,6 +3924,39 @@
                         "imageRegistry": {
                           "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                           "properties": {
+                            "imageRegistryCredentials": {
+                              "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                              "properties": {
+                                "allowInsecureRegistry": {
+                                  "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                  "type": "boolean"
+                                },
+                                "providers": {
+                                  "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                  "items": {
+                                    "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                    "enum": [
+                                      "default",
+                                      "amazon",
+                                      "azure",
+                                      "google",
+                                      "github"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secrets": {
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                               "type": "string"
@@ -4060,6 +4701,10 @@
                       "synchronize": {
                         "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                         "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -4796,6 +5441,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -5076,6 +5754,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -5135,6 +5846,10 @@
                             "preconditions": {
                               "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
                               "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
+                              "type": "string"
                             }
                           },
                           "type": "object",
@@ -5161,6 +5876,170 @@
                       "anyPattern": {
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                         "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "cel": {
+                        "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                        "properties": {
+                          "auditAnnotations": {
+                            "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                            "items": {
+                              "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                              "properties": {
+                                "key": {
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                                  "type": "string"
+                                },
+                                "valueExpression": {
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "valueExpression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "expressions": {
+                            "description": "Expressions is a list of CELExpression types.",
+                            "items": {
+                              "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                                  "type": "string"
+                                },
+                                "messageExpression": {
+                                  "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "paramKind": {
+                            "description": "ParamKind is a tuple of Group Kind and Version.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the API kind the resources belong to. Required.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "paramRef": {
+                            "description": "ParamRef references a parameter resource.",
+                            "properties": {
+                              "name": {
+                                "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                                "type": "string"
+                              },
+                              "parameterNotFoundAction": {
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                                "type": "string"
+                              },
+                              "selector": {
+                                "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "variables": {
+                            "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                            "items": {
+                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
                       },
                       "deny": {
                         "description": "Deny defines conditions used to pass or fail a validation rule.",
@@ -5273,6 +6152,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -5476,25 +6388,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -5518,15 +6453,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -5541,7 +6499,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -5549,8 +6507,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -5560,10 +6533,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -5594,7 +6575,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -5772,14 +6753,14 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                          "description": "Deprecated.",
                           "type": "object"
                         },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                          "description": "Deprecated. Use annotations per Attestor instead.",
                           "type": "object"
                         },
                         "attestations": {
@@ -5788,7 +6769,7 @@
                             "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                             "properties": {
                               "attestors": {
-                                "description": "Attestors specify the required attestors (i.e. authorities)",
+                                "description": "Attestors specify the required attestors (i.e. authorities).",
                                 "items": {
                                   "properties": {
                                     "count": {
@@ -5808,25 +6789,48 @@
                                             "type": "object"
                                           },
                                           "attestor": {
-                                            "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                            "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
                                           "certificates": {
-                                            "description": "Certificates specifies one or more certificates",
+                                            "description": "Certificates specifies one or more certificates.",
                                             "properties": {
                                               "cert": {
-                                                "description": "Certificate is an optional PEM encoded public certificate.",
+                                                "description": "Cert is an optional PEM-encoded public certificate.",
                                                 "type": "string"
                                               },
                                               "certChain": {
-                                                "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                                "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                                 "type": "string"
                                               },
-                                              "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                                 "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -5850,15 +6854,38 @@
                                                 "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                                 "type": "object"
                                               },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -5873,7 +6900,7 @@
                                                 "type": "string"
                                               },
                                               "subject": {
-                                                "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                                "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
                                               }
                                             },
@@ -5881,8 +6908,23 @@
                                             "additionalProperties": false
                                           },
                                           "keys": {
-                                            "description": "Keys specifies one or more public keys",
+                                            "description": "Keys specifies one or more public keys.",
                                             "properties": {
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "kms": {
                                                 "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                                 "type": "string"
@@ -5892,10 +6934,18 @@
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -5926,7 +6976,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                                 "type": "string"
                                               }
                                             },
@@ -6051,13 +7101,14 @@
                                 "type": "array"
                               },
                               "predicateType": {
-                                "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                                "description": "Deprecated in favour of 'Type', to be removed soon",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type defines the type of attestation contained within the Statement.",
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "predicateType"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -6084,25 +7135,48 @@
                                       "type": "object"
                                     },
                                     "attestor": {
-                                      "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                      "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                       "x-kubernetes-preserve-unknown-fields": true
                                     },
                                     "certificates": {
-                                      "description": "Certificates specifies one or more certificates",
+                                      "description": "Certificates specifies one or more certificates.",
                                       "properties": {
                                         "cert": {
-                                          "description": "Certificate is an optional PEM encoded public certificate.",
+                                          "description": "Cert is an optional PEM-encoded public certificate.",
                                           "type": "string"
                                         },
                                         "certChain": {
-                                          "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                          "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                           "type": "string"
                                         },
-                                        "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                           "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -6126,15 +7200,38 @@
                                           "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                           "type": "object"
                                         },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -6149,7 +7246,7 @@
                                           "type": "string"
                                         },
                                         "subject": {
-                                          "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                          "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
                                         }
                                       },
@@ -6157,8 +7254,23 @@
                                       "additionalProperties": false
                                     },
                                     "keys": {
-                                      "description": "Keys specifies one or more public keys",
+                                      "description": "Keys specifies one or more public keys.",
                                       "properties": {
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "kms": {
                                           "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                           "type": "string"
@@ -6168,10 +7280,18 @@
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -6202,7 +7322,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                           "type": "string"
                                         }
                                       },
@@ -6226,7 +7346,7 @@
                           "type": "array"
                         },
                         "image": {
-                          "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                          "description": "Deprecated. Use ImageReferences instead.",
                           "type": "string"
                         },
                         "imageReferences": {
@@ -6236,12 +7356,45 @@
                           },
                           "type": "array"
                         },
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "issuer": {
-                          "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "key": {
-                          "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                          "description": "Deprecated. Use StaticKeyAttestor instead.",
                           "type": "string"
                         },
                         "mutateDigest": {
@@ -6259,11 +7412,11 @@
                           "type": "boolean"
                         },
                         "roots": {
-                          "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "subject": {
-                          "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "type": {
@@ -6273,6 +7426,11 @@
                             "Notary"
                           ],
                           "type": "string"
+                        },
+                        "useCache": {
+                          "default": true,
+                          "description": "UseCache enables caching of image verify responses for this rule.",
+                          "type": "boolean"
                         },
                         "verifyDigest": {
                           "default": true,
@@ -6286,6 +7444,9 @@
                     "type": "array"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -6296,7 +7457,6 @@
           "additionalProperties": false
         },
         "conditions": {
-          "description": "Conditions is a list of conditions that apply to the policy",
           "items": {
             "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
             "properties": {
@@ -6352,11 +7512,11 @@
           "type": "array"
         },
         "ready": {
-          "description": "Ready indicates if the policy is ready to serve the admission request. Deprecated in favor of Conditions",
+          "description": "Deprecated in favor of Conditions",
           "type": "boolean"
         },
         "rulecount": {
-          "description": "RuleCount describes total number of rules in a policy",
+          "description": "RuleCountStatus contains four variables which describes counts for validate, generate, mutate and verify images rules",
           "properties": {
             "generate": {
               "description": "Count for generate rules in policy",
@@ -6380,6 +7540,25 @@
             "mutate",
             "validate",
             "verifyimages"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "validatingadmissionpolicy": {
+          "description": "ValidatingAdmissionPolicy contains status information",
+          "properties": {
+            "generated": {
+              "description": "Generated indicates whether a validating admission policy is generated from the policy or not",
+              "type": "boolean"
+            },
+            "message": {
+              "description": "Message is a human readable message indicating details about the generation of validating admission policy It is an empty string when validating admission policy is successfully generated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "generated",
+            "message"
           ],
           "type": "object",
           "additionalProperties": false

--- a/kyverno.io/clusterpolicy_v2beta1.json
+++ b/kyverno.io/clusterpolicy_v2beta1.json
@@ -15,6 +15,11 @@
     "spec": {
       "description": "Spec declares policy behaviors.",
       "properties": {
+        "admission": {
+          "default": true,
+          "description": "Admission controls if rules are applied during admission. Optional. Default value is \"true\".",
+          "type": "boolean"
+        },
         "applyRules": {
           "description": "ApplyRules controls how rules in a policy are applied. Rule are processed in the order of declaration. When set to `One` processing stops after a rule has been applied i.e. the rule matches and results in a pass, fail, or error. When set to `All` all rules in the policy are processed. The default is `All`.",
           "enum": [
@@ -36,8 +41,12 @@
           ],
           "type": "string"
         },
+        "generateExisting": {
+          "description": "GenerateExisting controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "type": "boolean"
+        },
         "generateExistingOnPolicyUpdate": {
-          "description": "GenerateExistingOnPolicyUpdate controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting instead",
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
@@ -49,26 +58,96 @@
           "items": {
             "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
             "properties": {
+              "celPreconditions": {
+                "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                "items": {
+                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
               "context": {
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                   "properties": {
                     "apiCall": {
-                      "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                      "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                       "properties": {
+                        "data": {
+                          "description": "Data specifies the POST data sent to the server.",
+                          "items": {
+                            "description": "RequestData contains the HTTP POST data",
+                            "properties": {
+                              "key": {
+                                "description": "Key is a unique identifier for the data value",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the data value",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "jmesPath": {
-                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                           "type": "string"
                         },
+                        "method": {
+                          "default": "GET",
+                          "description": "Method is the HTTP request type (GET or POST).",
+                          "enum": [
+                            "GET",
+                            "POST"
+                          ],
+                          "type": "string"
+                        },
+                        "service": {
+                          "description": "Service is an API call to a JSON web service",
+                          "properties": {
+                            "caBundle": {
+                              "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "urlPath": {
-                          "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                          "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "urlPath"
-                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -93,6 +172,39 @@
                     "imageRegistry": {
                       "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                       "properties": {
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                           "type": "string"
@@ -228,6 +340,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -414,6 +540,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -620,6 +760,10 @@
                   "synchronize": {
                     "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                     "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
                   }
                 },
                 "type": "object",
@@ -629,6 +773,10 @@
                 "additionalProperties": {
                   "items": {
                     "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
                       "key": {
                         "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                         "type": "string"
@@ -748,6 +896,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -938,6 +1100,20 @@
                               },
                               "type": "array"
                             },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "selector": {
                               "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                               "properties": {
@@ -1042,7 +1218,7 @@
                   "foreach": {
                     "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -1050,20 +1226,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1088,6 +1311,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1140,6 +1396,14 @@
                           "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                           "type": "string"
                         },
+                        "order": {
+                          "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                          "enum": [
+                            "Ascending",
+                            "Descending"
+                          ],
+                          "type": "string"
+                        },
                         "patchStrategicMerge": {
                           "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                           "x-kubernetes-preserve-unknown-fields": true
@@ -1159,6 +1423,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1200,6 +1468,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1255,10 +1527,179 @@
                   "targets": {
                     "description": "Targets defines the target resources to be mutated.",
                     "items": {
+                      "description": "TargetResourceSpec defines targets for mutating existing resources.",
                       "properties": {
                         "apiVersion": {
                           "description": "APIVersion specifies resource apiVersion.",
                           "type": "string"
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "kind": {
                           "description": "Kind specifies resource kind.",
@@ -1270,6 +1711,14 @@
                         },
                         "namespace": {
                           "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
                           "type": "string"
                         }
                       },
@@ -1288,7 +1737,7 @@
                 "type": "string"
               },
               "preconditions": {
-                "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but See: https://kyverno.io/docs/writing-policies/preconditions/",
+                "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/",
                 "properties": {
                   "all": {
                     "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
@@ -1297,6 +1746,10 @@
                         "key": {
                           "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "message": {
+                          "description": "Message is an optional display message",
+                          "type": "string"
                         },
                         "operator": {
                           "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1335,6 +1788,10 @@
                         "key": {
                           "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "message": {
+                          "description": "Message is an optional display message",
+                          "type": "string"
                         },
                         "operator": {
                           "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1377,11 +1834,175 @@
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "cel": {
+                    "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                    "properties": {
+                      "auditAnnotations": {
+                        "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                        "items": {
+                          "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                          "properties": {
+                            "key": {
+                              "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                              "type": "string"
+                            },
+                            "valueExpression": {
+                              "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "valueExpression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "expressions": {
+                        "description": "Expressions is a list of CELExpression types.",
+                        "items": {
+                          "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                              "type": "string"
+                            },
+                            "messageExpression": {
+                              "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "paramKind": {
+                        "description": "ParamKind is a tuple of Group Kind and Version.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind is the API kind the resources belong to. Required.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "paramRef": {
+                        "description": "ParamRef references a parameter resource.",
+                        "properties": {
+                          "name": {
+                            "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                            "type": "string"
+                          },
+                          "parameterNotFoundAction": {
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "variables": {
+                        "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                        "items": {
+                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "deny": {
                     "description": "Deny defines conditions used to pass or fail a validation rule.",
                     "properties": {
                       "conditions": {
-                        "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility See: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                        "description": "Multiple conditions can be declared under an `any` or `all` statement. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
                         "properties": {
                           "all": {
                             "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
@@ -1390,6 +2011,10 @@
                                 "key": {
                                   "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                   "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "message": {
+                                  "description": "Message is an optional display message",
+                                  "type": "string"
                                 },
                                 "operator": {
                                   "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1428,6 +2053,10 @@
                                 "key": {
                                   "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                   "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "message": {
+                                  "description": "Message is an optional display message",
+                                  "type": "string"
                                 },
                                 "operator": {
                                   "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1470,7 +2099,7 @@
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "anyPattern": {
                           "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -1482,20 +2111,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1520,6 +2196,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1603,6 +2312,10 @@
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                     "enum": [
@@ -1643,6 +2356,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1715,25 +2432,48 @@
                                     "type": "object"
                                   },
                                   "attestor": {
-                                    "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                    "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
                                   "certificates": {
-                                    "description": "Certificates specifies one or more certificates",
+                                    "description": "Certificates specifies one or more certificates.",
                                     "properties": {
                                       "cert": {
-                                        "description": "Certificate is an optional PEM encoded public certificate.",
+                                        "description": "Cert is an optional PEM-encoded public certificate.",
                                         "type": "string"
                                       },
                                       "certChain": {
-                                        "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                        "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                         "type": "string"
                                       },
-                                      "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                         "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1757,15 +2497,38 @@
                                         "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                         "type": "object"
                                       },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1780,7 +2543,7 @@
                                         "type": "string"
                                       },
                                       "subject": {
-                                        "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                        "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
                                       }
                                     },
@@ -1788,8 +2551,23 @@
                                     "additionalProperties": false
                                   },
                                   "keys": {
-                                    "description": "Keys specifies one or more public keys",
+                                    "description": "Keys specifies one or more public keys.",
                                     "properties": {
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "kms": {
                                         "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                         "type": "string"
@@ -1799,10 +2577,18 @@
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1833,7 +2619,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -1980,7 +2766,7 @@
                         "type": "string"
                       },
                       "version": {
-                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                         "enum": [
                           "v1.19",
                           "v1.20",
@@ -1989,6 +2775,7 @@
                           "v1.23",
                           "v1.24",
                           "v1.25",
+                          "v1.26",
                           "latest"
                         ],
                         "type": "string"
@@ -2012,7 +2799,7 @@
                         "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                         "properties": {
                           "attestors": {
-                            "description": "Attestors specify the required attestors (i.e. authorities)",
+                            "description": "Attestors specify the required attestors (i.e. authorities).",
                             "items": {
                               "properties": {
                                 "count": {
@@ -2032,25 +2819,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2074,15 +2884,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2097,7 +2930,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -2105,8 +2938,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -2116,10 +2964,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2150,7 +3006,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -2186,6 +3042,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -2228,6 +3088,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -2267,13 +3131,14 @@
                             "type": "array"
                           },
                           "predicateType": {
-                            "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                            "description": "Deprecated in favour of 'Type', to be removed soon",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type defines the type of attestation contained within the Statement.",
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "predicateType"
-                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2300,25 +3165,48 @@
                                   "type": "object"
                                 },
                                 "attestor": {
-                                  "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                  "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                   "x-kubernetes-preserve-unknown-fields": true
                                 },
                                 "certificates": {
-                                  "description": "Certificates specifies one or more certificates",
+                                  "description": "Certificates specifies one or more certificates.",
                                   "properties": {
                                     "cert": {
-                                      "description": "Certificate is an optional PEM encoded public certificate.",
+                                      "description": "Cert is an optional PEM-encoded public certificate.",
                                       "type": "string"
                                     },
                                     "certChain": {
-                                      "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                      "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                       "type": "string"
                                     },
-                                    "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                       "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2342,15 +3230,38 @@
                                       "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                       "type": "object"
                                     },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2365,7 +3276,7 @@
                                       "type": "string"
                                     },
                                     "subject": {
-                                      "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                      "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
                                     }
                                   },
@@ -2373,8 +3284,23 @@
                                   "additionalProperties": false
                                 },
                                 "keys": {
-                                  "description": "Keys specifies one or more public keys",
+                                  "description": "Keys specifies one or more public keys.",
                                   "properties": {
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "kms": {
                                       "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                       "type": "string"
@@ -2384,10 +3310,18 @@
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2418,7 +3352,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -2448,6 +3382,39 @@
                       },
                       "type": "array"
                     },
+                    "imageRegistryCredentials": {
+                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                      "properties": {
+                        "allowInsecureRegistry": {
+                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                          "items": {
+                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                            "enum": [
+                              "default",
+                              "amazon",
+                              "azure",
+                              "google",
+                              "github"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secrets": {
+                          "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "mutateDigest": {
                       "default": true,
                       "description": "MutateDigest enables replacement of image tags with digests. Defaults to true.",
@@ -2462,6 +3429,19 @@
                       "description": "Required validates that images are verified i.e. have matched passed a signature or attestation check.",
                       "type": "boolean"
                     },
+                    "type": {
+                      "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                      "enum": [
+                        "Cosign",
+                        "Notary"
+                      ],
+                      "type": "string"
+                    },
+                    "useCache": {
+                      "default": true,
+                      "description": "UseCache enables caching of image verify responses for this rule",
+                      "type": "boolean"
+                    },
                     "verifyDigest": {
                       "default": true,
                       "description": "VerifyDigest validates that images have a digest.",
@@ -2474,6 +3454,9 @@
                 "type": "array"
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -2481,6 +3464,10 @@
         },
         "schemaValidation": {
           "description": "SchemaValidation skips validation checks for policies as well as patched resources. Optional. The default value is set to \"true\", it must be set to \"false\" to disable the validation checks.",
+          "type": "boolean"
+        },
+        "useServerSideApply": {
+          "description": "UseServerSideApply controls whether to use server-side apply for generate rules If is set to \"true\" create & update for generate rules will use apply instead of create/update. Defaults to \"false\" if not specified.",
           "type": "boolean"
         },
         "validationFailureAction": {
@@ -2508,6 +3495,51 @@
                 ],
                 "type": "string"
               },
+              "namespaceSelector": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
               "namespaces": {
                 "items": {
                   "type": "string"
@@ -2533,33 +3565,103 @@
       "description": "Status contains policy runtime data.",
       "properties": {
         "autogen": {
-          "description": "Autogen contains autogen status information",
+          "description": "AutogenStatus contains autogen status information.",
           "properties": {
             "rules": {
               "description": "Rules is a list of Rule instances. It contains auto generated rules added for pod controllers",
               "items": {
                 "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
                 "properties": {
+                  "celPreconditions": {
+                    "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                    "items": {
+                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "properties": {
+                        "expression": {
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "expression",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "context": {
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                       "properties": {
                         "apiCall": {
-                          "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                          "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                           "properties": {
+                            "data": {
+                              "description": "Data specifies the POST data sent to the server.",
+                              "items": {
+                                "description": "RequestData contains the HTTP POST data",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is a unique identifier for the data value",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the data value",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
                             "jmesPath": {
-                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                               "type": "string"
                             },
+                            "method": {
+                              "default": "GET",
+                              "description": "Method is the HTTP request type (GET or POST).",
+                              "enum": [
+                                "GET",
+                                "POST"
+                              ],
+                              "type": "string"
+                            },
+                            "service": {
+                              "description": "Service is an API call to a JSON web service",
+                              "properties": {
+                                "caBundle": {
+                                  "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "urlPath": {
-                              "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                              "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "urlPath"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -2584,6 +3686,39 @@
                         "imageRegistry": {
                           "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                           "properties": {
+                            "imageRegistryCredentials": {
+                              "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                              "properties": {
+                                "allowInsecureRegistry": {
+                                  "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                  "type": "boolean"
+                                },
+                                "providers": {
+                                  "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                  "items": {
+                                    "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                    "enum": [
+                                      "default",
+                                      "amazon",
+                                      "azure",
+                                      "google",
+                                      "github"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secrets": {
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                               "type": "string"
@@ -2719,6 +3854,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -2909,6 +4058,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -3086,6 +4249,20 @@
                           "namespaces": {
                             "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                             "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
                               "type": "string"
                             },
                             "type": "array"
@@ -3286,6 +4463,10 @@
                       "synchronize": {
                         "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                         "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -3295,6 +4476,10 @@
                     "additionalProperties": {
                       "items": {
                         "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
                           "key": {
                             "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                             "type": "string"
@@ -3414,6 +4599,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -3604,6 +4803,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -3785,6 +4998,20 @@
                             },
                             "type": "array"
                           },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "selector": {
                             "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                             "properties": {
@@ -3883,7 +5110,7 @@
                       "foreach": {
                         "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -3891,20 +5118,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -3929,6 +5203,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -3981,6 +5288,14 @@
                               "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                               "type": "string"
                             },
+                            "order": {
+                              "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                              "enum": [
+                                "Ascending",
+                                "Descending"
+                              ],
+                              "type": "string"
+                            },
                             "patchStrategicMerge": {
                               "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                               "x-kubernetes-preserve-unknown-fields": true
@@ -4000,6 +5315,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4041,6 +5360,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4096,10 +5419,179 @@
                       "targets": {
                         "description": "Targets defines the target resources to be mutated.",
                         "items": {
+                          "description": "TargetResourceSpec defines targets for mutating existing resources.",
                           "properties": {
                             "apiVersion": {
                               "description": "APIVersion specifies resource apiVersion.",
                               "type": "string"
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "kind": {
                               "description": "Kind specifies resource kind.",
@@ -4111,6 +5603,14 @@
                             },
                             "namespace": {
                               "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
                               "type": "string"
                             }
                           },
@@ -4139,6 +5639,170 @@
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
+                      "cel": {
+                        "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                        "properties": {
+                          "auditAnnotations": {
+                            "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                            "items": {
+                              "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                              "properties": {
+                                "key": {
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                                  "type": "string"
+                                },
+                                "valueExpression": {
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "valueExpression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "expressions": {
+                            "description": "Expressions is a list of CELExpression types.",
+                            "items": {
+                              "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                                  "type": "string"
+                                },
+                                "messageExpression": {
+                                  "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "paramKind": {
+                            "description": "ParamKind is a tuple of Group Kind and Version.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the API kind the resources belong to. Required.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "paramRef": {
+                            "description": "ParamRef references a parameter resource.",
+                            "properties": {
+                              "name": {
+                                "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                                "type": "string"
+                              },
+                              "parameterNotFoundAction": {
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                                "type": "string"
+                              },
+                              "selector": {
+                                "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "variables": {
+                            "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                            "items": {
+                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "deny": {
                         "description": "Deny defines conditions used to pass or fail a validation rule.",
                         "properties": {
@@ -4153,7 +5817,7 @@
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "anyPattern": {
                               "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -4165,20 +5829,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -4203,6 +5914,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -4286,6 +6030,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -4326,6 +6074,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4398,25 +6150,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4440,15 +6215,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4463,7 +6261,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -4471,8 +6269,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -4482,10 +6295,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4516,7 +6337,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -4663,7 +6484,7 @@
                             "type": "string"
                           },
                           "version": {
-                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                             "enum": [
                               "v1.19",
                               "v1.20",
@@ -4672,6 +6493,7 @@
                               "v1.23",
                               "v1.24",
                               "v1.25",
+                              "v1.26",
                               "latest"
                             ],
                             "type": "string"
@@ -4693,14 +6515,14 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                          "description": "Deprecated.",
                           "type": "object"
                         },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                          "description": "Deprecated. Use annotations per Attestor instead.",
                           "type": "object"
                         },
                         "attestations": {
@@ -4709,7 +6531,7 @@
                             "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                             "properties": {
                               "attestors": {
-                                "description": "Attestors specify the required attestors (i.e. authorities)",
+                                "description": "Attestors specify the required attestors (i.e. authorities).",
                                 "items": {
                                   "properties": {
                                     "count": {
@@ -4729,25 +6551,48 @@
                                             "type": "object"
                                           },
                                           "attestor": {
-                                            "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                            "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
                                           "certificates": {
-                                            "description": "Certificates specifies one or more certificates",
+                                            "description": "Certificates specifies one or more certificates.",
                                             "properties": {
                                               "cert": {
-                                                "description": "Certificate is an optional PEM encoded public certificate.",
+                                                "description": "Cert is an optional PEM-encoded public certificate.",
                                                 "type": "string"
                                               },
                                               "certChain": {
-                                                "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                                "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                                 "type": "string"
                                               },
-                                              "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                                 "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4771,15 +6616,38 @@
                                                 "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                                 "type": "object"
                                               },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4794,7 +6662,7 @@
                                                 "type": "string"
                                               },
                                               "subject": {
-                                                "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                                "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
                                               }
                                             },
@@ -4802,8 +6670,23 @@
                                             "additionalProperties": false
                                           },
                                           "keys": {
-                                            "description": "Keys specifies one or more public keys",
+                                            "description": "Keys specifies one or more public keys.",
                                             "properties": {
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "kms": {
                                                 "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                                 "type": "string"
@@ -4813,10 +6696,18 @@
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4847,7 +6738,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                                 "type": "string"
                                               }
                                             },
@@ -4883,6 +6774,10 @@
                                           "key": {
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
                                           },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4925,6 +6820,10 @@
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
+                                          },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                             "enum": [
@@ -4964,13 +6863,14 @@
                                 "type": "array"
                               },
                               "predicateType": {
-                                "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                                "description": "Deprecated in favour of 'Type', to be removed soon",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type defines the type of attestation contained within the Statement.",
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "predicateType"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -4997,25 +6897,48 @@
                                       "type": "object"
                                     },
                                     "attestor": {
-                                      "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                      "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                       "x-kubernetes-preserve-unknown-fields": true
                                     },
                                     "certificates": {
-                                      "description": "Certificates specifies one or more certificates",
+                                      "description": "Certificates specifies one or more certificates.",
                                       "properties": {
                                         "cert": {
-                                          "description": "Certificate is an optional PEM encoded public certificate.",
+                                          "description": "Cert is an optional PEM-encoded public certificate.",
                                           "type": "string"
                                         },
                                         "certChain": {
-                                          "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                          "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                           "type": "string"
                                         },
-                                        "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                           "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5039,15 +6962,38 @@
                                           "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                           "type": "object"
                                         },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5062,7 +7008,7 @@
                                           "type": "string"
                                         },
                                         "subject": {
-                                          "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                          "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
                                         }
                                       },
@@ -5070,8 +7016,23 @@
                                       "additionalProperties": false
                                     },
                                     "keys": {
-                                      "description": "Keys specifies one or more public keys",
+                                      "description": "Keys specifies one or more public keys.",
                                       "properties": {
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "kms": {
                                           "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                           "type": "string"
@@ -5081,10 +7042,18 @@
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5115,7 +7084,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                           "type": "string"
                                         }
                                       },
@@ -5139,7 +7108,7 @@
                           "type": "array"
                         },
                         "image": {
-                          "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                          "description": "Deprecated. Use ImageReferences instead.",
                           "type": "string"
                         },
                         "imageReferences": {
@@ -5149,12 +7118,45 @@
                           },
                           "type": "array"
                         },
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "issuer": {
-                          "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "key": {
-                          "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                          "description": "Deprecated. Use StaticKeyAttestor instead.",
                           "type": "string"
                         },
                         "mutateDigest": {
@@ -5172,12 +7174,25 @@
                           "type": "boolean"
                         },
                         "roots": {
-                          "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "subject": {
-                          "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
+                        },
+                        "type": {
+                          "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "enum": [
+                            "Cosign",
+                            "Notary"
+                          ],
+                          "type": "string"
+                        },
+                        "useCache": {
+                          "default": true,
+                          "description": "UseCache enables caching of image verify responses for this rule.",
+                          "type": "boolean"
                         },
                         "verifyDigest": {
                           "default": true,
@@ -5191,6 +7206,9 @@
                     "type": "array"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -5201,7 +7219,6 @@
           "additionalProperties": false
         },
         "conditions": {
-          "description": "Conditions is a list of conditions that apply to the policy",
           "items": {
             "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
             "properties": {
@@ -5257,11 +7274,11 @@
           "type": "array"
         },
         "ready": {
-          "description": "Ready indicates if the policy is ready to serve the admission request. Deprecated in favor of Conditions",
+          "description": "Deprecated in favor of Conditions",
           "type": "boolean"
         },
         "rulecount": {
-          "description": "RuleCount describes total number of rules in a policy",
+          "description": "RuleCountStatus contains four variables which describes counts for validate, generate, mutate and verify images rules",
           "properties": {
             "generate": {
               "description": "Count for generate rules in policy",
@@ -5285,6 +7302,25 @@
             "mutate",
             "validate",
             "verifyimages"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "validatingadmissionpolicy": {
+          "description": "ValidatingAdmissionPolicy contains status information",
+          "properties": {
+            "generated": {
+              "description": "Generated indicates whether a validating admission policy is generated from the policy or not",
+              "type": "boolean"
+            },
+            "message": {
+              "description": "Message is a human readable message indicating details about the generation of validating admission policy It is an empty string when validating admission policy is successfully generated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "generated",
+            "message"
           ],
           "type": "object",
           "additionalProperties": false

--- a/kyverno.io/policy_v1.json
+++ b/kyverno.io/policy_v1.json
@@ -15,6 +15,11 @@
     "spec": {
       "description": "Spec defines policy behaviors and contains one or more rules.",
       "properties": {
+        "admission": {
+          "default": true,
+          "description": "Admission controls if rules are applied during admission. Optional. Default value is \"true\".",
+          "type": "boolean"
+        },
         "applyRules": {
           "description": "ApplyRules controls how rules in a policy are applied. Rule are processed in the order of declaration. When set to `One` processing stops after a rule has been applied i.e. the rule matches and results in a pass, fail, or error. When set to `All` all rules in the policy are processed. The default is `All`.",
           "enum": [
@@ -36,8 +41,12 @@
           ],
           "type": "string"
         },
+        "generateExisting": {
+          "description": "GenerateExisting controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "type": "boolean"
+        },
         "generateExistingOnPolicyUpdate": {
-          "description": "GenerateExistingOnPolicyUpdate controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting instead",
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
@@ -49,26 +58,96 @@
           "items": {
             "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
             "properties": {
+              "celPreconditions": {
+                "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                "items": {
+                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
               "context": {
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                   "properties": {
                     "apiCall": {
-                      "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                      "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                       "properties": {
+                        "data": {
+                          "description": "Data specifies the POST data sent to the server.",
+                          "items": {
+                            "description": "RequestData contains the HTTP POST data",
+                            "properties": {
+                              "key": {
+                                "description": "Key is a unique identifier for the data value",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the data value",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "jmesPath": {
-                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                           "type": "string"
                         },
+                        "method": {
+                          "default": "GET",
+                          "description": "Method is the HTTP request type (GET or POST).",
+                          "enum": [
+                            "GET",
+                            "POST"
+                          ],
+                          "type": "string"
+                        },
+                        "service": {
+                          "description": "Service is an API call to a JSON web service",
+                          "properties": {
+                            "caBundle": {
+                              "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "urlPath": {
-                          "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                          "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "urlPath"
-                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -93,6 +172,39 @@
                     "imageRegistry": {
                       "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                       "properties": {
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                           "type": "string"
@@ -228,6 +340,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -418,6 +544,20 @@
                               },
                               "type": "array"
                             },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "selector": {
                               "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                               "properties": {
@@ -595,6 +735,20 @@
                       "namespaces": {
                         "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                         "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
                           "type": "string"
                         },
                         "type": "array"
@@ -795,6 +949,10 @@
                   "synchronize": {
                     "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                     "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
                   }
                 },
                 "type": "object",
@@ -804,6 +962,10 @@
                 "additionalProperties": {
                   "items": {
                     "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
                       "key": {
                         "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                         "type": "string"
@@ -923,6 +1085,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -1113,6 +1289,20 @@
                               },
                               "type": "array"
                             },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "selector": {
                               "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                               "properties": {
@@ -1294,6 +1484,20 @@
                         },
                         "type": "array"
                       },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "selector": {
                         "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                         "properties": {
@@ -1392,7 +1596,7 @@
                   "foreach": {
                     "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -1400,20 +1604,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1438,6 +1689,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1490,6 +1774,14 @@
                           "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                           "type": "string"
                         },
+                        "order": {
+                          "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                          "enum": [
+                            "Ascending",
+                            "Descending"
+                          ],
+                          "type": "string"
+                        },
                         "patchStrategicMerge": {
                           "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                           "x-kubernetes-preserve-unknown-fields": true
@@ -1509,6 +1801,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1550,6 +1846,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1605,10 +1905,179 @@
                   "targets": {
                     "description": "Targets defines the target resources to be mutated.",
                     "items": {
+                      "description": "TargetResourceSpec defines targets for mutating existing resources.",
                       "properties": {
                         "apiVersion": {
                           "description": "APIVersion specifies resource apiVersion.",
                           "type": "string"
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "kind": {
                           "description": "Kind specifies resource kind.",
@@ -1620,6 +2089,14 @@
                         },
                         "namespace": {
                           "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
                           "type": "string"
                         }
                       },
@@ -1648,6 +2125,170 @@
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "cel": {
+                    "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                    "properties": {
+                      "auditAnnotations": {
+                        "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                        "items": {
+                          "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                          "properties": {
+                            "key": {
+                              "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                              "type": "string"
+                            },
+                            "valueExpression": {
+                              "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "valueExpression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "expressions": {
+                        "description": "Expressions is a list of CELExpression types.",
+                        "items": {
+                          "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                              "type": "string"
+                            },
+                            "messageExpression": {
+                              "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "paramKind": {
+                        "description": "ParamKind is a tuple of Group Kind and Version.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind is the API kind the resources belong to. Required.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "paramRef": {
+                        "description": "ParamRef references a parameter resource.",
+                        "properties": {
+                          "name": {
+                            "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                            "type": "string"
+                          },
+                          "parameterNotFoundAction": {
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "variables": {
+                        "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                        "items": {
+                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "deny": {
                     "description": "Deny defines conditions used to pass or fail a validation rule.",
                     "properties": {
@@ -1662,7 +2303,7 @@
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "anyPattern": {
                           "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -1674,20 +2315,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1712,6 +2400,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1795,6 +2516,10 @@
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                     "enum": [
@@ -1835,6 +2560,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1907,25 +2636,48 @@
                                     "type": "object"
                                   },
                                   "attestor": {
-                                    "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                    "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
                                   "certificates": {
-                                    "description": "Certificates specifies one or more certificates",
+                                    "description": "Certificates specifies one or more certificates.",
                                     "properties": {
                                       "cert": {
-                                        "description": "Certificate is an optional PEM encoded public certificate.",
+                                        "description": "Cert is an optional PEM-encoded public certificate.",
                                         "type": "string"
                                       },
                                       "certChain": {
-                                        "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                        "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                         "type": "string"
                                       },
-                                      "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                         "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1949,15 +2701,38 @@
                                         "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                         "type": "object"
                                       },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1972,7 +2747,7 @@
                                         "type": "string"
                                       },
                                       "subject": {
-                                        "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                        "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
                                       }
                                     },
@@ -1980,8 +2755,23 @@
                                     "additionalProperties": false
                                   },
                                   "keys": {
-                                    "description": "Keys specifies one or more public keys",
+                                    "description": "Keys specifies one or more public keys.",
                                     "properties": {
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "kms": {
                                         "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                         "type": "string"
@@ -1991,10 +2781,18 @@
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -2025,7 +2823,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -2172,7 +2970,7 @@
                         "type": "string"
                       },
                       "version": {
-                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                         "enum": [
                           "v1.19",
                           "v1.20",
@@ -2181,6 +2979,7 @@
                           "v1.23",
                           "v1.24",
                           "v1.25",
+                          "v1.26",
                           "latest"
                         ],
                         "type": "string"
@@ -2202,14 +3001,14 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                      "description": "Deprecated.",
                       "type": "object"
                     },
                     "annotations": {
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                      "description": "Deprecated. Use annotations per Attestor instead.",
                       "type": "object"
                     },
                     "attestations": {
@@ -2218,7 +3017,7 @@
                         "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                         "properties": {
                           "attestors": {
-                            "description": "Attestors specify the required attestors (i.e. authorities)",
+                            "description": "Attestors specify the required attestors (i.e. authorities).",
                             "items": {
                               "properties": {
                                 "count": {
@@ -2238,25 +3037,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2280,15 +3102,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2303,7 +3148,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -2311,8 +3156,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -2322,10 +3182,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2356,7 +3224,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -2392,6 +3260,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -2434,6 +3306,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -2473,13 +3349,14 @@
                             "type": "array"
                           },
                           "predicateType": {
-                            "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                            "description": "Deprecated in favour of 'Type', to be removed soon",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type defines the type of attestation contained within the Statement.",
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "predicateType"
-                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2506,25 +3383,48 @@
                                   "type": "object"
                                 },
                                 "attestor": {
-                                  "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                  "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                   "x-kubernetes-preserve-unknown-fields": true
                                 },
                                 "certificates": {
-                                  "description": "Certificates specifies one or more certificates",
+                                  "description": "Certificates specifies one or more certificates.",
                                   "properties": {
                                     "cert": {
-                                      "description": "Certificate is an optional PEM encoded public certificate.",
+                                      "description": "Cert is an optional PEM-encoded public certificate.",
                                       "type": "string"
                                     },
                                     "certChain": {
-                                      "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                      "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                       "type": "string"
                                     },
-                                    "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                       "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2548,15 +3448,38 @@
                                       "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                       "type": "object"
                                     },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2571,7 +3494,7 @@
                                       "type": "string"
                                     },
                                     "subject": {
-                                      "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                      "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
                                     }
                                   },
@@ -2579,8 +3502,23 @@
                                   "additionalProperties": false
                                 },
                                 "keys": {
-                                  "description": "Keys specifies one or more public keys",
+                                  "description": "Keys specifies one or more public keys.",
                                   "properties": {
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "kms": {
                                       "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                       "type": "string"
@@ -2590,10 +3528,18 @@
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2624,7 +3570,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -2648,7 +3594,7 @@
                       "type": "array"
                     },
                     "image": {
-                      "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                      "description": "Deprecated. Use ImageReferences instead.",
                       "type": "string"
                     },
                     "imageReferences": {
@@ -2658,12 +3604,45 @@
                       },
                       "type": "array"
                     },
+                    "imageRegistryCredentials": {
+                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                      "properties": {
+                        "allowInsecureRegistry": {
+                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                          "items": {
+                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                            "enum": [
+                              "default",
+                              "amazon",
+                              "azure",
+                              "google",
+                              "github"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secrets": {
+                          "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "issuer": {
-                      "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
                     },
                     "key": {
-                      "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                      "description": "Deprecated. Use StaticKeyAttestor instead.",
                       "type": "string"
                     },
                     "mutateDigest": {
@@ -2681,12 +3660,25 @@
                       "type": "boolean"
                     },
                     "roots": {
-                      "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
                     },
                     "subject": {
-                      "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                      "description": "Deprecated. Use KeylessAttestor instead.",
                       "type": "string"
+                    },
+                    "type": {
+                      "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                      "enum": [
+                        "Cosign",
+                        "Notary"
+                      ],
+                      "type": "string"
+                    },
+                    "useCache": {
+                      "default": true,
+                      "description": "UseCache enables caching of image verify responses for this rule.",
+                      "type": "boolean"
                     },
                     "verifyDigest": {
                       "default": true,
@@ -2700,6 +3692,9 @@
                 "type": "array"
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -2707,6 +3702,10 @@
         },
         "schemaValidation": {
           "description": "SchemaValidation skips validation checks for policies as well as patched resources. Optional. The default value is set to \"true\", it must be set to \"false\" to disable the validation checks.",
+          "type": "boolean"
+        },
+        "useServerSideApply": {
+          "description": "UseServerSideApply controls whether to use server-side apply for generate rules If is set to \"true\" create & update for generate rules will use apply instead of create/update. Defaults to \"false\" if not specified.",
           "type": "boolean"
         },
         "validationFailureAction": {
@@ -2734,6 +3733,51 @@
                 ],
                 "type": "string"
               },
+              "namespaceSelector": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
               "namespaces": {
                 "items": {
                   "type": "string"
@@ -2756,36 +3800,106 @@
       "additionalProperties": false
     },
     "status": {
-      "description": "Status contains policy runtime information. Deprecated. Policy metrics are available via the metrics endpoint",
+      "description": "Deprecated. Policy metrics are available via the metrics endpoint",
       "properties": {
         "autogen": {
-          "description": "Autogen contains autogen status information",
+          "description": "AutogenStatus contains autogen status information.",
           "properties": {
             "rules": {
               "description": "Rules is a list of Rule instances. It contains auto generated rules added for pod controllers",
               "items": {
                 "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
                 "properties": {
+                  "celPreconditions": {
+                    "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                    "items": {
+                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "properties": {
+                        "expression": {
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "expression",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "context": {
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                       "properties": {
                         "apiCall": {
-                          "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                          "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                           "properties": {
+                            "data": {
+                              "description": "Data specifies the POST data sent to the server.",
+                              "items": {
+                                "description": "RequestData contains the HTTP POST data",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is a unique identifier for the data value",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the data value",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
                             "jmesPath": {
-                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                               "type": "string"
                             },
+                            "method": {
+                              "default": "GET",
+                              "description": "Method is the HTTP request type (GET or POST).",
+                              "enum": [
+                                "GET",
+                                "POST"
+                              ],
+                              "type": "string"
+                            },
+                            "service": {
+                              "description": "Service is an API call to a JSON web service",
+                              "properties": {
+                                "caBundle": {
+                                  "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "urlPath": {
-                              "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                              "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "urlPath"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -2810,6 +3924,39 @@
                         "imageRegistry": {
                           "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                           "properties": {
+                            "imageRegistryCredentials": {
+                              "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                              "properties": {
+                                "allowInsecureRegistry": {
+                                  "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                  "type": "boolean"
+                                },
+                                "providers": {
+                                  "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                  "items": {
+                                    "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                    "enum": [
+                                      "default",
+                                      "amazon",
+                                      "azure",
+                                      "google",
+                                      "github"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secrets": {
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                               "type": "string"
@@ -2945,6 +4092,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -3135,6 +4296,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -3312,6 +4487,20 @@
                           "namespaces": {
                             "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                             "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
                               "type": "string"
                             },
                             "type": "array"
@@ -3512,6 +4701,10 @@
                       "synchronize": {
                         "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                         "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -3521,6 +4714,10 @@
                     "additionalProperties": {
                       "items": {
                         "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
                           "key": {
                             "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                             "type": "string"
@@ -3640,6 +4837,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -3830,6 +5041,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -4011,6 +5236,20 @@
                             },
                             "type": "array"
                           },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "selector": {
                             "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                             "properties": {
@@ -4109,7 +5348,7 @@
                       "foreach": {
                         "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -4117,20 +5356,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -4155,6 +5441,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -4207,6 +5526,14 @@
                               "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                               "type": "string"
                             },
+                            "order": {
+                              "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                              "enum": [
+                                "Ascending",
+                                "Descending"
+                              ],
+                              "type": "string"
+                            },
                             "patchStrategicMerge": {
                               "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                               "x-kubernetes-preserve-unknown-fields": true
@@ -4226,6 +5553,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4267,6 +5598,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4322,10 +5657,179 @@
                       "targets": {
                         "description": "Targets defines the target resources to be mutated.",
                         "items": {
+                          "description": "TargetResourceSpec defines targets for mutating existing resources.",
                           "properties": {
                             "apiVersion": {
                               "description": "APIVersion specifies resource apiVersion.",
                               "type": "string"
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "kind": {
                               "description": "Kind specifies resource kind.",
@@ -4337,6 +5841,14 @@
                             },
                             "namespace": {
                               "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
                               "type": "string"
                             }
                           },
@@ -4365,6 +5877,170 @@
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
+                      "cel": {
+                        "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                        "properties": {
+                          "auditAnnotations": {
+                            "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                            "items": {
+                              "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                              "properties": {
+                                "key": {
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                                  "type": "string"
+                                },
+                                "valueExpression": {
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "valueExpression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "expressions": {
+                            "description": "Expressions is a list of CELExpression types.",
+                            "items": {
+                              "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                                  "type": "string"
+                                },
+                                "messageExpression": {
+                                  "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "paramKind": {
+                            "description": "ParamKind is a tuple of Group Kind and Version.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the API kind the resources belong to. Required.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "paramRef": {
+                            "description": "ParamRef references a parameter resource.",
+                            "properties": {
+                              "name": {
+                                "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                                "type": "string"
+                              },
+                              "parameterNotFoundAction": {
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                                "type": "string"
+                              },
+                              "selector": {
+                                "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "variables": {
+                            "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                            "items": {
+                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "deny": {
                         "description": "Deny defines conditions used to pass or fail a validation rule.",
                         "properties": {
@@ -4379,7 +6055,7 @@
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "anyPattern": {
                               "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -4391,20 +6067,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -4429,6 +6152,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -4512,6 +6268,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -4552,6 +6312,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4624,25 +6388,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4666,15 +6453,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4689,7 +6499,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -4697,8 +6507,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -4708,10 +6533,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4742,7 +6575,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -4889,7 +6722,7 @@
                             "type": "string"
                           },
                           "version": {
-                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                             "enum": [
                               "v1.19",
                               "v1.20",
@@ -4898,6 +6731,7 @@
                               "v1.23",
                               "v1.24",
                               "v1.25",
+                              "v1.26",
                               "latest"
                             ],
                             "type": "string"
@@ -4919,14 +6753,14 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                          "description": "Deprecated.",
                           "type": "object"
                         },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                          "description": "Deprecated. Use annotations per Attestor instead.",
                           "type": "object"
                         },
                         "attestations": {
@@ -4935,7 +6769,7 @@
                             "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                             "properties": {
                               "attestors": {
-                                "description": "Attestors specify the required attestors (i.e. authorities)",
+                                "description": "Attestors specify the required attestors (i.e. authorities).",
                                 "items": {
                                   "properties": {
                                     "count": {
@@ -4955,25 +6789,48 @@
                                             "type": "object"
                                           },
                                           "attestor": {
-                                            "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                            "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
                                           "certificates": {
-                                            "description": "Certificates specifies one or more certificates",
+                                            "description": "Certificates specifies one or more certificates.",
                                             "properties": {
                                               "cert": {
-                                                "description": "Certificate is an optional PEM encoded public certificate.",
+                                                "description": "Cert is an optional PEM-encoded public certificate.",
                                                 "type": "string"
                                               },
                                               "certChain": {
-                                                "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                                "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                                 "type": "string"
                                               },
-                                              "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                                 "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4997,15 +6854,38 @@
                                                 "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                                 "type": "object"
                                               },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -5020,7 +6900,7 @@
                                                 "type": "string"
                                               },
                                               "subject": {
-                                                "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                                "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
                                               }
                                             },
@@ -5028,8 +6908,23 @@
                                             "additionalProperties": false
                                           },
                                           "keys": {
-                                            "description": "Keys specifies one or more public keys",
+                                            "description": "Keys specifies one or more public keys.",
                                             "properties": {
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "kms": {
                                                 "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                                 "type": "string"
@@ -5039,10 +6934,18 @@
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -5073,7 +6976,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                                 "type": "string"
                                               }
                                             },
@@ -5109,6 +7012,10 @@
                                           "key": {
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
                                           },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -5151,6 +7058,10 @@
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
+                                          },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                             "enum": [
@@ -5190,13 +7101,14 @@
                                 "type": "array"
                               },
                               "predicateType": {
-                                "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                                "description": "Deprecated in favour of 'Type', to be removed soon",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type defines the type of attestation contained within the Statement.",
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "predicateType"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -5223,25 +7135,48 @@
                                       "type": "object"
                                     },
                                     "attestor": {
-                                      "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                      "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                       "x-kubernetes-preserve-unknown-fields": true
                                     },
                                     "certificates": {
-                                      "description": "Certificates specifies one or more certificates",
+                                      "description": "Certificates specifies one or more certificates.",
                                       "properties": {
                                         "cert": {
-                                          "description": "Certificate is an optional PEM encoded public certificate.",
+                                          "description": "Cert is an optional PEM-encoded public certificate.",
                                           "type": "string"
                                         },
                                         "certChain": {
-                                          "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                          "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                           "type": "string"
                                         },
-                                        "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                           "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5265,15 +7200,38 @@
                                           "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                           "type": "object"
                                         },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5288,7 +7246,7 @@
                                           "type": "string"
                                         },
                                         "subject": {
-                                          "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                          "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
                                         }
                                       },
@@ -5296,8 +7254,23 @@
                                       "additionalProperties": false
                                     },
                                     "keys": {
-                                      "description": "Keys specifies one or more public keys",
+                                      "description": "Keys specifies one or more public keys.",
                                       "properties": {
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "kms": {
                                           "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                           "type": "string"
@@ -5307,10 +7280,18 @@
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5341,7 +7322,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                           "type": "string"
                                         }
                                       },
@@ -5365,7 +7346,7 @@
                           "type": "array"
                         },
                         "image": {
-                          "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                          "description": "Deprecated. Use ImageReferences instead.",
                           "type": "string"
                         },
                         "imageReferences": {
@@ -5375,12 +7356,45 @@
                           },
                           "type": "array"
                         },
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "issuer": {
-                          "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "key": {
-                          "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                          "description": "Deprecated. Use StaticKeyAttestor instead.",
                           "type": "string"
                         },
                         "mutateDigest": {
@@ -5398,12 +7412,25 @@
                           "type": "boolean"
                         },
                         "roots": {
-                          "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "subject": {
-                          "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
+                        },
+                        "type": {
+                          "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "enum": [
+                            "Cosign",
+                            "Notary"
+                          ],
+                          "type": "string"
+                        },
+                        "useCache": {
+                          "default": true,
+                          "description": "UseCache enables caching of image verify responses for this rule.",
+                          "type": "boolean"
                         },
                         "verifyDigest": {
                           "default": true,
@@ -5417,6 +7444,9 @@
                     "type": "array"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -5427,7 +7457,6 @@
           "additionalProperties": false
         },
         "conditions": {
-          "description": "Conditions is a list of conditions that apply to the policy",
           "items": {
             "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
             "properties": {
@@ -5483,11 +7512,11 @@
           "type": "array"
         },
         "ready": {
-          "description": "Ready indicates if the policy is ready to serve the admission request. Deprecated in favor of Conditions",
+          "description": "Deprecated in favor of Conditions",
           "type": "boolean"
         },
         "rulecount": {
-          "description": "RuleCount describes total number of rules in a policy",
+          "description": "RuleCountStatus contains four variables which describes counts for validate, generate, mutate and verify images rules",
           "properties": {
             "generate": {
               "description": "Count for generate rules in policy",
@@ -5511,6 +7540,25 @@
             "mutate",
             "validate",
             "verifyimages"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "validatingadmissionpolicy": {
+          "description": "ValidatingAdmissionPolicy contains status information",
+          "properties": {
+            "generated": {
+              "description": "Generated indicates whether a validating admission policy is generated from the policy or not",
+              "type": "boolean"
+            },
+            "message": {
+              "description": "Message is a human readable message indicating details about the generation of validating admission policy It is an empty string when validating admission policy is successfully generated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "generated",
+            "message"
           ],
           "type": "object",
           "additionalProperties": false

--- a/kyverno.io/policy_v2beta1.json
+++ b/kyverno.io/policy_v2beta1.json
@@ -15,6 +15,11 @@
     "spec": {
       "description": "Spec defines policy behaviors and contains one or more rules.",
       "properties": {
+        "admission": {
+          "default": true,
+          "description": "Admission controls if rules are applied during admission. Optional. Default value is \"true\".",
+          "type": "boolean"
+        },
         "applyRules": {
           "description": "ApplyRules controls how rules in a policy are applied. Rule are processed in the order of declaration. When set to `One` processing stops after a rule has been applied i.e. the rule matches and results in a pass, fail, or error. When set to `All` all rules in the policy are processed. The default is `All`.",
           "enum": [
@@ -36,8 +41,12 @@
           ],
           "type": "string"
         },
+        "generateExisting": {
+          "description": "GenerateExisting controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "type": "boolean"
+        },
         "generateExistingOnPolicyUpdate": {
-          "description": "GenerateExistingOnPolicyUpdate controls whether to trigger generate rule in existing resources If is set to \"true\" generate rule will be triggered and applied to existing matched resources. Defaults to \"false\" if not specified.",
+          "description": "Deprecated, use generateExisting instead",
           "type": "boolean"
         },
         "mutateExistingOnPolicyUpdate": {
@@ -49,26 +58,96 @@
           "items": {
             "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
             "properties": {
+              "celPreconditions": {
+                "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                "items": {
+                  "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                  "properties": {
+                    "expression": {
+                      "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "expression",
+                    "name"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "type": "array"
+              },
               "context": {
                 "description": "Context defines variables and data sources that can be used during rule execution.",
                 "items": {
                   "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                   "properties": {
                     "apiCall": {
-                      "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                      "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                       "properties": {
+                        "data": {
+                          "description": "Data specifies the POST data sent to the server.",
+                          "items": {
+                            "description": "RequestData contains the HTTP POST data",
+                            "properties": {
+                              "key": {
+                                "description": "Key is a unique identifier for the data value",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Value is the data value",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "required": [
+                              "key",
+                              "value"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "jmesPath": {
-                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                          "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                           "type": "string"
                         },
+                        "method": {
+                          "default": "GET",
+                          "description": "Method is the HTTP request type (GET or POST).",
+                          "enum": [
+                            "GET",
+                            "POST"
+                          ],
+                          "type": "string"
+                        },
+                        "service": {
+                          "description": "Service is an API call to a JSON web service",
+                          "properties": {
+                            "caBundle": {
+                              "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                              "type": "string"
+                            },
+                            "url": {
+                              "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "url"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "urlPath": {
-                          "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                          "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "urlPath"
-                      ],
                       "type": "object",
                       "additionalProperties": false
                     },
@@ -93,6 +172,39 @@
                     "imageRegistry": {
                       "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                       "properties": {
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "jmesPath": {
                           "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                           "type": "string"
@@ -228,6 +340,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -414,6 +540,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -620,6 +760,10 @@
                   "synchronize": {
                     "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                     "type": "boolean"
+                  },
+                  "uid": {
+                    "description": "UID specifies the resource uid.",
+                    "type": "string"
                   }
                 },
                 "type": "object",
@@ -629,6 +773,10 @@
                 "additionalProperties": {
                   "items": {
                     "properties": {
+                      "jmesPath": {
+                        "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                        "type": "string"
+                      },
                       "key": {
                         "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                         "type": "string"
@@ -748,6 +896,20 @@
                             "namespaces": {
                               "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                               "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
                                 "type": "string"
                               },
                               "type": "array"
@@ -938,6 +1100,20 @@
                               },
                               "type": "array"
                             },
+                            "operations": {
+                              "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                              "items": {
+                                "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                "enum": [
+                                  "CREATE",
+                                  "CONNECT",
+                                  "UPDATE",
+                                  "DELETE"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
                             "selector": {
                               "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                               "properties": {
@@ -1042,7 +1218,7 @@
                   "foreach": {
                     "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "context": {
                           "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -1050,20 +1226,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1088,6 +1311,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1140,6 +1396,14 @@
                           "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                           "type": "string"
                         },
+                        "order": {
+                          "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                          "enum": [
+                            "Ascending",
+                            "Descending"
+                          ],
+                          "type": "string"
+                        },
                         "patchStrategicMerge": {
                           "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                           "x-kubernetes-preserve-unknown-fields": true
@@ -1159,6 +1423,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1200,6 +1468,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1255,10 +1527,179 @@
                   "targets": {
                     "description": "Targets defines the target resources to be mutated.",
                     "items": {
+                      "description": "TargetResourceSpec defines targets for mutating existing resources.",
                       "properties": {
                         "apiVersion": {
                           "description": "APIVersion specifies resource apiVersion.",
                           "type": "string"
+                        },
+                        "context": {
+                          "description": "Context defines variables and data sources that can be used during rule execution.",
+                          "items": {
+                            "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                            "properties": {
+                              "apiCall": {
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "type": "string"
+                                  },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "urlPath": {
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "description": "ConfigMap is the ConfigMap reference.",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the ConfigMap name.",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the ConfigMap namespace.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "imageRegistry": {
+                                "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "reference"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "description": "Name is the variable name.",
+                                "type": "string"
+                              },
+                              "variable": {
+                                "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                "properties": {
+                                  "default": {
+                                    "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "jmesPath": {
+                                    "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "kind": {
                           "description": "Kind specifies resource kind.",
@@ -1270,6 +1711,14 @@
                         },
                         "namespace": {
                           "description": "Namespace specifies resource namespace.",
+                          "type": "string"
+                        },
+                        "preconditions": {
+                          "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                          "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "uid": {
+                          "description": "UID specifies the resource uid.",
                           "type": "string"
                         }
                       },
@@ -1288,7 +1737,7 @@
                 "type": "string"
               },
               "preconditions": {
-                "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but See: https://kyverno.io/docs/writing-policies/preconditions/",
+                "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. See: https://kyverno.io/docs/writing-policies/preconditions/",
                 "properties": {
                   "all": {
                     "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
@@ -1297,6 +1746,10 @@
                         "key": {
                           "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "message": {
+                          "description": "Message is an optional display message",
+                          "type": "string"
                         },
                         "operator": {
                           "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1335,6 +1788,10 @@
                         "key": {
                           "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                           "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "message": {
+                          "description": "Message is an optional display message",
+                          "type": "string"
                         },
                         "operator": {
                           "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1377,11 +1834,175 @@
                     "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
+                  "cel": {
+                    "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                    "properties": {
+                      "auditAnnotations": {
+                        "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                        "items": {
+                          "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                          "properties": {
+                            "key": {
+                              "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                              "type": "string"
+                            },
+                            "valueExpression": {
+                              "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "valueExpression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "expressions": {
+                        "description": "Expressions is a list of CELExpression types.",
+                        "items": {
+                          "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                              "type": "string"
+                            },
+                            "message": {
+                              "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                              "type": "string"
+                            },
+                            "messageExpression": {
+                              "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                              "type": "string"
+                            },
+                            "reason": {
+                              "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "paramKind": {
+                        "description": "ParamKind is a tuple of Group Kind and Version.",
+                        "properties": {
+                          "apiVersion": {
+                            "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "Kind is the API kind the resources belong to. Required.",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "paramRef": {
+                        "description": "ParamRef references a parameter resource.",
+                        "properties": {
+                          "name": {
+                            "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                            "type": "string"
+                          },
+                          "parameterNotFoundAction": {
+                            "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "variables": {
+                        "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                        "items": {
+                          "description": "Variable is the definition of a variable that is used for composition.",
+                          "properties": {
+                            "expression": {
+                              "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "expression",
+                            "name"
+                          ],
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
                   "deny": {
                     "description": "Deny defines conditions used to pass or fail a validation rule.",
                     "properties": {
                       "conditions": {
-                        "description": "Multiple conditions can be declared under an `any` or `all` statement. A direct list of conditions (without `any` or `all` statements) is also supported for backwards compatibility See: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
+                        "description": "Multiple conditions can be declared under an `any` or `all` statement. See: https://kyverno.io/docs/writing-policies/validate/#deny-rules",
                         "properties": {
                           "all": {
                             "description": "AllConditions enable variable-based conditional rule execution. This is useful for finer control of when an rule is applied. A condition can reference object data using JMESPath notation. Here, all of the conditions need to pass.",
@@ -1390,6 +2011,10 @@
                                 "key": {
                                   "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                   "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "message": {
+                                  "description": "Message is an optional display message",
+                                  "type": "string"
                                 },
                                 "operator": {
                                   "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1428,6 +2053,10 @@
                                 "key": {
                                   "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                   "x-kubernetes-preserve-unknown-fields": true
+                                },
+                                "message": {
+                                  "description": "Message is an optional display message",
+                                  "type": "string"
                                 },
                                 "operator": {
                                   "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1470,7 +2099,7 @@
                   "foreach": {
                     "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                     "items": {
-                      "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                      "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                       "properties": {
                         "anyPattern": {
                           "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -1482,20 +2111,67 @@
                             "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                             "properties": {
                               "apiCall": {
-                                "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                 "properties": {
+                                  "data": {
+                                    "description": "Data specifies the POST data sent to the server.",
+                                    "items": {
+                                      "description": "RequestData contains the HTTP POST data",
+                                      "properties": {
+                                        "key": {
+                                          "description": "Key is a unique identifier for the data value",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value is the data value",
+                                          "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "jmesPath": {
-                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                    "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                     "type": "string"
                                   },
+                                  "method": {
+                                    "default": "GET",
+                                    "description": "Method is the HTTP request type (GET or POST).",
+                                    "enum": [
+                                      "GET",
+                                      "POST"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "service": {
+                                    "description": "Service is an API call to a JSON web service",
+                                    "properties": {
+                                      "caBundle": {
+                                        "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                        "type": "string"
+                                      },
+                                      "url": {
+                                        "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "urlPath": {
-                                    "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                    "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                     "type": "string"
                                   }
                                 },
-                                "required": [
-                                  "urlPath"
-                                ],
                                 "type": "object",
                                 "additionalProperties": false
                               },
@@ -1520,6 +2196,39 @@
                               "imageRegistry": {
                                 "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                 "properties": {
+                                  "imageRegistryCredentials": {
+                                    "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                    "properties": {
+                                      "allowInsecureRegistry": {
+                                        "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                        "type": "boolean"
+                                      },
+                                      "providers": {
+                                        "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                        "items": {
+                                          "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                          "enum": [
+                                            "default",
+                                            "amazon",
+                                            "azure",
+                                            "google",
+                                            "github"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "secrets": {
+                                        "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
                                   "jmesPath": {
                                     "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                     "type": "string"
@@ -1603,6 +2312,10 @@
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
+                                  },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                     "enum": [
@@ -1643,6 +2356,10 @@
                                   "key": {
                                     "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                     "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "message": {
+                                    "description": "Message is an optional display message",
+                                    "type": "string"
                                   },
                                   "operator": {
                                     "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -1715,25 +2432,48 @@
                                     "type": "object"
                                   },
                                   "attestor": {
-                                    "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                    "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                     "x-kubernetes-preserve-unknown-fields": true
                                   },
                                   "certificates": {
-                                    "description": "Certificates specifies one or more certificates",
+                                    "description": "Certificates specifies one or more certificates.",
                                     "properties": {
                                       "cert": {
-                                        "description": "Certificate is an optional PEM encoded public certificate.",
+                                        "description": "Cert is an optional PEM-encoded public certificate.",
                                         "type": "string"
                                       },
                                       "certChain": {
-                                        "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                        "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                         "type": "string"
                                       },
-                                      "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                         "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "rekor": {
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1757,15 +2497,38 @@
                                         "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                         "type": "object"
                                       },
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "issuer": {
                                         "description": "Issuer is the certificate issuer used for keyless signing.",
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1780,7 +2543,7 @@
                                         "type": "string"
                                       },
                                       "subject": {
-                                        "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                        "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                         "type": "string"
                                       }
                                     },
@@ -1788,8 +2551,23 @@
                                     "additionalProperties": false
                                   },
                                   "keys": {
-                                    "description": "Keys specifies one or more public keys",
+                                    "description": "Keys specifies one or more public keys.",
                                     "properties": {
+                                      "ctlog": {
+                                        "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                        "properties": {
+                                          "ignoreSCT": {
+                                            "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "kms": {
                                         "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                         "type": "string"
@@ -1799,10 +2577,18 @@
                                         "type": "string"
                                       },
                                       "rekor": {
-                                        "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                         "properties": {
+                                          "ignoreTlog": {
+                                            "description": "IgnoreTlog skips transparency log verification.",
+                                            "type": "boolean"
+                                          },
+                                          "pubkey": {
+                                            "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                            "type": "string"
+                                          },
                                           "url": {
-                                            "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                            "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                             "type": "string"
                                           }
                                         },
@@ -1833,7 +2619,7 @@
                                       },
                                       "signatureAlgorithm": {
                                         "default": "sha256",
-                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                        "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                         "type": "string"
                                       }
                                     },
@@ -1980,7 +2766,7 @@
                         "type": "string"
                       },
                       "version": {
-                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                        "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                         "enum": [
                           "v1.19",
                           "v1.20",
@@ -1989,6 +2775,7 @@
                           "v1.23",
                           "v1.24",
                           "v1.25",
+                          "v1.26",
                           "latest"
                         ],
                         "type": "string"
@@ -2012,7 +2799,7 @@
                         "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                         "properties": {
                           "attestors": {
-                            "description": "Attestors specify the required attestors (i.e. authorities)",
+                            "description": "Attestors specify the required attestors (i.e. authorities).",
                             "items": {
                               "properties": {
                                 "count": {
@@ -2032,25 +2819,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2074,15 +2884,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2097,7 +2930,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -2105,8 +2938,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -2116,10 +2964,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -2150,7 +3006,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -2186,6 +3042,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -2228,6 +3088,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -2267,13 +3131,14 @@
                             "type": "array"
                           },
                           "predicateType": {
-                            "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                            "description": "Deprecated in favour of 'Type', to be removed soon",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "Type defines the type of attestation contained within the Statement.",
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "predicateType"
-                        ],
                         "type": "object",
                         "additionalProperties": false
                       },
@@ -2300,25 +3165,48 @@
                                   "type": "object"
                                 },
                                 "attestor": {
-                                  "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                  "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                   "x-kubernetes-preserve-unknown-fields": true
                                 },
                                 "certificates": {
-                                  "description": "Certificates specifies one or more certificates",
+                                  "description": "Certificates specifies one or more certificates.",
                                   "properties": {
                                     "cert": {
-                                      "description": "Certificate is an optional PEM encoded public certificate.",
+                                      "description": "Cert is an optional PEM-encoded public certificate.",
                                       "type": "string"
                                     },
                                     "certChain": {
-                                      "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                      "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                       "type": "string"
                                     },
-                                    "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                       "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "rekor": {
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2342,15 +3230,38 @@
                                       "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                       "type": "object"
                                     },
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "issuer": {
                                       "description": "Issuer is the certificate issuer used for keyless signing.",
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2365,7 +3276,7 @@
                                       "type": "string"
                                     },
                                     "subject": {
-                                      "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                      "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                       "type": "string"
                                     }
                                   },
@@ -2373,8 +3284,23 @@
                                   "additionalProperties": false
                                 },
                                 "keys": {
-                                  "description": "Keys specifies one or more public keys",
+                                  "description": "Keys specifies one or more public keys.",
                                   "properties": {
+                                    "ctlog": {
+                                      "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                      "properties": {
+                                        "ignoreSCT": {
+                                          "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
                                     "kms": {
                                       "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                       "type": "string"
@@ -2384,10 +3310,18 @@
                                       "type": "string"
                                     },
                                     "rekor": {
-                                      "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                      "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                       "properties": {
+                                        "ignoreTlog": {
+                                          "description": "IgnoreTlog skips transparency log verification.",
+                                          "type": "boolean"
+                                        },
+                                        "pubkey": {
+                                          "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                          "type": "string"
+                                        },
                                         "url": {
-                                          "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                          "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                           "type": "string"
                                         }
                                       },
@@ -2418,7 +3352,7 @@
                                     },
                                     "signatureAlgorithm": {
                                       "default": "sha256",
-                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                      "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                       "type": "string"
                                     }
                                   },
@@ -2448,6 +3382,39 @@
                       },
                       "type": "array"
                     },
+                    "imageRegistryCredentials": {
+                      "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                      "properties": {
+                        "allowInsecureRegistry": {
+                          "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                          "type": "boolean"
+                        },
+                        "providers": {
+                          "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                          "items": {
+                            "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                            "enum": [
+                              "default",
+                              "amazon",
+                              "azure",
+                              "google",
+                              "github"
+                            ],
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "secrets": {
+                          "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
                     "mutateDigest": {
                       "default": true,
                       "description": "MutateDigest enables replacement of image tags with digests. Defaults to true.",
@@ -2462,6 +3429,19 @@
                       "description": "Required validates that images are verified i.e. have matched passed a signature or attestation check.",
                       "type": "boolean"
                     },
+                    "type": {
+                      "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                      "enum": [
+                        "Cosign",
+                        "Notary"
+                      ],
+                      "type": "string"
+                    },
+                    "useCache": {
+                      "default": true,
+                      "description": "UseCache enables caching of image verify responses for this rule",
+                      "type": "boolean"
+                    },
                     "verifyDigest": {
                       "default": true,
                       "description": "VerifyDigest validates that images have a digest.",
@@ -2474,6 +3454,9 @@
                 "type": "array"
               }
             },
+            "required": [
+              "name"
+            ],
             "type": "object",
             "additionalProperties": false
           },
@@ -2481,6 +3464,10 @@
         },
         "schemaValidation": {
           "description": "SchemaValidation skips validation checks for policies as well as patched resources. Optional. The default value is set to \"true\", it must be set to \"false\" to disable the validation checks.",
+          "type": "boolean"
+        },
+        "useServerSideApply": {
+          "description": "UseServerSideApply controls whether to use server-side apply for generate rules If is set to \"true\" create & update for generate rules will use apply instead of create/update. Defaults to \"false\" if not specified.",
           "type": "boolean"
         },
         "validationFailureAction": {
@@ -2508,6 +3495,51 @@
                 ],
                 "type": "string"
               },
+              "namespaceSelector": {
+                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic",
+                "additionalProperties": false
+              },
               "namespaces": {
                 "items": {
                   "type": "string"
@@ -2533,33 +3565,103 @@
       "description": "Status contains policy runtime data.",
       "properties": {
         "autogen": {
-          "description": "Autogen contains autogen status information",
+          "description": "AutogenStatus contains autogen status information.",
           "properties": {
             "rules": {
               "description": "Rules is a list of Rule instances. It contains auto generated rules added for pod controllers",
               "items": {
                 "description": "Rule defines a validation, mutation, or generation control for matching resources. Each rules contains a match declaration to select resources, and an optional exclude declaration to specify which resources to exclude.",
                 "properties": {
+                  "celPreconditions": {
+                    "description": "CELPreconditions are used to determine if a policy rule should be applied by evaluating a set of CEL conditions. It can only be used with the validate.cel subrule",
+                    "items": {
+                      "description": "MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.",
+                      "properties": {
+                        "expression": {
+                          "description": "Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables: \n 'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/ \n Required.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName') \n Required.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "expression",
+                        "name"
+                      ],
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  },
                   "context": {
                     "description": "Context defines variables and data sources that can be used during rule execution.",
                     "items": {
                       "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                       "properties": {
                         "apiCall": {
-                          "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                          "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                           "properties": {
+                            "data": {
+                              "description": "Data specifies the POST data sent to the server.",
+                              "items": {
+                                "description": "RequestData contains the HTTP POST data",
+                                "properties": {
+                                  "key": {
+                                    "description": "Key is a unique identifier for the data value",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Value is the data value",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "value"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
                             "jmesPath": {
-                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                              "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                               "type": "string"
                             },
+                            "method": {
+                              "default": "GET",
+                              "description": "Method is the HTTP request type (GET or POST).",
+                              "enum": [
+                                "GET",
+                                "POST"
+                              ],
+                              "type": "string"
+                            },
+                            "service": {
+                              "description": "Service is an API call to a JSON web service",
+                              "properties": {
+                                "caBundle": {
+                                  "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                  "type": "string"
+                                },
+                                "url": {
+                                  "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "url"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "urlPath": {
-                              "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                              "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                               "type": "string"
                             }
                           },
-                          "required": [
-                            "urlPath"
-                          ],
                           "type": "object",
                           "additionalProperties": false
                         },
@@ -2584,6 +3686,39 @@
                         "imageRegistry": {
                           "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                           "properties": {
+                            "imageRegistryCredentials": {
+                              "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                              "properties": {
+                                "allowInsecureRegistry": {
+                                  "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                  "type": "boolean"
+                                },
+                                "providers": {
+                                  "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                  "items": {
+                                    "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                    "enum": [
+                                      "default",
+                                      "amazon",
+                                      "azure",
+                                      "google",
+                                      "github"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "secrets": {
+                                  "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
                             "jmesPath": {
                               "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                               "type": "string"
@@ -2719,6 +3854,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -2909,6 +4058,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -3086,6 +4249,20 @@
                           "namespaces": {
                             "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                             "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
                               "type": "string"
                             },
                             "type": "array"
@@ -3286,6 +4463,10 @@
                       "synchronize": {
                         "description": "Synchronize controls if generated resources should be kept in-sync with their source resource. If Synchronize is set to \"true\" changes to generated resources will be overwritten with resource data from Data or the resource specified in the Clone declaration. Optional. Defaults to \"false\" if not specified.",
                         "type": "boolean"
+                      },
+                      "uid": {
+                        "description": "UID specifies the resource uid.",
+                        "type": "string"
                       }
                     },
                     "type": "object",
@@ -3295,6 +4476,10 @@
                     "additionalProperties": {
                       "items": {
                         "properties": {
+                          "jmesPath": {
+                            "description": "JMESPath is an optional JMESPath expression to apply to the image value. This is useful when the extracted image begins with a prefix like 'docker://'. The 'trim_prefix' function may be used to trim the prefix: trim_prefix(@, 'docker://'). Note - Image digest mutation may not be used when applying a JMESPAth to an image.",
+                            "type": "string"
+                          },
                           "key": {
                             "description": "Key is an optional name of the field within 'path' that will be used to uniquely identify an image. Note - this field MUST be unique.",
                             "type": "string"
@@ -3414,6 +4599,20 @@
                                 "namespaces": {
                                   "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
                                   "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
                                     "type": "string"
                                   },
                                   "type": "array"
@@ -3604,6 +4803,20 @@
                                   },
                                   "type": "array"
                                 },
+                                "operations": {
+                                  "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                                  "items": {
+                                    "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                                    "enum": [
+                                      "CREATE",
+                                      "CONNECT",
+                                      "UPDATE",
+                                      "DELETE"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
                                 "selector": {
                                   "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                                   "properties": {
@@ -3785,6 +4998,20 @@
                             },
                             "type": "array"
                           },
+                          "operations": {
+                            "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                            "items": {
+                              "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                              "enum": [
+                                "CREATE",
+                                "CONNECT",
+                                "UPDATE",
+                                "DELETE"
+                              ],
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
                           "selector": {
                             "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
                             "properties": {
@@ -3883,7 +5110,7 @@
                       "foreach": {
                         "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachMutation applies mutation rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "context": {
                               "description": "Context defines variables and data sources that can be used during rule execution.",
@@ -3891,20 +5118,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -3929,6 +5203,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -3981,6 +5288,14 @@
                               "description": "List specifies a JMESPath expression that results in one or more elements to which the validation logic is applied.",
                               "type": "string"
                             },
+                            "order": {
+                              "description": "Order defines the iteration order on the list. Can be Ascending to iterate from first to last element or Descending to iterate in from last to first element.",
+                              "enum": [
+                                "Ascending",
+                                "Descending"
+                              ],
+                              "type": "string"
+                            },
                             "patchStrategicMerge": {
                               "description": "PatchStrategicMerge is a strategic merge patch used to modify resources. See https://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/ and https://kubectl.docs.kubernetes.io/references/kustomize/patchesstrategicmerge/.",
                               "x-kubernetes-preserve-unknown-fields": true
@@ -4000,6 +5315,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4041,6 +5360,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4096,10 +5419,179 @@
                       "targets": {
                         "description": "Targets defines the target resources to be mutated.",
                         "items": {
+                          "description": "TargetResourceSpec defines targets for mutating existing resources.",
                           "properties": {
                             "apiVersion": {
                               "description": "APIVersion specifies resource apiVersion.",
                               "type": "string"
+                            },
+                            "context": {
+                              "description": "Context defines variables and data sources that can be used during rule execution.",
+                              "items": {
+                                "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
+                                "properties": {
+                                  "apiCall": {
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
+                                    "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "type": "string"
+                                      },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "urlPath": {
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "description": "ConfigMap is the ConfigMap reference.",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name is the ConfigMap name.",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the ConfigMap namespace.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "imageRegistry": {
+                                    "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
+                                    "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "description": "Reference is image reference to a container image in the registry. Example: ghcr.io/kyverno/kyverno:latest",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "reference"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "description": "Name is the variable name.",
+                                    "type": "string"
+                                  },
+                                  "variable": {
+                                    "description": "Variable defines an arbitrary JMESPath context variable that can be defined inline.",
+                                    "properties": {
+                                      "default": {
+                                        "description": "Default is an optional arbitrary JSON object that the variable may take if the JMESPath expression evaluates to nil",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "jmesPath": {
+                                        "description": "JMESPath is an optional JMESPath Expression that can be used to transform the variable.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "Value is any arbitrary JSON object representable in YAML or JSON form.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
                             },
                             "kind": {
                               "description": "Kind specifies resource kind.",
@@ -4111,6 +5603,14 @@
                             },
                             "namespace": {
                               "description": "Namespace specifies resource namespace.",
+                              "type": "string"
+                            },
+                            "preconditions": {
+                              "description": "Preconditions are used to determine if a policy rule should be applied by evaluating a set of conditions. The declaration can contain nested `any` or `all` statements. A direct list of conditions (without `any` or `all` statements is supported for backwards compatibility but will be deprecated in the next major release. See: https://kyverno.io/docs/writing-policies/preconditions/",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "uid": {
+                              "description": "UID specifies the resource uid.",
                               "type": "string"
                             }
                           },
@@ -4139,6 +5639,170 @@
                         "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
                         "x-kubernetes-preserve-unknown-fields": true
                       },
+                      "cel": {
+                        "description": "CEL allows validation checks using the Common Expression Language (https://kubernetes.io/docs/reference/using-api/cel/).",
+                        "properties": {
+                          "auditAnnotations": {
+                            "description": "AuditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request.",
+                            "items": {
+                              "description": "AuditAnnotation describes how to produce an audit annotation for an API request.",
+                              "properties": {
+                                "key": {
+                                  "description": "key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length. \n The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: \"{ValidatingAdmissionPolicy name}/{key}\". \n If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded. \n Required.",
+                                  "type": "string"
+                                },
+                                "valueExpression": {
+                                  "description": "valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb. \n If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list. \n Required.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "valueExpression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "expressions": {
+                            "description": "Expressions is a list of CELExpression types.",
+                            "items": {
+                              "description": "Validation specifies the CEL expression which is used to apply the validation.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables: \n - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value. For example, a variable named 'foo' can be accessed as 'variables.foo'. - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request. See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the request resource. \n The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible. \n Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are: \"true\", \"false\", \"null\", \"in\", \"as\", \"break\", \"const\", \"continue\", \"else\", \"for\", \"function\", \"if\", \"import\", \"let\", \"loop\", \"package\", \"namespace\", \"return\". Examples: - Expression accessing a property named \"namespace\": {\"Expression\": \"object.__namespace__ > 0\"} - Expression accessing a property named \"x-prop\": {\"Expression\": \"object.x__dash__prop > 0\"} - Expression accessing a property named \"redact__d\": {\"Expression\": \"object.redact__underscores__d > 0\"} \n Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type: - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and non-intersecting elements in `Y` are appended, retaining their partial order. - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with non-intersecting keys are appended, retaining their partial order. Required.",
+                                  "type": "string"
+                                },
+                                "message": {
+                                  "description": "Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is \"failed rule: {Rule}\". e.g. \"must be a URL with the host matching spec.host\" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is \"failed Expression: {Expression}\".",
+                                  "type": "string"
+                                },
+                                "messageExpression": {
+                                  "description": "messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: \"object.x must be less than max (\"+string(params.max)+\")\"",
+                                  "type": "string"
+                                },
+                                "reason": {
+                                  "description": "Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: \"Unauthorized\", \"Forbidden\", \"Invalid\", \"RequestEntityTooLarge\". If not set, StatusReasonInvalid is used in the response to the client.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "paramKind": {
+                            "description": "ParamKind is a tuple of Group Kind and Version.",
+                            "properties": {
+                              "apiVersion": {
+                                "description": "APIVersion is the API group version the resources belong to. In format of \"group/version\". Required.",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "description": "Kind is the API kind the resources belong to. Required.",
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "paramRef": {
+                            "description": "ParamRef references a parameter resource.",
+                            "properties": {
+                              "name": {
+                                "description": "`name` is the name of the resource being referenced. \n `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields. \n A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty. \n - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error. \n - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.",
+                                "type": "string"
+                              },
+                              "parameterNotFoundAction": {
+                                "description": "`parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy. \n Allowed values are `Allow` or `Deny` Default to `Deny`",
+                                "type": "string"
+                              },
+                              "selector": {
+                                "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind. \n If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together. \n One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-map-type": "atomic",
+                            "additionalProperties": false
+                          },
+                          "variables": {
+                            "description": "Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy.",
+                            "items": {
+                              "description": "Variable is the definition of a variable that is used for composition.",
+                              "properties": {
+                                "expression": {
+                                  "description": "Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is \"foo\", the variable will be available as `variables.foo`",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
                       "deny": {
                         "description": "Deny defines conditions used to pass or fail a validation rule.",
                         "properties": {
@@ -4153,7 +5817,7 @@
                       "foreach": {
                         "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                         "items": {
-                          "description": "ForEach applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
+                          "description": "ForEachValidation applies validate rules to a list of sub-elements by creating a context for each entry in the list and looping over it to apply the specified logic.",
                           "properties": {
                             "anyPattern": {
                               "description": "AnyPattern specifies list of validation patterns. At least one of the patterns must be satisfied for the validation rule to succeed.",
@@ -4165,20 +5829,67 @@
                                 "description": "ContextEntry adds variables and data sources to a rule Context. Either a ConfigMap reference or a APILookup must be provided.",
                                 "properties": {
                                   "apiCall": {
-                                    "description": "APICall defines an HTTP request to the Kubernetes API server. The JSON data retrieved is stored in the context.",
+                                    "description": "APICall is an HTTP request to the Kubernetes API server, or other JSON web service. The data returned is stored in the context with the name for the context entry.",
                                     "properties": {
+                                      "data": {
+                                        "description": "Data specifies the POST data sent to the server.",
+                                        "items": {
+                                          "description": "RequestData contains the HTTP POST data",
+                                          "properties": {
+                                            "key": {
+                                              "description": "Key is a unique identifier for the data value",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "Value is the data value",
+                                              "x-kubernetes-preserve-unknown-fields": true
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value"
+                                          ],
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
                                       "jmesPath": {
-                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the API server. For example a JMESPath of \"items | length(@)\" applied to the API server response to the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
+                                        "description": "JMESPath is an optional JSON Match Expression that can be used to transform the JSON response returned from the server. For example a JMESPath of \"items | length(@)\" applied to the API server response for the URLPath \"/apis/apps/v1/deployments\" will return the total count of deployments across all namespaces.",
                                         "type": "string"
                                       },
+                                      "method": {
+                                        "default": "GET",
+                                        "description": "Method is the HTTP request type (GET or POST).",
+                                        "enum": [
+                                          "GET",
+                                          "POST"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "service": {
+                                        "description": "Service is an API call to a JSON web service",
+                                        "properties": {
+                                          "caBundle": {
+                                            "description": "CABundle is a PEM encoded CA bundle which will be used to validate the server certificate.",
+                                            "type": "string"
+                                          },
+                                          "url": {
+                                            "description": "URL is the JSON web service URL. A typical form is `https://{service}.{namespace}:{port}/{path}`.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "urlPath": {
-                                        "description": "URLPath is the URL path to be used in the HTTP GET request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command.",
+                                        "description": "URLPath is the URL path to be used in the HTTP GET or POST request to the Kubernetes API server (e.g. \"/api/v1/namespaces\" or  \"/apis/apps/v1/deployments\"). The format required is the same format used by the `kubectl get --raw` command. See https://kyverno.io/docs/writing-policies/external-data-sources/#variables-from-kubernetes-api-server-calls for details.",
                                         "type": "string"
                                       }
                                     },
-                                    "required": [
-                                      "urlPath"
-                                    ],
                                     "type": "object",
                                     "additionalProperties": false
                                   },
@@ -4203,6 +5914,39 @@
                                   "imageRegistry": {
                                     "description": "ImageRegistry defines requests to an OCI/Docker V2 registry to fetch image details.",
                                     "properties": {
+                                      "imageRegistryCredentials": {
+                                        "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry",
+                                        "properties": {
+                                          "allowInsecureRegistry": {
+                                            "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                                            "type": "boolean"
+                                          },
+                                          "providers": {
+                                            "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                                            "items": {
+                                              "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                              "enum": [
+                                                "default",
+                                                "amazon",
+                                                "azure",
+                                                "google",
+                                                "github"
+                                              ],
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "secrets": {
+                                            "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
                                       "jmesPath": {
                                         "description": "JMESPath is an optional JSON Match Expression that can be used to transform the ImageData struct returned as a result of processing the image reference.",
                                         "type": "string"
@@ -4286,6 +6030,10 @@
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
+                                      },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                         "enum": [
@@ -4326,6 +6074,10 @@
                                       "key": {
                                         "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                         "x-kubernetes-preserve-unknown-fields": true
+                                      },
+                                      "message": {
+                                        "description": "Message is an optional display message",
+                                        "type": "string"
                                       },
                                       "operator": {
                                         "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4398,25 +6150,48 @@
                                         "type": "object"
                                       },
                                       "attestor": {
-                                        "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                        "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                         "x-kubernetes-preserve-unknown-fields": true
                                       },
                                       "certificates": {
-                                        "description": "Certificates specifies one or more certificates",
+                                        "description": "Certificates specifies one or more certificates.",
                                         "properties": {
                                           "cert": {
-                                            "description": "Certificate is an optional PEM encoded public certificate.",
+                                            "description": "Cert is an optional PEM-encoded public certificate.",
                                             "type": "string"
                                           },
                                           "certChain": {
-                                            "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                            "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                             "type": "string"
                                           },
-                                          "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                             "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "rekor": {
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4440,15 +6215,38 @@
                                             "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                             "type": "object"
                                           },
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "issuer": {
                                             "description": "Issuer is the certificate issuer used for keyless signing.",
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4463,7 +6261,7 @@
                                             "type": "string"
                                           },
                                           "subject": {
-                                            "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                            "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                             "type": "string"
                                           }
                                         },
@@ -4471,8 +6269,23 @@
                                         "additionalProperties": false
                                       },
                                       "keys": {
-                                        "description": "Keys specifies one or more public keys",
+                                        "description": "Keys specifies one or more public keys.",
                                         "properties": {
+                                          "ctlog": {
+                                            "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                            "properties": {
+                                              "ignoreSCT": {
+                                                "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
                                           "kms": {
                                             "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                             "type": "string"
@@ -4482,10 +6295,18 @@
                                             "type": "string"
                                           },
                                           "rekor": {
-                                            "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                            "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                             "properties": {
+                                              "ignoreTlog": {
+                                                "description": "IgnoreTlog skips transparency log verification.",
+                                                "type": "boolean"
+                                              },
+                                              "pubkey": {
+                                                "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                "type": "string"
+                                              },
                                               "url": {
-                                                "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                 "type": "string"
                                               }
                                             },
@@ -4516,7 +6337,7 @@
                                           },
                                           "signatureAlgorithm": {
                                             "default": "sha256",
-                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                            "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                             "type": "string"
                                           }
                                         },
@@ -4663,7 +6484,7 @@
                             "type": "string"
                           },
                           "version": {
-                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, latest. Defaults to latest.",
+                            "description": "Version defines the Pod Security Standard versions that Kubernetes supports. Allowed values are v1.19, v1.20, v1.21, v1.22, v1.23, v1.24, v1.25, v1.26, latest. Defaults to latest.",
                             "enum": [
                               "v1.19",
                               "v1.20",
@@ -4672,6 +6493,7 @@
                               "v1.23",
                               "v1.24",
                               "v1.25",
+                              "v1.26",
                               "latest"
                             ],
                             "type": "string"
@@ -4693,14 +6515,14 @@
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "AdditionalExtensions are certificate-extensions used for keyless signing. Deprecated.",
+                          "description": "Deprecated.",
                           "type": "object"
                         },
                         "annotations": {
                           "additionalProperties": {
                             "type": "string"
                           },
-                          "description": "Annotations are used for image verification. Every specified key-value pair must exist and match in the verified payload. The payload may contain other key-value pairs. Deprecated. Use annotations per Attestor instead.",
+                          "description": "Deprecated. Use annotations per Attestor instead.",
                           "type": "object"
                         },
                         "attestations": {
@@ -4709,7 +6531,7 @@
                             "description": "Attestation are checks for signed in-toto Statements that are used to verify the image. See https://github.com/in-toto/attestation. Kyverno fetches signed attestations from the OCI registry and decodes them into a list of Statements.",
                             "properties": {
                               "attestors": {
-                                "description": "Attestors specify the required attestors (i.e. authorities)",
+                                "description": "Attestors specify the required attestors (i.e. authorities).",
                                 "items": {
                                   "properties": {
                                     "count": {
@@ -4729,25 +6551,48 @@
                                             "type": "object"
                                           },
                                           "attestor": {
-                                            "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                            "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
                                           "certificates": {
-                                            "description": "Certificates specifies one or more certificates",
+                                            "description": "Certificates specifies one or more certificates.",
                                             "properties": {
                                               "cert": {
-                                                "description": "Certificate is an optional PEM encoded public certificate.",
+                                                "description": "Cert is an optional PEM-encoded public certificate.",
                                                 "type": "string"
                                               },
                                               "certChain": {
-                                                "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                                "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                                 "type": "string"
                                               },
-                                              "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                                 "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "rekor": {
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4771,15 +6616,38 @@
                                                 "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                                 "type": "object"
                                               },
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "issuer": {
                                                 "description": "Issuer is the certificate issuer used for keyless signing.",
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4794,7 +6662,7 @@
                                                 "type": "string"
                                               },
                                               "subject": {
-                                                "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                                "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                                 "type": "string"
                                               }
                                             },
@@ -4802,8 +6670,23 @@
                                             "additionalProperties": false
                                           },
                                           "keys": {
-                                            "description": "Keys specifies one or more public keys",
+                                            "description": "Keys specifies one or more public keys.",
                                             "properties": {
+                                              "ctlog": {
+                                                "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                                "properties": {
+                                                  "ignoreSCT": {
+                                                    "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
                                               "kms": {
                                                 "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                                 "type": "string"
@@ -4813,10 +6696,18 @@
                                                 "type": "string"
                                               },
                                               "rekor": {
-                                                "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                                "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                                 "properties": {
+                                                  "ignoreTlog": {
+                                                    "description": "IgnoreTlog skips transparency log verification.",
+                                                    "type": "boolean"
+                                                  },
+                                                  "pubkey": {
+                                                    "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                                    "type": "string"
+                                                  },
                                                   "url": {
-                                                    "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                                    "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                                     "type": "string"
                                                   }
                                                 },
@@ -4847,7 +6738,7 @@
                                               },
                                               "signatureAlgorithm": {
                                                 "default": "sha256",
-                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                                "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                                 "type": "string"
                                               }
                                             },
@@ -4883,6 +6774,10 @@
                                           "key": {
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
+                                          },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
                                           },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
@@ -4925,6 +6820,10 @@
                                             "description": "Key is the context entry (using JMESPath) for conditional rule evaluation.",
                                             "x-kubernetes-preserve-unknown-fields": true
                                           },
+                                          "message": {
+                                            "description": "Message is an optional display message",
+                                            "type": "string"
+                                          },
                                           "operator": {
                                             "description": "Operator is the conditional operation to perform. Valid operators are: Equals, NotEquals, In, AnyIn, AllIn, NotIn, AnyNotIn, AllNotIn, GreaterThanOrEquals, GreaterThan, LessThanOrEquals, LessThan, DurationGreaterThanOrEquals, DurationGreaterThan, DurationLessThanOrEquals, DurationLessThan",
                                             "enum": [
@@ -4964,13 +6863,14 @@
                                 "type": "array"
                               },
                               "predicateType": {
-                                "description": "PredicateType defines the type of Predicate contained within the Statement.",
+                                "description": "Deprecated in favour of 'Type', to be removed soon",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type defines the type of attestation contained within the Statement.",
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "predicateType"
-                            ],
                             "type": "object",
                             "additionalProperties": false
                           },
@@ -4997,25 +6897,48 @@
                                       "type": "object"
                                     },
                                     "attestor": {
-                                      "description": "Attestor is a nested AttestorSet used to specify a more complex set of match authorities",
+                                      "description": "Attestor is a nested set of Attestor used to specify a more complex set of match authorities.",
                                       "x-kubernetes-preserve-unknown-fields": true
                                     },
                                     "certificates": {
-                                      "description": "Certificates specifies one or more certificates",
+                                      "description": "Certificates specifies one or more certificates.",
                                       "properties": {
                                         "cert": {
-                                          "description": "Certificate is an optional PEM encoded public certificate.",
+                                          "description": "Cert is an optional PEM-encoded public certificate.",
                                           "type": "string"
                                         },
                                         "certChain": {
-                                          "description": "CertificateChain is an optional PEM encoded set of certificates used to verify",
+                                          "description": "CertChain is an optional PEM encoded set of certificates used to verify.",
                                           "type": "string"
                                         },
-                                        "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
                                           "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "rekor": {
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5039,15 +6962,38 @@
                                           "description": "AdditionalExtensions are certificate-extensions used for keyless signing.",
                                           "type": "object"
                                         },
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "issuer": {
                                           "description": "Issuer is the certificate issuer used for keyless signing.",
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked and a root certificate chain is expected instead. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5062,7 +7008,7 @@
                                           "type": "string"
                                         },
                                         "subject": {
-                                          "description": "Subject is the verified identity used for keyless signing, for example the email address",
+                                          "description": "Subject is the verified identity used for keyless signing, for example the email address.",
                                           "type": "string"
                                         }
                                       },
@@ -5070,8 +7016,23 @@
                                       "additionalProperties": false
                                     },
                                     "keys": {
-                                      "description": "Keys specifies one or more public keys",
+                                      "description": "Keys specifies one or more public keys.",
                                       "properties": {
+                                        "ctlog": {
+                                          "description": "CTLog (certificate timestamp log) provides a configuration for validation of Signed Certificate Timestamps (SCTs). If the value is unset, the default behavior by Cosign is used.",
+                                          "properties": {
+                                            "ignoreSCT": {
+                                              "description": "IgnoreSCT defines whether to use the Signed Certificate Timestamp (SCT) log to check for a certificate timestamp. Default is false. Set to true if this was opted out during signing.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "PubKey, if set, is used to validate SCTs against a custom source.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
                                         "kms": {
                                           "description": "KMS provides the URI to the public key stored in a Key Management System. See: https://github.com/sigstore/cosign/blob/main/KMS.md",
                                           "type": "string"
@@ -5081,10 +7042,18 @@
                                           "type": "string"
                                         },
                                         "rekor": {
-                                          "description": "Rekor provides configuration for the Rekor transparency log service. If the value is nil, Rekor is not checked. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
+                                          "description": "Rekor provides configuration for the Rekor transparency log service. If an empty object is provided the public instance of Rekor (https://rekor.sigstore.dev) is used.",
                                           "properties": {
+                                            "ignoreTlog": {
+                                              "description": "IgnoreTlog skips transparency log verification.",
+                                              "type": "boolean"
+                                            },
+                                            "pubkey": {
+                                              "description": "RekorPubKey is an optional PEM-encoded public key to use for a custom Rekor. If set, this will be used to validate transparency log signatures from a custom Rekor.",
+                                              "type": "string"
+                                            },
                                             "url": {
-                                              "description": "URL is the address of the transparency log. Defaults to the public log https://rekor.sigstore.dev.",
+                                              "description": "URL is the address of the transparency log. Defaults to the public Rekor log instance https://rekor.sigstore.dev.",
                                               "type": "string"
                                             }
                                           },
@@ -5115,7 +7084,7 @@
                                         },
                                         "signatureAlgorithm": {
                                           "default": "sha256",
-                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512",
+                                          "description": "Specify signature algorithm for public keys. Supported values are sha256 and sha512.",
                                           "type": "string"
                                         }
                                       },
@@ -5139,7 +7108,7 @@
                           "type": "array"
                         },
                         "image": {
-                          "description": "Image is the image name consisting of the registry address, repository, image, and tag. Wildcards ('*' and '?') are allowed. See: https://kubernetes.io/docs/concepts/containers/images. Deprecated. Use ImageReferences instead.",
+                          "description": "Deprecated. Use ImageReferences instead.",
                           "type": "string"
                         },
                         "imageReferences": {
@@ -5149,12 +7118,45 @@
                           },
                           "type": "array"
                         },
+                        "imageRegistryCredentials": {
+                          "description": "ImageRegistryCredentials provides credentials that will be used for authentication with registry.",
+                          "properties": {
+                            "allowInsecureRegistry": {
+                              "description": "AllowInsecureRegistry allows insecure access to a registry.",
+                              "type": "boolean"
+                            },
+                            "providers": {
+                              "description": "Providers specifies a list of OCI Registry names, whose authentication providers are provided. It can be of one of these values: default,google,azure,amazon,github.",
+                              "items": {
+                                "description": "ImageRegistryCredentialsProvidersType provides the list of credential providers required.",
+                                "enum": [
+                                  "default",
+                                  "amazon",
+                                  "azure",
+                                  "google",
+                                  "github"
+                                ],
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "secrets": {
+                              "description": "Secrets specifies a list of secrets that are provided for credentials. Secrets must live in the Kyverno namespace.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
                         "issuer": {
-                          "description": "Issuer is the certificate issuer used for keyless signing. Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "key": {
-                          "description": "Key is the PEM encoded public key that the image or attestation is signed with. Deprecated. Use StaticKeyAttestor instead.",
+                          "description": "Deprecated. Use StaticKeyAttestor instead.",
                           "type": "string"
                         },
                         "mutateDigest": {
@@ -5172,12 +7174,25 @@
                           "type": "boolean"
                         },
                         "roots": {
-                          "description": "Roots is the PEM encoded Root certificate chain used for keyless signing Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
                         },
                         "subject": {
-                          "description": "Subject is the identity used for keyless signing, for example an email address Deprecated. Use KeylessAttestor instead.",
+                          "description": "Deprecated. Use KeylessAttestor instead.",
                           "type": "string"
+                        },
+                        "type": {
+                          "description": "Type specifies the method of signature validation. The allowed options are Cosign and Notary. By default Cosign is used if a type is not specified.",
+                          "enum": [
+                            "Cosign",
+                            "Notary"
+                          ],
+                          "type": "string"
+                        },
+                        "useCache": {
+                          "default": true,
+                          "description": "UseCache enables caching of image verify responses for this rule.",
+                          "type": "boolean"
                         },
                         "verifyDigest": {
                           "default": true,
@@ -5191,6 +7206,9 @@
                     "type": "array"
                   }
                 },
+                "required": [
+                  "name"
+                ],
                 "type": "object",
                 "additionalProperties": false
               },
@@ -5201,7 +7219,6 @@
           "additionalProperties": false
         },
         "conditions": {
-          "description": "Conditions is a list of conditions that apply to the policy",
           "items": {
             "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
             "properties": {
@@ -5257,11 +7274,11 @@
           "type": "array"
         },
         "ready": {
-          "description": "Ready indicates if the policy is ready to serve the admission request. Deprecated in favor of Conditions",
+          "description": "Deprecated in favor of Conditions",
           "type": "boolean"
         },
         "rulecount": {
-          "description": "RuleCount describes total number of rules in a policy",
+          "description": "RuleCountStatus contains four variables which describes counts for validate, generate, mutate and verify images rules",
           "properties": {
             "generate": {
               "description": "Count for generate rules in policy",
@@ -5285,6 +7302,25 @@
             "mutate",
             "validate",
             "verifyimages"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "validatingadmissionpolicy": {
+          "description": "ValidatingAdmissionPolicy contains status information",
+          "properties": {
+            "generated": {
+              "description": "Generated indicates whether a validating admission policy is generated from the policy or not",
+              "type": "boolean"
+            },
+            "message": {
+              "description": "Message is a human readable message indicating details about the generation of validating admission policy It is an empty string when validating admission policy is successfully generated.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "generated",
+            "message"
           ],
           "type": "object",
           "additionalProperties": false

--- a/kyverno.io/policyexception_v2beta1.json
+++ b/kyverno.io/policyexception_v2beta1.json
@@ -1,0 +1,468 @@
+{
+  "description": "PolicyException declares resources to be excluded from specified policies.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Spec declares policy exception behaviors.",
+      "properties": {
+        "background": {
+          "description": "Background controls if exceptions are applied to existing policies during a background scan. Optional. Default value is \"true\". The value must be set to \"false\" if the policy rule uses variables that are only available in the admission review request (e.g. user name).",
+          "type": "boolean"
+        },
+        "exceptions": {
+          "description": "Exceptions is a list policy/rules to be excluded",
+          "items": {
+            "description": "Exception stores infos about a policy and rules",
+            "properties": {
+              "policyName": {
+                "description": "PolicyName identifies the policy to which the exception is applied. The policy name uses the format <namespace>/<name> unless it references a ClusterPolicy.",
+                "type": "string"
+              },
+              "ruleNames": {
+                "description": "RuleNames identifies the rules to which the exception is applied.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "policyName",
+              "ruleNames"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "match": {
+          "description": "Match defines match clause used to check if a resource applies to the exception",
+          "properties": {
+            "all": {
+              "description": "All allows specifying resources which will be ANDed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "any": {
+              "description": "Any allows specifying resources which will be ORed",
+              "items": {
+                "description": "ResourceFilter allow users to \"AND\" or \"OR\" between resources",
+                "properties": {
+                  "clusterRoles": {
+                    "description": "ClusterRoles is the list of cluster-wide role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "resources": {
+                    "description": "ResourceDescription contains information about the resource being created or modified.",
+                    "properties": {
+                      "annotations": {
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Annotations is a  map of annotations (key-value pairs of type string). Annotation keys and values support the wildcard characters \"*\" (matches zero or many characters) and \"?\" (matches at least one character).",
+                        "type": "object"
+                      },
+                      "kinds": {
+                        "description": "Kinds is a list of resource kinds.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "name": {
+                        "description": "Name is the name of the resource. The name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character). NOTE: \"Name\" is being deprecated in favor of \"Names\".",
+                        "type": "string"
+                      },
+                      "names": {
+                        "description": "Names are the names of the resources. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "namespaceSelector": {
+                        "description": "NamespaceSelector is a label selector for the resource namespace. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character).Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      },
+                      "namespaces": {
+                        "description": "Namespaces is a list of namespaces names. Each name supports wildcard characters \"*\" (matches zero or many characters) and \"?\" (at least one character).",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "operations": {
+                        "description": "Operations can contain values [\"CREATE, \"UPDATE\", \"CONNECT\", \"DELETE\"], which are used to match a specific action.",
+                        "items": {
+                          "description": "AdmissionOperation can have one of the values CREATE, UPDATE, CONNECT, DELETE, which are used to match a specific action.",
+                          "enum": [
+                            "CREATE",
+                            "CONNECT",
+                            "UPDATE",
+                            "DELETE"
+                          ],
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "selector": {
+                        "description": "Selector is a label selector. Label keys and values in `matchLabels` support the wildcard characters `*` (matches zero or many characters) and `?` (matches one character). Wildcards allows writing label selectors like [\"storage.k8s.io/*\": \"*\"]. Note that using [\"*\" : \"*\"] matches any key and value but does not match an empty label set.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "roles": {
+                    "description": "Roles is the list of namespaced role names for the user.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "subjects": {
+                    "description": "Subjects is the list of subject names like users, user groups, and service accounts.",
+                    "items": {
+                      "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+                      "properties": {
+                        "apiGroup": {
+                          "description": "APIGroup holds the API group of the referenced subject. Defaults to \"\" for ServiceAccount subjects. Defaults to \"rbac.authorization.k8s.io\" for User and Group subjects.",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the object being referenced.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "exceptions",
+        "match"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/kyverno.io/updaterequest_v1beta1.json
+++ b/kyverno.io/updaterequest_v1beta1.json
@@ -13,7 +13,7 @@
       "type": "object"
     },
     "spec": {
-      "description": "Spec is the information to identify the update request.",
+      "description": "ResourceSpec is the information to identify the trigger resource.",
       "properties": {
         "context": {
           "description": "Context ...",
@@ -263,6 +263,10 @@
           "type": "object",
           "additionalProperties": false
         },
+        "deleteDownstream": {
+          "description": "DeleteDownstream represents whether the downstream needs to be deleted.",
+          "type": "boolean"
+        },
         "policy": {
           "description": "Specifies the name of the policy.",
           "type": "string"
@@ -276,7 +280,7 @@
           "type": "string"
         },
         "resource": {
-          "description": "ResourceSpec is the information to identify the update request.",
+          "description": "ResourceSpec is the information to identify the trigger resource.",
           "properties": {
             "apiVersion": {
               "description": "APIVersion specifies resource apiVersion.",
@@ -293,16 +297,30 @@
             "namespace": {
               "description": "Namespace specifies resource namespace.",
               "type": "string"
+            },
+            "uid": {
+              "description": "UID specifies the resource uid.",
+              "type": "string"
             }
           },
           "type": "object",
           "additionalProperties": false
+        },
+        "rule": {
+          "description": "Rule is the associate rule name of the current UR.",
+          "type": "string"
+        },
+        "synchronize": {
+          "description": "Synchronize represents the sync behavior of the corresponding rule Optional. Defaults to \"false\" if not specified.",
+          "type": "boolean"
         }
       },
       "required": [
         "context",
+        "deleteDownstream",
         "policy",
-        "resource"
+        "resource",
+        "rule"
       ],
       "type": "object",
       "additionalProperties": false
@@ -329,6 +347,10 @@
               "namespace": {
                 "description": "Namespace specifies resource namespace.",
                 "type": "string"
+              },
+              "uid": {
+                "description": "UID specifies the resource uid.",
+                "type": "string"
               }
             },
             "type": "object",
@@ -337,7 +359,7 @@
           "type": "array"
         },
         "handler": {
-          "description": "Handler represents the instance ID that handles the UR",
+          "description": "Deprecated",
           "type": "string"
         },
         "message": {


### PR DESCRIPTION
chore: update kyverno/v1 crd schemas as per v1.11.0 as they are missing some of the newly added objects.