### PR TITLE
update argoproj.io Argo CD schemas for 2.9.3 release

### DIFF
--- a/argoproj.io/application_v1alpha1.json
+++ b/argoproj.io/application_v1alpha1.json
@@ -360,6 +360,55 @@
                       "description": "Namespace sets the namespace that Kustomize adds to all resources",
                       "type": "string"
                     },
+                    "patches": {
+                      "description": "Patches is a list of Kustomize patches",
+                      "items": {
+                        "properties": {
+                          "options": {
+                            "additionalProperties": {
+                              "type": "boolean"
+                            },
+                            "type": "object"
+                          },
+                          "patch": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "target": {
+                            "properties": {
+                              "annotationSelector": {
+                                "type": "string"
+                              },
+                              "group": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "labelSelector": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              },
+                              "version": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
                     "replicas": {
                       "description": "Replicas is a list of Kustomize Replicas override specifications",
                       "items": {
@@ -708,6 +757,55 @@
                       "namespace": {
                         "description": "Namespace sets the namespace that Kustomize adds to all resources",
                         "type": "string"
+                      },
+                      "patches": {
+                        "description": "Patches is a list of Kustomize patches",
+                        "items": {
+                          "properties": {
+                            "options": {
+                              "additionalProperties": {
+                                "type": "boolean"
+                              },
+                              "type": "object"
+                            },
+                            "patch": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "properties": {
+                                "annotationSelector": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "labelSelector": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
                       },
                       "replicas": {
                         "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -1198,6 +1296,55 @@
                   "description": "Namespace sets the namespace that Kustomize adds to all resources",
                   "type": "string"
                 },
+                "patches": {
+                  "description": "Patches is a list of Kustomize patches",
+                  "items": {
+                    "properties": {
+                      "options": {
+                        "additionalProperties": {
+                          "type": "boolean"
+                        },
+                        "type": "object"
+                      },
+                      "patch": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "target": {
+                        "properties": {
+                          "annotationSelector": {
+                            "type": "string"
+                          },
+                          "group": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "labelSelector": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "namespace": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
                 "replicas": {
                   "description": "Replicas is a list of Kustomize Replicas override specifications",
                   "items": {
@@ -1546,6 +1693,55 @@
                   "namespace": {
                     "description": "Namespace sets the namespace that Kustomize adds to all resources",
                     "type": "string"
+                  },
+                  "patches": {
+                    "description": "Patches is a list of Kustomize patches",
+                    "items": {
+                      "properties": {
+                        "options": {
+                          "additionalProperties": {
+                            "type": "boolean"
+                          },
+                          "type": "object"
+                        },
+                        "patch": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "target": {
+                          "properties": {
+                            "annotationSelector": {
+                              "type": "string"
+                            },
+                            "group": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "labelSelector": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "type": "array"
                   },
                   "replicas": {
                     "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -2069,6 +2265,55 @@
                         "description": "Namespace sets the namespace that Kustomize adds to all resources",
                         "type": "string"
                       },
+                      "patches": {
+                        "description": "Patches is a list of Kustomize patches",
+                        "items": {
+                          "properties": {
+                            "options": {
+                              "additionalProperties": {
+                                "type": "boolean"
+                              },
+                              "type": "object"
+                            },
+                            "patch": {
+                              "type": "string"
+                            },
+                            "path": {
+                              "type": "string"
+                            },
+                            "target": {
+                              "properties": {
+                                "annotationSelector": {
+                                  "type": "string"
+                                },
+                                "group": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "labelSelector": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "namespace": {
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
                       "replicas": {
                         "description": "Replicas is a list of Kustomize Replicas override specifications",
                         "items": {
@@ -2417,6 +2662,55 @@
                         "namespace": {
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
+                        },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
                         },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -2920,6 +3214,55 @@
                               "description": "Namespace sets the namespace that Kustomize adds to all resources",
                               "type": "string"
                             },
+                            "patches": {
+                              "description": "Patches is a list of Kustomize patches",
+                              "items": {
+                                "properties": {
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "boolean"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "patch": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "target": {
+                                    "properties": {
+                                      "annotationSelector": {
+                                        "type": "string"
+                                      },
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "labelSelector": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "version": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
                             "replicas": {
                               "description": "Replicas is a list of Kustomize Replicas override specifications",
                               "items": {
@@ -3268,6 +3611,55 @@
                               "namespace": {
                                 "description": "Namespace sets the namespace that Kustomize adds to all resources",
                                 "type": "string"
+                              },
+                              "patches": {
+                                "description": "Patches is a list of Kustomize patches",
+                                "items": {
+                                  "properties": {
+                                    "options": {
+                                      "additionalProperties": {
+                                        "type": "boolean"
+                                      },
+                                      "type": "object"
+                                    },
+                                    "patch": {
+                                      "type": "string"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "target": {
+                                      "properties": {
+                                        "annotationSelector": {
+                                          "type": "string"
+                                        },
+                                        "group": {
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "labelSelector": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        },
+                                        "version": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
                               },
                               "replicas": {
                                 "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -3767,6 +4159,55 @@
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
                         },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
                           "items": {
@@ -4115,6 +4556,55 @@
                           "namespace": {
                             "description": "Namespace sets the namespace that Kustomize adds to all resources",
                             "type": "string"
+                          },
+                          "patches": {
+                            "description": "Patches is a list of Kustomize patches",
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "description": "Replicas is a list of Kustomize Replicas override specifications",
@@ -4648,6 +5138,55 @@
                           "description": "Namespace sets the namespace that Kustomize adds to all resources",
                           "type": "string"
                         },
+                        "patches": {
+                          "description": "Patches is a list of Kustomize patches",
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "replicas": {
                           "description": "Replicas is a list of Kustomize Replicas override specifications",
                           "items": {
@@ -4996,6 +5535,55 @@
                           "namespace": {
                             "description": "Namespace sets the namespace that Kustomize adds to all resources",
                             "type": "string"
+                          },
+                          "patches": {
+                            "description": "Patches is a list of Kustomize patches",
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "description": "Replicas is a list of Kustomize Replicas override specifications",

--- a/argoproj.io/applicationset_v1alpha1.json
+++ b/argoproj.io/applicationset_v1alpha1.json
@@ -364,6 +364,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -653,6 +701,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -1201,6 +1297,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -1490,6 +1634,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -2044,6 +2236,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -2333,6 +2573,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -2854,6 +3142,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -3143,6 +3479,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -3700,6 +4084,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -3989,6 +4421,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -4537,6 +5017,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -4826,6 +5354,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -5380,6 +5956,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -5669,6 +6293,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -6190,6 +6862,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -6479,6 +7199,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -7018,6 +7786,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -7307,6 +8123,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -8130,6 +8994,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -8419,6 +9331,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -8922,6 +9882,9 @@
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "topic": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
@@ -9232,6 +10195,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -9521,6 +10532,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -10070,6 +11129,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -10359,6 +11466,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -10916,6 +12071,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -11205,6 +12408,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -11753,6 +13004,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -12042,6 +13341,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -12596,6 +13943,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -12885,6 +14280,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -13406,6 +14849,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -13695,6 +15186,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -14234,6 +15773,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -14523,6 +16110,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -15346,6 +16981,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -15635,6 +17318,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -16138,6 +17869,9 @@
                                   ],
                                   "type": "object",
                                   "additionalProperties": false
+                                },
+                                "topic": {
+                                  "type": "string"
                                 }
                               },
                               "required": [
@@ -16448,6 +18182,54 @@
                                             "namespace": {
                                               "type": "string"
                                             },
+                                            "patches": {
+                                              "items": {
+                                                "properties": {
+                                                  "options": {
+                                                    "additionalProperties": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "patch": {
+                                                    "type": "string"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "target": {
+                                                    "properties": {
+                                                      "annotationSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "group": {
+                                                        "type": "string"
+                                                      },
+                                                      "kind": {
+                                                        "type": "string"
+                                                      },
+                                                      "labelSelector": {
+                                                        "type": "string"
+                                                      },
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "version": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
                                             "replicas": {
                                               "items": {
                                                 "properties": {
@@ -16737,6 +18519,54 @@
                                               },
                                               "namespace": {
                                                 "type": "string"
+                                              },
+                                              "patches": {
+                                                "items": {
+                                                  "properties": {
+                                                    "options": {
+                                                      "additionalProperties": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "patch": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "target": {
+                                                      "properties": {
+                                                        "annotationSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "group": {
+                                                          "type": "string"
+                                                        },
+                                                        "kind": {
+                                                          "type": "string"
+                                                        },
+                                                        "labelSelector": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "namespace": {
+                                                          "type": "string"
+                                                        },
+                                                        "version": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
                                               },
                                               "replicas": {
                                                 "items": {
@@ -17292,6 +19122,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -17581,6 +19459,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -18115,6 +20041,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -18404,6 +20378,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -19227,6 +21249,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -19516,6 +21586,54 @@
                                     },
                                     "namespace": {
                                       "type": "string"
+                                    },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
                                     },
                                     "replicas": {
                                       "items": {
@@ -20019,6 +22137,9 @@
                         ],
                         "type": "object",
                         "additionalProperties": false
+                      },
+                      "topic": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -20329,6 +22450,54 @@
                                   "namespace": {
                                     "type": "string"
                                   },
+                                  "patches": {
+                                    "items": {
+                                      "properties": {
+                                        "options": {
+                                          "additionalProperties": {
+                                            "type": "boolean"
+                                          },
+                                          "type": "object"
+                                        },
+                                        "patch": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "target": {
+                                          "properties": {
+                                            "annotationSelector": {
+                                              "type": "string"
+                                            },
+                                            "group": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "labelSelector": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            },
+                                            "version": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
                                   "replicas": {
                                     "items": {
                                       "properties": {
@@ -20619,6 +22788,54 @@
                                     "namespace": {
                                       "type": "string"
                                     },
+                                    "patches": {
+                                      "items": {
+                                        "properties": {
+                                          "options": {
+                                            "additionalProperties": {
+                                              "type": "boolean"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "patch": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "target": {
+                                            "properties": {
+                                              "annotationSelector": {
+                                                "type": "string"
+                                              },
+                                              "group": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "labelSelector": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
                                     "replicas": {
                                       "items": {
                                         "properties": {
@@ -20878,9 +23095,39 @@
           },
           "type": "array"
         },
+        "ignoreApplicationDifferences": {
+          "items": {
+            "properties": {
+              "jqPathExpressions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "jsonPointers": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
         "preservedFields": {
           "properties": {
             "annotations": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "labels": {
               "items": {
                 "type": "string"
               },
@@ -21262,6 +23509,54 @@
                         "namespace": {
                           "type": "string"
                         },
+                        "patches": {
+                          "items": {
+                            "properties": {
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "boolean"
+                                },
+                                "type": "object"
+                              },
+                              "patch": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "target": {
+                                "properties": {
+                                  "annotationSelector": {
+                                    "type": "string"
+                                  },
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "labelSelector": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "version": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
                         "replicas": {
                           "items": {
                             "properties": {
@@ -21551,6 +23846,54 @@
                           },
                           "namespace": {
                             "type": "string"
+                          },
+                          "patches": {
+                            "items": {
+                              "properties": {
+                                "options": {
+                                  "additionalProperties": {
+                                    "type": "boolean"
+                                  },
+                                  "type": "object"
+                                },
+                                "patch": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "target": {
+                                  "properties": {
+                                    "annotationSelector": {
+                                      "type": "string"
+                                    },
+                                    "group": {
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "type": "string"
+                                    },
+                                    "labelSelector": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "type": "string"
+                                    },
+                                    "version": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
                           },
                           "replicas": {
                             "items": {


### PR DESCRIPTION
Argo CD had another major release v2.9 that added some changes to their CRDs. This PR incorporates all changes as of ([v2.9.3](https://github.com/argoproj/argo-cd/releases/tag/v2.9.3)) .

I've used the `crd-extractor.sh` to extract the CRDs from a clean k3d cluster.

Tested manually using `kubeconform` against custom resources that previously failed validation when linked against this repository.