### PR TITLE
include datadog in provider_v1beta2.json

### DIFF
--- a/notification.toolkit.fluxcd.io/provider_v1beta2.json
+++ b/notification.toolkit.fluxcd.io/provider_v1beta2.json
@@ -98,7 +98,8 @@
             "opsgenie",
             "alertmanager",
             "grafana",
-            "githubdispatch"
+            "githubdispatch",
+            "datadog"
           ],
           "type": "string"
         },


### PR DESCRIPTION
Datadog is a supported provider for [this version](https://fluxcd.io/flux/components/notification/providers/#datadog)