### PR TITLE
Add CRDs for Openshift v4.14

### DIFF
--- a/openshift/v4.14-strict/alertingrule_monitoring.openshift.io_v1.json
+++ b/openshift/v4.14-strict/alertingrule_monitoring.openshift.io_v1.json
@@ -1,0 +1,148 @@
+{
+    "description": "AlertingRule represents a set of user-defined Prometheus rule groups containing alerting rules.  This resource is the supported method for cluster admins to create alerts based on metrics recorded by the platform monitoring stack in OpenShift, i.e. the Prometheus instance deployed to the openshift-monitoring namespace.  You might use this to create custom alerting rules not shipped with OpenShift based on metrics from components such as the node_exporter, which provides machine-level metrics such as CPU usage, or kube-state-metrics, which provides metrics on Kubernetes usage. \n The API is mostly compatible with the upstream PrometheusRule type from the prometheus-operator.  The primary difference being that recording rules are not allowed here -- only alerting rules.  For each AlertingRule resource created, a corresponding PrometheusRule will be created in the openshift-monitoring namespace.  OpenShift requires admins to use the AlertingRule resource rather than the upstream type in order to allow better OpenShift specific defaulting and validation, while not modifying the upstream APIs directly. \n You can find upstream API documentation for PrometheusRule resources here: \n https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec describes the desired state of this AlertingRule object.",
+            "properties": {
+                "groups": {
+                    "description": "groups is a list of grouped alerting rules.  Rule groups are the unit at which Prometheus parallelizes rule processing.  All rules in a single group share a configured evaluation interval.  All rules in the group will be processed together on this interval, sequentially, and all rules will be processed. \n It's common to group related alerting rules into a single AlertingRule resources, and within that resource, closely related alerts, or simply alerts with the same interval, into individual groups.  You are also free to create AlertingRule resources with only a single rule group, but be aware that this can have a performance impact on Prometheus if the group is extremely large or has very complex query expressions to evaluate. Spreading very complex rules across multiple groups to allow them to be processed in parallel is also a common use-case.",
+                    "items": {
+                        "description": "RuleGroup is a list of sequentially evaluated alerting rules.",
+                        "properties": {
+                            "interval": {
+                                "description": "interval is how often rules in the group are evaluated.  If not specified, it defaults to the global.evaluation_interval configured in Prometheus, which itself defaults to 30 seconds.  You can check if this value has been modified from the default on your cluster by inspecting the platform Prometheus configuration: The relevant field in that resource is: spec.evaluationInterval",
+                                "maxLength": 2048,
+                                "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the name of the group.",
+                                "maxLength": 2048,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "rules": {
+                                "description": "rules is a list of sequentially evaluated alerting rules.  Prometheus may process rule groups in parallel, but rules within a single group are always processed sequentially, and all rules are processed.",
+                                "items": {
+                                    "description": "Rule describes an alerting rule. See Prometheus documentation: - https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules",
+                                    "properties": {
+                                        "alert": {
+                                            "description": "alert is the name of the alert. Must be a valid label value, i.e. may contain any Unicode character.",
+                                            "maxLength": 2048,
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "annotations": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "annotations to add to each alert.  These are values that can be used to store longer additional information that you won't query on, such as alert descriptions or runbook links.",
+                                            "type": "object"
+                                        },
+                                        "expr": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "description": "expr is the PromQL expression to evaluate. Every evaluation cycle this is evaluated at the current time, and all resultant time series become pending or firing alerts.  This is most often a string representing a PromQL expression, e.g.: mapi_current_pending_csr > mapi_max_pending_csr In rare cases this could be a simple integer, e.g. a simple \"1\" if the intent is to create an alert that is always firing.  This is sometimes used to create an always-firing \"Watchdog\" alert in order to ensure the alerting pipeline is functional.",
+                                            "x-kubernetes-int-or-string": true
+                                        },
+                                        "for": {
+                                            "description": "for is the time period after which alerts are considered firing after first returning results.  Alerts which have not yet fired for long enough are considered pending.",
+                                            "maxLength": 2048,
+                                            "pattern": "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "labels to add or overwrite for each alert.  The results of the PromQL expression for the alert will result in an existing set of labels for the alert, after evaluating the expression, for any label specified here with the same name as a label in that set, the label here wins and overwrites the previous value.  These should typically be short identifying values that may be useful to query against.  A common example is the alert severity, where one sets `severity: warning` under the `labels` key:",
+                                            "type": "object"
+                                        }
+                                    },
+                                    "required": [
+                                        "alert",
+                                        "expr"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "rules"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "required": [
+                "groups"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status describes the current state of this AlertOverrides object.",
+            "properties": {
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "prometheusRule": {
+                    "description": "prometheusRule is the generated PrometheusRule for this AlertingRule.  Each AlertingRule instance results in a generated PrometheusRule object in the same namespace, which is always the openshift-monitoring namespace.",
+                    "properties": {
+                        "name": {
+                            "description": "name of the referenced PrometheusRule.",
+                            "maxLength": 2048,
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/alertrelabelconfig_monitoring.openshift.io_v1.json
+++ b/openshift/v4.14-strict/alertrelabelconfig_monitoring.openshift.io_v1.json
@@ -1,0 +1,191 @@
+{
+    "description": "AlertRelabelConfig defines a set of relabel configs for alerts. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec describes the desired state of this AlertRelabelConfig object.",
+            "properties": {
+                "configs": {
+                    "description": "configs is a list of sequentially evaluated alert relabel configs.",
+                    "items": {
+                        "description": "RelabelConfig allows dynamic rewriting of label sets for alerts. See Prometheus documentation: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
+                        "properties": {
+                            "action": {
+                                "default": "Replace",
+                                "description": "action to perform based on regex matching. Must be one of: 'Replace', 'Keep', 'Drop', 'HashMod', 'LabelMap', 'LabelDrop', or 'LabelKeep'. Default is: 'Replace'",
+                                "enum": [
+                                    "Replace",
+                                    "Keep",
+                                    "Drop",
+                                    "HashMod",
+                                    "LabelMap",
+                                    "LabelDrop",
+                                    "LabelKeep"
+                                ],
+                                "type": "string"
+                            },
+                            "modulus": {
+                                "description": "modulus to take of the hash of the source label values.  This can be combined with the 'HashMod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'. This is only valid if sourceLabels is not empty and action is not 'LabelKeep' or 'LabelDrop'.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "regex": {
+                                "default": "(.*)",
+                                "description": "regex against which the extracted value is matched. Default is: '(.*)' regex is required for all actions except 'HashMod'",
+                                "maxLength": 2048,
+                                "type": "string"
+                            },
+                            "replacement": {
+                                "description": "replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is 'Replace' or 'LabelMap' and forbidden for actions 'LabelKeep' and 'LabelDrop'. Regex capture groups are available. Default is: '$1'",
+                                "maxLength": 2048,
+                                "type": "string"
+                            },
+                            "separator": {
+                                "description": "separator placed between concatenated source label values. When omitted, Prometheus will use its default value of ';'.",
+                                "maxLength": 2048,
+                                "type": "string"
+                            },
+                            "sourceLabels": {
+                                "description": "sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the 'Replace', 'Keep', and 'Drop' actions. Not allowed for actions 'LabelKeep' and 'LabelDrop'.",
+                                "items": {
+                                    "description": "LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, and underscores.",
+                                    "maxLength": 2048,
+                                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "targetLabel": {
+                                "description": "targetLabel to which the resulting value is written in a 'Replace' action. It is required for 'Replace' and 'HashMod' actions and forbidden for actions 'LabelKeep' and 'LabelDrop'. Regex capture groups are available.",
+                                "maxLength": 2048,
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                            {
+                                "message": "relabel action hashmod requires non-zero modulus",
+                                "rule": "self.action != 'HashMod' || self.modulus != 0"
+                            },
+                            {
+                                "message": "targetLabel is required when action is Replace or HashMod",
+                                "rule": "(self.action != 'Replace' && self.action != 'HashMod') || has(self.targetLabel)"
+                            },
+                            {
+                                "message": "LabelKeep and LabelDrop actions require only 'regex', and no other fields (found sourceLabels)",
+                                "rule": "(self.action != 'LabelDrop' && self.action != 'LabelKeep') || !has(self.sourceLabels)"
+                            },
+                            {
+                                "message": "LabelKeep and LabelDrop actions require only 'regex', and no other fields (found targetLabel)",
+                                "rule": "(self.action != 'LabelDrop' && self.action != 'LabelKeep') || !has(self.targetLabel)"
+                            },
+                            {
+                                "message": "LabelKeep and LabelDrop actions require only 'regex', and no other fields (found modulus)",
+                                "rule": "(self.action != 'LabelDrop' && self.action != 'LabelKeep') || !has(self.modulus)"
+                            },
+                            {
+                                "message": "LabelKeep and LabelDrop actions require only 'regex', and no other fields (found separator)",
+                                "rule": "(self.action != 'LabelDrop' && self.action != 'LabelKeep') || !has(self.separator)"
+                            },
+                            {
+                                "message": "LabelKeep and LabelDrop actions require only 'regex', and no other fields (found replacement)",
+                                "rule": "(self.action != 'LabelDrop' && self.action != 'LabelKeep') || !has(self.replacement)"
+                            },
+                            {
+                                "message": "modulus requires sourceLabels to be present",
+                                "rule": "!has(self.modulus) || (has(self.modulus) && size(self.sourceLabels) > 0)"
+                            },
+                            {
+                                "message": "sourceLabels is required for actions Replace, Keep, Drop, HashMod and LabelMap",
+                                "rule": "(self.action == 'LabelDrop' || self.action == 'LabelKeep') || has(self.sourceLabels)"
+                            },
+                            {
+                                "message": "replacement is required for actions Replace and LabelMap",
+                                "rule": "(self.action != 'Replace' && self.action != 'LabelMap') || has(self.replacement)"
+                            }
+                        ],
+                        "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "configs"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status describes the current state of this AlertRelabelConfig object.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions contains details on the state of the AlertRelabelConfig, may be empty.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/alibabacloudmachineproviderconfig_machine.openshift.io_v1.json
+++ b/openshift/v4.14-strict/alibabacloudmachineproviderconfig_machine.openshift.io_v1.json
@@ -1,0 +1,230 @@
+{
+    "description": "AlibabaCloudMachineProviderConfig is the Schema for the alibabacloudmachineproviderconfig API Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "bandwidth": {
+            "description": "Bandwidth describes the internet bandwidth strategy for the instance",
+            "properties": {
+                "internetMaxBandwidthIn": {
+                    "description": "InternetMaxBandwidthIn is the maximum inbound public bandwidth. Unit: Mbit/s. Valid values: When the purchased outbound public bandwidth is less than or equal to 10 Mbit/s, the valid values of this parameter are 1 to 10. Currently the default is `10` when outbound bandwidth is less than or equal to 10 Mbit/s. When the purchased outbound public bandwidth is greater than 10, the valid values are 1 to the InternetMaxBandwidthOut value. Currently the default is the value used for `InternetMaxBandwidthOut` when outbound public bandwidth is greater than 10.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "internetMaxBandwidthOut": {
+                    "description": "InternetMaxBandwidthOut is the maximum outbound public bandwidth. Unit: Mbit/s. Valid values: 0 to 100. When a value greater than 0 is used then a public IP address is assigned to the instance. Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `0`",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "credentialsSecret": {
+            "description": "CredentialsSecret is a reference to the secret with alibabacloud credentials. Otherwise, defaults to permissions provided by attached RAM role where the actuator is running.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "dataDisk": {
+            "description": "DataDisks holds information regarding the extra disks attached to the instance",
+            "items": {
+                "description": "DataDisk contains the information regarding the datadisk attached to an instance",
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "imageId": {
+            "description": "The ID of the image used to create the instance.",
+            "type": "string"
+        },
+        "instanceType": {
+            "description": "The instance type of the instance.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "ramRoleName": {
+            "description": "RAMRoleName is the name of the instance Resource Access Management (RAM) role. This allows the instance to perform API calls as this specified RAM role.",
+            "type": "string"
+        },
+        "regionId": {
+            "description": "The ID of the region in which to create the instance. You can call the DescribeRegions operation to query the most recent region list.",
+            "type": "string"
+        },
+        "resourceGroup": {
+            "description": "ResourceGroup references the resource group to which to assign the instance. A reference holds either the resource group ID, the resource name, or the required tags to search. When more than one resource group are returned for a search, an error will be produced and the Machine will not be created. Resource Groups do not support searching by tags.",
+            "properties": {
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the resource",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags is a set of metadata based upon ECS object tags used to identify a resource. For details about usage when multiple resources are found, please see the owning parent field documentation.",
+                    "items": {
+                        "description": "Tag  The tags of ECS Instance",
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "description": "type identifies the resource reference type for this entry.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "securityGroups": {
+            "description": "SecurityGroups is a list of security group references to assign to the instance. A reference holds either the security group ID, the resource name, or the required tags to search. When more than one security group is returned for a tag search, all the groups are associated with the instance up to the maximum number of security groups to which an instance can belong. For more information, see the \"Security group limits\" section in Limits. https://www.alibabacloud.com/help/en/doc-detail/25412.htm",
+            "items": {
+                "description": "ResourceTagReference is a reference to a specific AlibabaCloud resource by ID, or tags. Only one of ID or Tags may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                    "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the resource",
+                        "type": "string"
+                    },
+                    "tags": {
+                        "description": "Tags is a set of metadata based upon ECS object tags used to identify a resource. For details about usage when multiple resources are found, please see the owning parent field documentation.",
+                        "items": {
+                            "description": "Tag  The tags of ECS Instance",
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": {
+                        "description": "type identifies the resource reference type for this entry.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "systemDisk": {
+            "description": "SystemDisk holds the properties regarding the system disk for the instance",
+            "properties": {
+                "category": {
+                    "description": "Category is the category of the system disk. Valid values: cloud_essd: ESSD. When the parameter is set to this value, you can use the SystemDisk.PerformanceLevel parameter to specify the performance level of the disk. cloud_efficiency: ultra disk. cloud_ssd: standard SSD. cloud: basic disk. Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently for non-I/O optimized instances of retired instance types, the default is `cloud`. Currently for other instances, the default is `cloud_efficiency`.",
+                    "enum": [
+                        "cloud_efficiency",
+                        "cloud_ssd",
+                        "cloud_essd",
+                        "cloud"
+                    ],
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the name of the system disk. If the name is specified the name must be 2 to 128 characters in length. It must start with a letter and cannot start with http:// or https://. It can contain letters, digits, colons (:), underscores (_), and hyphens (-). Empty value means the platform chooses a default, which is subject to change over time. Currently the default is `\"\"`.",
+                    "maxLength": 128,
+                    "type": "string"
+                },
+                "performanceLevel": {
+                    "description": "PerformanceLevel is the performance level of the ESSD used as the system disk. Valid values: \n PL0: A single ESSD can deliver up to 10,000 random read/write IOPS. PL1: A single ESSD can deliver up to 50,000 random read/write IOPS. PL2: A single ESSD can deliver up to 100,000 random read/write IOPS. PL3: A single ESSD can deliver up to 1,000,000 random read/write IOPS. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is `PL1`. For more information about ESSD performance levels, see ESSDs.",
+                    "enum": [
+                        "PL0",
+                        "PL1",
+                        "PL2",
+                        "PL3"
+                    ],
+                    "type": "string"
+                },
+                "size": {
+                    "description": "Size is the size of the system disk. Unit: GiB. Valid values: 20 to 500. The value must be at least 20 and greater than or equal to the size of the image. Empty value means the platform chooses a default, which is subject to change over time. Currently the default is `40` or the size of the image depending on whichever is greater.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "tag": {
+            "description": "Tags are the set of metadata to add to an instance.",
+            "items": {
+                "description": "Tag  The tags of ECS Instance",
+                "type": "object"
+            },
+            "type": "array"
+        },
+        "tenancy": {
+            "description": "Tenancy specifies whether to create the instance on a dedicated host. Valid values: \n default: creates the instance on a non-dedicated host. host: creates the instance on a dedicated host. If you do not specify the DedicatedHostID parameter, Alibaba Cloud automatically selects a dedicated host for the instance. Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `default`.",
+            "type": "string"
+        },
+        "userDataSecret": {
+            "description": "UserDataSecret contains a local reference to a secret that contains the UserData to apply to the instance",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "vSwitch": {
+            "description": "VSwitch is a reference to the vswitch to use for this instance. A reference holds either the vSwitch ID, the resource name, or the required tags to search. When more than one vSwitch is returned for a tag search, only the first vSwitch returned will be used. This parameter is required when you create an instance of the VPC type. You can call the DescribeVSwitches operation to query the created vSwitches.",
+            "properties": {
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the resource",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags is a set of metadata based upon ECS object tags used to identify a resource. For details about usage when multiple resources are found, please see the owning parent field documentation.",
+                    "items": {
+                        "description": "Tag  The tags of ECS Instance",
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "description": "type identifies the resource reference type for this entry.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "vpcId": {
+            "description": "The ID of the vpc",
+            "type": "string"
+        },
+        "zoneId": {
+            "description": "The ID of the zone in which to create the instance. You can call the DescribeZones operation to query the most recent region list.",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/alibabacloudmachineproviderstatus_machine.openshift.io_v1.json
+++ b/openshift/v4.14-strict/alibabacloudmachineproviderstatus_machine.openshift.io_v1.json
@@ -1,0 +1,73 @@
+{
+    "description": "AlibabaCloudMachineProviderStatus is the Schema for the alibabacloudmachineproviderconfig API Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "conditions": {
+            "description": "Conditions is a set of conditions associated with the Machine to indicate errors or other status",
+            "items": {
+                "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                "properties": {
+                    "lastTransitionTime": {
+                        "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                        "type": "string"
+                    },
+                    "observedGeneration": {
+                        "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "reason": {
+                        "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "status of the condition, one of True, False, Unknown.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "instanceId": {
+            "description": "InstanceID is the instance ID of the machine created in alibabacloud",
+            "type": "string"
+        },
+        "instanceState": {
+            "description": "InstanceState is the state of the alibabacloud instance for this machine",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/all.json
+++ b/openshift/v4.14-strict/all.json
@@ -398,6 +398,18 @@
         },
         {
             "$ref": "user_user.openshift.io_v1.json"
-        }
+        },
+		{
+			"$ref": "kubeletconfig_machineconfiguration.openshift.io_v1.json"
+		},
+		{
+			"$ref": "containerruntimeconfig_machineconfiguration.openshift.io_v1.json"
+		},
+		{
+			"$ref": "machineconfig_machineconfiguration.openshift.io_v1.json"
+		},
+		{
+			"$ref": "machineconfigpool_machineconfiguration.openshift.io_v1.json"
+		}
     ]
 }

--- a/openshift/v4.14-strict/all.json
+++ b/openshift/v4.14-strict/all.json
@@ -1,0 +1,403 @@
+{
+    "oneOf": [
+        {
+            "$ref": "apirequestcount_apiserver.openshift.io_v1.json"
+        },
+        {
+            "$ref": "deploymentconfig_apps.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusterrolebinding_authorization.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusterrole_authorization.openshift.io_v1.json"
+        },
+        {
+            "$ref": "rolebindingrestriction_authorization.openshift.io_v1.json"
+        },
+        {
+            "$ref": "rolebinding_authorization.openshift.io_v1.json"
+        },
+        {
+            "$ref": "role_authorization.openshift.io_v1.json"
+        },
+        {
+            "$ref": "binarybuildrequestoptions_build.openshift.io_v1.json"
+        },
+        {
+            "$ref": "buildconfig_build.openshift.io_v1.json"
+        },
+        {
+            "$ref": "buildrequest_build.openshift.io_v1.json"
+        },
+        {
+            "$ref": "build_build.openshift.io_v1.json"
+        },
+        {
+            "$ref": "cloudprivateipconfig_cloud.network.openshift.io_v1.json"
+        },
+        {
+            "$ref": "apiserver_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "authentication_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "backup_config.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "build_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusteroperator_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusterversion_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "console_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "dns_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "featuregate_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagecontentpolicy_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagedigestmirrorset_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "image_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagetagmirrorset_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "infrastructure_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "ingress_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "insightsdatagather_config.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "network_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "node_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauth_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "operatorhub_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "project_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "proxy_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "scheduler_config.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consoleclidownload_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consoleexternalloglink_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consolelink_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consolenotification_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consoleplugin_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consolequickstart_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consolesample_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "consoleyamlsample_console.openshift.io_v1.json"
+        },
+        {
+            "$ref": "podnetworkconnectivitycheck_controlplane.operator.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "notstableconfigtype_example.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "stableconfigtype_example.openshift.io_v1.json"
+        },
+        {
+            "$ref": "helmchartrepository_helm.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "projecthelmchartrepository_helm.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "imagesignature_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestreamimage_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestreamimport_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestreamlayers_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestreammapping_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestream_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagestreamtag_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "image_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagetag_image.openshift.io_v1.json"
+        },
+        {
+            "$ref": "config_imageregistry.operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagepruner_imageregistry.operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "dnsrecord_ingress.operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "datagather_insights.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "alibabacloudmachineproviderconfig_machine.openshift.io_v1.json"
+        },
+        {
+            "$ref": "alibabacloudmachineproviderstatus_machine.openshift.io_v1.json"
+        },
+        {
+            "$ref": "awsmachineproviderconfig_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "azuremachineproviderspec_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "azuremachineproviderstatus_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "controlplanemachineset_machine.openshift.io_v1.json"
+        },
+        {
+            "$ref": "gcpmachineproviderspec_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "gcpmachineproviderstatus_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "machinehealthcheck_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "machineset_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "machine_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "nutanixmachineproviderconfig_machine.openshift.io_v1.json"
+        },
+        {
+            "$ref": "openstackproviderspec_machine.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "powervsmachineproviderconfig_machine.openshift.io_v1.json"
+        },
+        {
+            "$ref": "vspheremachineproviderspec_machine.openshift.io_v1beta1.json"
+        },
+        {
+            "$ref": "alertingrule_monitoring.openshift.io_v1.json"
+        },
+        {
+            "$ref": "alertrelabelconfig_monitoring.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusternetwork_network.openshift.io_v1.json"
+        },
+        {
+            "$ref": "egressnetworkpolicy_network.openshift.io_v1.json"
+        },
+        {
+            "$ref": "hostsubnet_network.openshift.io_v1.json"
+        },
+        {
+            "$ref": "netnamespace_network.openshift.io_v1.json"
+        },
+        {
+            "$ref": "egressrouter_network.operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauthaccesstoken_oauth.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauthauthorizetoken_oauth.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauthclientauthorization_oauth.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauthclient_oauth.openshift.io_v1.json"
+        },
+        {
+            "$ref": "oauthredirectreference_oauth.openshift.io_v1.json"
+        },
+        {
+            "$ref": "authentication_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "cloudcredential_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clustercsidriver_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "config_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "console_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "csisnapshotcontroller_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "dns_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "etcdbackup_operator.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "etcd_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "imagecontentsourcepolicy_operator.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "ingresscontroller_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "insightsoperator_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "kubeapiserver_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "kubecontrollermanager_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "kubescheduler_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "kubestorageversionmigrator_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "myoperatorresource_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "network_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "olm_operator.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "openshiftapiserver_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "openshiftcontrollermanager_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "serviceca_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "servicecatalogapiserver_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "servicecatalogcontrollermanager_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "storage_operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "platformoperator_platform.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "projectrequest_project.openshift.io_v1.json"
+        },
+        {
+            "$ref": "project_project.openshift.io_v1.json"
+        },
+        {
+            "$ref": "appliedclusterresourcequota_quota.openshift.io_v1.json"
+        },
+        {
+            "$ref": "clusterresourcequota_quota.openshift.io_v1.json"
+        },
+        {
+            "$ref": "route_route.openshift.io_v1.json"
+        },
+        {
+            "$ref": "config_samples.operator.openshift.io_v1.json"
+        },
+        {
+            "$ref": "rangeallocation_security.internal.openshift.io_v1.json"
+        },
+        {
+            "$ref": "rangeallocation_security.openshift.io_v1.json"
+        },
+        {
+            "$ref": "securitycontextconstraints_security.openshift.io_v1.json"
+        },
+        {
+            "$ref": "servicecertsigneroperatorconfig_servicecertsigner.config.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "sharedconfigmap_sharedresource.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "sharedsecret_sharedresource.openshift.io_v1alpha1.json"
+        },
+        {
+            "$ref": "brokertemplateinstance_template.openshift.io_v1.json"
+        },
+        {
+            "$ref": "templateinstance_template.openshift.io_v1.json"
+        },
+        {
+            "$ref": "template_template.openshift.io_v1.json"
+        },
+        {
+            "$ref": "group_user.openshift.io_v1.json"
+        },
+        {
+            "$ref": "identity_user.openshift.io_v1.json"
+        },
+        {
+            "$ref": "useridentitymapping_user.openshift.io_v1.json"
+        },
+        {
+            "$ref": "user_user.openshift.io_v1.json"
+        }
+    ]
+}

--- a/openshift/v4.14-strict/apirequestcount_apiserver.openshift.io_v1.json
+++ b/openshift/v4.14-strict/apirequestcount_apiserver.openshift.io_v1.json
@@ -1,0 +1,304 @@
+{
+    "description": "APIRequestCount tracks requests made to an API. The instance name must be of the form `resource.version.group`, matching the resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec defines the characteristics of the resource.",
+            "properties": {
+                "numberOfUsersToReport": {
+                    "default": 10,
+                    "description": "numberOfUsersToReport is the number of users to include in the report. If unspecified or zero, the default is ten.  This is default is subject to change.",
+                    "format": "int64",
+                    "maximum": 100,
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status contains the observed state of the resource.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions contains details of the current status of this API Resource.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "maxLength": 32768,
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "minimum": 0,
+                                "type": "integer",
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "maxLength": 1024,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "maxLength": 316,
+                                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "currentHour": {
+                    "description": "currentHour contains request history for the current hour. This is porcelain to make the API easier to read by humans seeing if they addressed a problem. This field is reset on the hour.",
+                    "properties": {
+                        "byNode": {
+                            "description": "byNode contains logs of requests per node.",
+                            "items": {
+                                "description": "PerNodeAPIRequestLog contains logs of requests to a certain node.",
+                                "properties": {
+                                    "byUser": {
+                                        "description": "byUser contains request details by top .spec.numberOfUsersToReport users. Note that because in the case of an apiserver, restart the list of top users is determined on a best-effort basis, the list might be imprecise. In addition, some system users may be explicitly included in the list.",
+                                        "items": {
+                                            "description": "PerUserAPIRequestCount contains logs of a user's requests.",
+                                            "properties": {
+                                                "byVerb": {
+                                                    "description": "byVerb details by verb.",
+                                                    "items": {
+                                                        "description": "PerVerbAPIRequestCount requestCounts requests by API request verb.",
+                                                        "properties": {
+                                                            "requestCount": {
+                                                                "description": "requestCount of requests for verb.",
+                                                                "format": "int64",
+                                                                "minimum": 0,
+                                                                "type": "integer",
+                                                                "maximum": 9223372036854776000
+                                                            },
+                                                            "verb": {
+                                                                "description": "verb of API request (get, list, create, etc...)",
+                                                                "maxLength": 20,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "maxItems": 10,
+                                                    "type": "array"
+                                                },
+                                                "requestCount": {
+                                                    "description": "requestCount of requests by the user across all verbs.",
+                                                    "format": "int64",
+                                                    "minimum": 0,
+                                                    "type": "integer",
+                                                    "maximum": 9223372036854776000
+                                                },
+                                                "userAgent": {
+                                                    "description": "userAgent that made the request. The same user often has multiple binaries which connect (pods with many containers).  The different binaries will have different userAgents, but the same user.  In addition, we have userAgents with version information embedded and the userName isn't likely to change.",
+                                                    "maxLength": 1024,
+                                                    "type": "string"
+                                                },
+                                                "username": {
+                                                    "description": "userName that made the request.",
+                                                    "maxLength": 512,
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "maxItems": 500,
+                                        "type": "array"
+                                    },
+                                    "nodeName": {
+                                        "description": "nodeName where the request are being handled.",
+                                        "maxLength": 512,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "requestCount": {
+                                        "description": "requestCount is a sum of all requestCounts across all users, even those outside of the top 10 users.",
+                                        "format": "int64",
+                                        "minimum": 0,
+                                        "type": "integer",
+                                        "maximum": 9223372036854776000
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "maxItems": 512,
+                            "type": "array"
+                        },
+                        "requestCount": {
+                            "description": "requestCount is a sum of all requestCounts across nodes.",
+                            "format": "int64",
+                            "minimum": 0,
+                            "type": "integer",
+                            "maximum": 9223372036854776000
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "last24h": {
+                    "description": "last24h contains request history for the last 24 hours, indexed by the hour, so 12:00AM-12:59 is in index 0, 6am-6:59am is index 6, etc. The index of the current hour is updated live and then duplicated into the requestsLastHour field.",
+                    "items": {
+                        "description": "PerResourceAPIRequestLog logs request for various nodes.",
+                        "properties": {
+                            "byNode": {
+                                "description": "byNode contains logs of requests per node.",
+                                "items": {
+                                    "description": "PerNodeAPIRequestLog contains logs of requests to a certain node.",
+                                    "properties": {
+                                        "byUser": {
+                                            "description": "byUser contains request details by top .spec.numberOfUsersToReport users. Note that because in the case of an apiserver, restart the list of top users is determined on a best-effort basis, the list might be imprecise. In addition, some system users may be explicitly included in the list.",
+                                            "items": {
+                                                "description": "PerUserAPIRequestCount contains logs of a user's requests.",
+                                                "properties": {
+                                                    "byVerb": {
+                                                        "description": "byVerb details by verb.",
+                                                        "items": {
+                                                            "description": "PerVerbAPIRequestCount requestCounts requests by API request verb.",
+                                                            "properties": {
+                                                                "requestCount": {
+                                                                    "description": "requestCount of requests for verb.",
+                                                                    "format": "int64",
+                                                                    "minimum": 0,
+                                                                    "type": "integer",
+                                                                    "maximum": 9223372036854776000
+                                                                },
+                                                                "verb": {
+                                                                    "description": "verb of API request (get, list, create, etc...)",
+                                                                    "maxLength": 20,
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "maxItems": 10,
+                                                        "type": "array"
+                                                    },
+                                                    "requestCount": {
+                                                        "description": "requestCount of requests by the user across all verbs.",
+                                                        "format": "int64",
+                                                        "minimum": 0,
+                                                        "type": "integer",
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "userAgent": {
+                                                        "description": "userAgent that made the request. The same user often has multiple binaries which connect (pods with many containers).  The different binaries will have different userAgents, but the same user.  In addition, we have userAgents with version information embedded and the userName isn't likely to change.",
+                                                        "maxLength": 1024,
+                                                        "type": "string"
+                                                    },
+                                                    "username": {
+                                                        "description": "userName that made the request.",
+                                                        "maxLength": 512,
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "maxItems": 500,
+                                            "type": "array"
+                                        },
+                                        "nodeName": {
+                                            "description": "nodeName where the request are being handled.",
+                                            "maxLength": 512,
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "requestCount": {
+                                            "description": "requestCount is a sum of all requestCounts across all users, even those outside of the top 10 users.",
+                                            "format": "int64",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 9223372036854776000
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "maxItems": 512,
+                                "type": "array"
+                            },
+                            "requestCount": {
+                                "description": "requestCount is a sum of all requestCounts across nodes.",
+                                "format": "int64",
+                                "minimum": 0,
+                                "type": "integer",
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "maxItems": 24,
+                    "type": "array"
+                },
+                "removedInRelease": {
+                    "description": "removedInRelease is when the API will be removed.",
+                    "maxLength": 64,
+                    "minLength": 0,
+                    "pattern": "^[0-9][0-9]*\\.[0-9][0-9]*$",
+                    "type": "string"
+                },
+                "requestCount": {
+                    "description": "requestCount is a sum of all requestCounts across all current hours, nodes, and users.",
+                    "format": "int64",
+                    "minimum": 0,
+                    "type": "integer",
+                    "maximum": 9223372036854776000
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/apiserver_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/apiserver_config.openshift.io_v1.json
@@ -1,0 +1,230 @@
+{
+    "description": "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "additionalCORSAllowedOrigins": {
+                    "description": "additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "audit": {
+                    "default": {
+                        "profile": "Default"
+                    },
+                    "description": "audit specifies the settings for audit configuration to be applied to all OpenShift-provided API servers in the cluster.",
+                    "properties": {
+                        "customRules": {
+                            "description": "customRules specify profiles per group. These profile take precedence over the top-level profile field if they apply. They are evaluation from top to bottom and the first one that matches, applies.",
+                            "items": {
+                                "description": "AuditCustomRule describes a custom rule for an audit profile that takes precedence over the top-level profile.",
+                                "properties": {
+                                    "group": {
+                                        "description": "group is a name of group a request user must be member of in order to this profile to apply.",
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "profile": {
+                                        "description": "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster. \n The following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n If unset, the 'Default' profile is used as the default.",
+                                        "enum": [
+                                            "Default",
+                                            "WriteRequestBodies",
+                                            "AllRequestBodies",
+                                            "None"
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "group",
+                                    "profile"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "group"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                        },
+                        "profile": {
+                            "default": "Default",
+                            "description": "profile specifies the name of the desired top-level audit profile to be applied to all requests sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver, openshift-apiserver and oauth-apiserver), with the exception of those requests that match one or more of the customRules. \n The following profiles are provided: - Default: default policy which means MetaData level logging with the exception of events (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody level). - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n Warning: It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly. \n If unset, the 'Default' profile is used as the default.",
+                            "enum": [
+                                "Default",
+                                "WriteRequestBodies",
+                                "AllRequestBodies",
+                                "None"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "clientCA": {
+                    "description": "clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data[\"ca-bundle.crt\"] - CA bundle.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "encryption": {
+                    "description": "encryption allows the configuration of encryption of resources at the datastore layer.",
+                    "properties": {
+                        "type": {
+                            "description": "type defines what encryption type should be used to encrypt resources at the datastore layer. When this field is unset (i.e. when it is set to the empty string), identity is implied. The behavior of unset can and will change over time.  Even if encryption is enabled by default, the meaning of unset may change to a different encryption type based on changes in best practices. \n When encryption is enabled, all sensitive resources shipped with the platform are encrypted. This list of sensitive resources can and will change over time.  The current authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io",
+                            "enum": [
+                                "",
+                                "identity",
+                                "aescbc",
+                                "aesgcm"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "servingCerts": {
+                    "description": "servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.",
+                    "properties": {
+                        "namedCertificates": {
+                            "description": "namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames. If no named certificates are provided, or no named certificates match the server name as understood by a client, the defaultServingCertificate will be used.",
+                            "items": {
+                                "description": "APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.",
+                                "properties": {
+                                    "names": {
+                                        "description": "names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates. Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "servingCertificate": {
+                                        "description": "servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic. The secret must exist in the openshift-config namespace and contain the following required fields: - Secret.Data[\"tls.key\"] - TLS private key. - Secret.Data[\"tls.crt\"] - TLS certificate.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tlsSecurityProfile": {
+                    "description": "tlsSecurityProfile specifies settings for TLS connections for externally exposed servers. \n If unset, a default (which may change between releases) is chosen. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available MinTLSVersions is VersionTLS12.",
+                    "properties": {
+                        "custom": {
+                            "description": "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: TLSv1.1",
+                            "properties": {
+                                "ciphers": {
+                                    "description": "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "minTLSVersion": {
+                                    "description": "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12",
+                                    "enum": [
+                                        "VersionTLS10",
+                                        "VersionTLS11",
+                                        "VersionTLS12",
+                                        "VersionTLS13"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "intermediate": {
+                            "description": "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "modern": {
+                            "description": "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported.",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "old": {
+                            "description": "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: TLSv1.0",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "type": {
+                            "description": "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.",
+                            "enum": [
+                                "Old",
+                                "Intermediate",
+                                "Modern",
+                                "Custom"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/appliedclusterresourcequota_quota.openshift.io_v1.json
+++ b/openshift/v4.14-strict/appliedclusterresourcequota_quota.openshift.io_v1.json
@@ -1,0 +1,276 @@
+{
+    "description": "AppliedClusterResourceQuota mirrors ClusterResourceQuota at a project scope, for projection into a project.  It allows a project-admin to know which ClusterResourceQuotas are applied to his project and their associated usage. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec defines the desired quota",
+            "properties": {
+                "quota": {
+                    "description": "Quota defines the desired quota",
+                    "properties": {
+                        "hard": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                            "type": "object"
+                        },
+                        "scopeSelector": {
+                            "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "A list of scope selector requirements by scope of the resources.",
+                                    "items": {
+                                        "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+                                        "properties": {
+                                            "operator": {
+                                                "description": "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "scopeName": {
+                                                "description": "The name of the scope that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "operator",
+                                            "scopeName"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "scopes": {
+                            "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
+                            "items": {
+                                "description": "A ResourceQuotaScope defines a filter that must match each object tracked by a quota",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "selector": {
+                    "description": "Selector is the selector used to match projects. It should only select active projects on the scale of dozens (though it can select many more less active projects).  These projects will contend on object creation through this resource.",
+                    "properties": {
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "AnnotationSelector is used to select projects by annotation.",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "labels": {
+                            "description": "LabelSelector is used to select projects by label.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "quota",
+                "selector"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status defines the actual enforced quota and its current usage",
+            "properties": {
+                "namespaces": {
+                    "description": "Namespaces slices the usage by project.  This division allows for quick resolution of deletion reconciliation inside of a single project without requiring a recalculation across all projects.  This can be used to pull the deltas for a given project.",
+                    "items": {
+                        "description": "ResourceQuotaStatusByNamespace gives status for a particular project",
+                        "properties": {
+                            "namespace": {
+                                "description": "Namespace the project this status applies to",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status indicates how many resources have been consumed by this project",
+                                "properties": {
+                                    "hard": {
+                                        "additionalProperties": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                                        "type": "object"
+                                    },
+                                    "used": {
+                                        "additionalProperties": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Used is the current observed total usage of the resource in the namespace.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "namespace",
+                            "status"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "total": {
+                    "description": "Total defines the actual enforced quota and its current usage across all projects",
+                    "properties": {
+                        "hard": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                            "type": "object"
+                        },
+                        "used": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Used is the current observed total usage of the resource in the namespace.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "total"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/authentication_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/authentication_config.openshift.io_v1.json
@@ -1,0 +1,121 @@
+{
+    "description": "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "oauthMetadata": {
+                    "description": "oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw '/.well-known/oauth-authorization-server' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key \"oauthMetadata\" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "serviceAccountIssuer": {
+                    "description": "serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the previous issuer value. Instead, the tokens issued by previous service account issuer will continue to be trusted for a time period chosen by the platform (currently set to 24h). This time period is subject to change over time. This allows internal components to transition to use new service account issuer without service distruption.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.",
+                    "type": "string"
+                },
+                "webhookTokenAuthenticator": {
+                    "description": "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service.",
+                    "properties": {
+                        "kubeConfig": {
+                            "description": "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "kubeConfig"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "webhookTokenAuthenticators": {
+                    "description": "webhookTokenAuthenticators is DEPRECATED, setting it has no effect.",
+                    "items": {
+                        "description": "deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.",
+                        "properties": {
+                            "kubeConfig": {
+                                "description": "kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.",
+                                "properties": {
+                                    "name": {
+                                        "description": "name is the metadata.name of the referenced secret",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "integratedOAuthMetadata": {
+                    "description": "integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw '/.well-known/oauth-authorization-server' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key \"oauthMetadata\" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/authentication_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/authentication_operator.openshift.io_v1.json
@@ -1,0 +1,176 @@
+{
+    "description": "Authentication provides information to configure an operator to manage authentication. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "oauthAPIServer": {
+                    "description": "OAuthAPIServer holds status specific only to oauth-apiserver",
+                    "properties": {
+                        "latestAvailableRevision": {
+                            "description": "LatestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
+                            "format": "int32",
+                            "minimum": 0,
+                            "type": "integer",
+                            "maximum": 2147483647
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/awsmachineproviderconfig_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/awsmachineproviderconfig_machine.openshift.io_v1beta1.json
@@ -1,0 +1,401 @@
+{
+    "description": "AWSMachineProviderConfig is the Schema for the awsmachineproviderconfigs API Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "ami": {
+            "description": "AMI is the reference to the AMI from which to create the machine instance.",
+            "properties": {
+                "arn": {
+                    "description": "ARN of resource",
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "Filters is a set of filters used to identify a resource",
+                    "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the filter. Filter names are case-sensitive.",
+                                "type": "string"
+                            },
+                            "values": {
+                                "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "blockDevices": {
+            "description": "BlockDevices is the set of block device mapping associated to this instance, block device without a name will be used as a root device and only one device without a name is allowed https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html",
+            "items": {
+                "description": "BlockDeviceMappingSpec describes a block device mapping",
+                "properties": {
+                    "deviceName": {
+                        "description": "The device name exposed to the machine (for example, /dev/sdh or xvdh).",
+                        "type": "string"
+                    },
+                    "ebs": {
+                        "description": "Parameters used to automatically set up EBS volumes when the machine is launched.",
+                        "properties": {
+                            "deleteOnTermination": {
+                                "description": "Indicates whether the EBS volume is deleted on machine termination.",
+                                "type": "boolean"
+                            },
+                            "encrypted": {
+                                "description": "Indicates whether the EBS volume is encrypted. Encrypted Amazon EBS volumes may only be attached to machines that support Amazon EBS encryption.",
+                                "type": "boolean"
+                            },
+                            "iops": {
+                                "description": "The number of I/O operations per second (IOPS) that the volume supports. For io1, this represents the number of IOPS that are provisioned for the volume. For gp2, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting. For more information about General Purpose SSD baseline performance, I/O credits, and bursting, see Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the Amazon Elastic Compute Cloud User Guide. \n Minimal and maximal IOPS for io1 and gp2 are constrained. Please, check https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html for precise boundaries for individual volumes. \n Condition: This parameter is required for requests to create io1 volumes; it is not used in requests to create gp2, st1, sc1, or standard volumes.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "kmsKey": {
+                                "description": "Indicates the KMS key that should be used to encrypt the Amazon EBS volume.",
+                                "properties": {
+                                    "arn": {
+                                        "description": "ARN of resource",
+                                        "type": "string"
+                                    },
+                                    "filters": {
+                                        "description": "Filters is a set of filters used to identify a resource",
+                                        "items": {
+                                            "description": "Filter is a filter used to identify an AWS resource",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "Name of the filter. Filter names are case-sensitive.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "id": {
+                                        "description": "ID of resource",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "volumeSize": {
+                                "description": "The size of the volume, in GiB. \n Constraints: 1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned IOPS SSD (io1), 500-16384 for Throughput Optimized HDD (st1), 500-16384 for Cold HDD (sc1), and 1-1024 for Magnetic (standard) volumes. If you specify a snapshot, the volume size must be equal to or larger than the snapshot size. \n Default: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "volumeType": {
+                                "description": "The volume type: gp2, io1, st1, sc1, or standard. Default: standard",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "noDevice": {
+                        "description": "Suppresses the specified device included in the block device mapping of the AMI.",
+                        "type": "string"
+                    },
+                    "virtualName": {
+                        "description": "The virtual device name (ephemeralN). Machine store volumes are numbered starting from 0. An machine type with 2 available machine store volumes can specify mappings for ephemeral0 and ephemeral1.The number of available machine store volumes depends on the machine type. After you connect to the machine, you must mount the volume. \n Constraints: For M3 machines, you must specify machine store volumes in the block device mapping for the machine. When you launch an M3 machine, we ignore any machine store volumes specified in the block device mapping for the AMI.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "credentialsSecret": {
+            "description": "CredentialsSecret is a reference to the secret with AWS credentials. Otherwise, defaults to permissions provided by attached IAM role where the actuator is running.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "deviceIndex": {
+            "description": "DeviceIndex is the index of the device on the instance for the network interface attachment. Defaults to 0.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "iamInstanceProfile": {
+            "description": "IAMInstanceProfile is a reference to an IAM role to assign to the instance",
+            "properties": {
+                "arn": {
+                    "description": "ARN of resource",
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "Filters is a set of filters used to identify a resource",
+                    "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the filter. Filter names are case-sensitive.",
+                                "type": "string"
+                            },
+                            "values": {
+                                "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "instanceType": {
+            "description": "InstanceType is the type of instance to create. Example: m4.xlarge",
+            "type": "string"
+        },
+        "keyName": {
+            "description": "KeyName is the name of the KeyPair to use for SSH",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "loadBalancers": {
+            "description": "LoadBalancers is the set of load balancers to which the new instance should be added once it is created.",
+            "items": {
+                "description": "LoadBalancerReference is a reference to a load balancer on AWS.",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "AWSLoadBalancerType is the type of LoadBalancer to use when registering an instance with load balancers specified in LoadBalancerNames",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "metadataServiceOptions": {
+            "description": "MetadataServiceOptions allows users to configure instance metadata service interaction options. If nothing specified, default AWS IMDS settings will be applied. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html",
+            "properties": {
+                "authentication": {
+                    "description": "Authentication determines whether or not the host requires the use of authentication when interacting with the metadata service. When using authentication, this enforces v2 interaction method (IMDSv2) with the metadata service. When omitted, this means the user has no opinion and the value is left to the platform to choose a good default, which is subject to change over time. The current default is optional. At this point this field represents `HttpTokens` parameter from `InstanceMetadataOptionsRequest` structure in AWS EC2 API https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html",
+                    "enum": [
+                        "Required",
+                        "Optional"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "networkInterfaceType": {
+            "description": "NetworkInterfaceType specifies the type of network interface to be used for the primary network interface. Valid values are \"ENA\", \"EFA\", and omitted, which means no opinion and the platform chooses a good default which may change over time. The current default value is \"ENA\". Please visit https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html to learn more about the AWS Elastic Fabric Adapter interface option.",
+            "enum": [
+                "ENA",
+                "EFA"
+            ],
+            "type": "string"
+        },
+        "placement": {
+            "description": "Placement specifies where to create the instance in AWS",
+            "properties": {
+                "availabilityZone": {
+                    "description": "AvailabilityZone is the availability zone of the instance",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Region is the region to use to create the instance",
+                    "type": "string"
+                },
+                "tenancy": {
+                    "description": "Tenancy indicates if instance should run on shared or single-tenant hardware. There are supported 3 options: default, dedicated and host.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "placementGroupName": {
+            "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance. The placement group must already be created and may use any placement strategy. When omitted, no placement group is used when creating the EC2 instance.",
+            "type": "string"
+        },
+        "publicIp": {
+            "description": "PublicIP specifies whether the instance should get a public IP. If not present, it should use the default of its subnet.",
+            "type": "boolean"
+        },
+        "securityGroups": {
+            "description": "SecurityGroups is an array of references to security groups that should be applied to the instance.",
+            "items": {
+                "description": "AWSResourceReference is a reference to a specific AWS resource by ID, ARN, or filters. Only one of ID, ARN or Filters may be specified. Specifying more than one will result in a validation error.",
+                "properties": {
+                    "arn": {
+                        "description": "ARN of resource",
+                        "type": "string"
+                    },
+                    "filters": {
+                        "description": "Filters is a set of filters used to identify a resource",
+                        "items": {
+                            "description": "Filter is a filter used to identify an AWS resource",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the filter. Filter names are case-sensitive.",
+                                    "type": "string"
+                                },
+                                "values": {
+                                    "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": "array"
+                    },
+                    "id": {
+                        "description": "ID of resource",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "spotMarketOptions": {
+            "description": "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
+            "properties": {
+                "maxPrice": {
+                    "description": "The maximum price the user is willing to pay for their instances Default: On-Demand price",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "subnet": {
+            "description": "Subnet is a reference to the subnet to use for this instance",
+            "properties": {
+                "arn": {
+                    "description": "ARN of resource",
+                    "type": "string"
+                },
+                "filters": {
+                    "description": "Filters is a set of filters used to identify a resource",
+                    "items": {
+                        "description": "Filter is a filter used to identify an AWS resource",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the filter. Filter names are case-sensitive.",
+                                "type": "string"
+                            },
+                            "values": {
+                                "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "tags": {
+            "description": "Tags is the set of tags to add to apply to an instance, in addition to the ones added by default by the actuator. These tags are additive. The actuator will ensure these tags are present, but will not remove any other tags that may exist on the instance.",
+            "items": {
+                "description": "TagSpecification is the name/value pair for a tag",
+                "properties": {
+                    "name": {
+                        "description": "Name of the tag",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Value of the tag",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "userDataSecret": {
+            "description": "UserDataSecret contains a local reference to a secret that contains the UserData to apply to the instance",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/azuremachineproviderspec_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/azuremachineproviderspec_machine.openshift.io_v1beta1.json
@@ -1,0 +1,497 @@
+{
+    "description": "AzureMachineProviderSpec is the type that will be embedded in a Machine.Spec.ProviderSpec field for an Azure virtual machine. It is used by the Azure machine actuator to create a single Machine. Required parameters such as location that are not specified by this configuration, will be defaulted by the actuator. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "acceleratedNetworking": {
+            "description": "AcceleratedNetworking enables or disables Azure accelerated networking feature. Set to false by default. If true, then this will depend on whether the requested VMSize is supported. If set to true with an unsupported VMSize, Azure will return an error.",
+            "type": "boolean"
+        },
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "applicationSecurityGroups": {
+            "description": "Application Security Groups that need to be attached to the machine's interface. No application security groups will be attached if zero-length.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "availabilitySet": {
+            "description": "AvailabilitySet specifies the availability set to use for this instance. Availability set should be precreated, before using this field.",
+            "type": "string"
+        },
+        "credentialsSecret": {
+            "description": "CredentialsSecret is a reference to the secret with Azure credentials.",
+            "properties": {
+                "name": {
+                    "description": "name is unique within a namespace to reference a secret resource.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "namespace defines the space within which the secret name must be unique.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "dataDisks": {
+            "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine.",
+            "items": {
+                "description": "DataDisk specifies the parameters that are used to add one or more data disks to the machine. A Data Disk is a managed disk that's attached to a virtual machine to store application data. It differs from an OS Disk as it doesn't come with a pre-installed OS, and it cannot contain the boot volume. It is registered as SCSI drive and labeled with the chosen `lun`. e.g. for `lun: 0` the raw disk device will be available at `/dev/disk/azure/scsi1/lun0`. \n As the Data Disk disk device is attached raw to the virtual machine, it will need to be partitioned, formatted with a filesystem and mounted, in order for it to be usable. This can be done by creating a custom userdata Secret with custom Ignition configuration to achieve the desired initialization. At this stage the previously defined `lun` is to be used as the \"device\" key for referencing the raw disk device to be initialized. Once the custom userdata Secret has been created, it can be referenced in the Machine's `.providerSpec.userDataSecret`. For further guidance and examples, please refer to the official OpenShift docs.",
+                "properties": {
+                    "cachingType": {
+                        "description": "CachingType specifies the caching requirements. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is CachingTypeNone.",
+                        "enum": [
+                            "None",
+                            "ReadOnly",
+                            "ReadWrite"
+                        ],
+                        "type": "string"
+                    },
+                    "deletionPolicy": {
+                        "description": "DeletionPolicy specifies the data disk deletion policy upon Machine deletion. Possible values are \"Delete\",\"Detach\". When \"Delete\" is used the data disk is deleted when the Machine is deleted. When \"Detach\" is used the data disk is detached from the Machine and retained when the Machine is deleted.",
+                        "enum": [
+                            "Delete",
+                            "Detach"
+                        ],
+                        "type": "string"
+                    },
+                    "diskSizeGB": {
+                        "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                        "format": "int32",
+                        "minimum": 4,
+                        "type": "integer",
+                        "maximum": 2147483647
+                    },
+                    "lun": {
+                        "description": "Lun Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and therefore must be unique for each data disk attached to a VM. This value is also needed for referencing the data disks devices within userdata to perform disk initialization through Ignition (e.g. partition/format/mount). The value must be between 0 and 63.",
+                        "format": "int32",
+                        "maximum": 63,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "managedDisk": {
+                        "description": "ManagedDisk specifies the Managed Disk parameters for the data disk. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is a ManagedDisk with with storageAccountType: \"Premium_LRS\" and diskEncryptionSet.id: \"Default\".",
+                        "properties": {
+                            "diskEncryptionSet": {
+                                "description": "DiskEncryptionSet is the disk encryption set properties. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is a DiskEncryptionSet with id: \"Default\".",
+                                "properties": {
+                                    "id": {
+                                        "description": "ID is the disk encryption set ID Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is: \"Default\".",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "storageAccountType": {
+                                "description": "StorageAccountType is the storage account type to use. Possible values include \"Standard_LRS\", \"Premium_LRS\" and \"UltraSSD_LRS\".",
+                                "enum": [
+                                    "Standard_LRS",
+                                    "Premium_LRS",
+                                    "UltraSSD_LRS"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "nameSuffix": {
+                        "description": "NameSuffix is the suffix to be appended to the machine name to generate the disk name. Each disk name will be in format <machineName>_<nameSuffix>. NameSuffix name must start and finish with an alphanumeric character and can only contain letters, numbers, underscores, periods or hyphens. The overall disk name must not exceed 80 chars in length.",
+                        "maxLength": 78,
+                        "pattern": "^[a-zA-Z0-9](?:[\\w\\.-]*[a-zA-Z0-9])?$",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "deletionPolicy",
+                    "diskSizeGB",
+                    "lun",
+                    "nameSuffix"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "diagnostics": {
+            "description": "Diagnostics configures the diagnostics settings for the virtual machine. This allows you to configure boot diagnostics such as capturing serial output from the virtual machine on boot. This is useful for debugging software based launch issues.",
+            "properties": {
+                "boot": {
+                    "description": "AzureBootDiagnostics configures the boot diagnostics settings for the virtual machine. This allows you to configure capturing serial output from the virtual machine on boot. This is useful for debugging software based launch issues.",
+                    "properties": {
+                        "customerManaged": {
+                            "description": "CustomerManaged provides reference to the customer manager storage account.",
+                            "properties": {
+                                "storageAccountURI": {
+                                    "description": "StorageAccountURI is the URI of the customer managed storage account. The URI typically will be `https://<mystorageaccountname>.blob.core.windows.net/` but may differ if you are using Azure DNS zone endpoints. You can find the correct endpoint by looking for the Blob Primary Endpoint in the endpoints tab in the Azure console.",
+                                    "maxLength": 1024,
+                                    "pattern": "^https://",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "storageAccountURI"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "storageAccountType": {
+                            "description": "StorageAccountType determines if the storage account for storing the diagnostics data should be provisioned by Azure (AzureManaged) or by the customer (CustomerManaged).",
+                            "enum": [
+                                "AzureManaged",
+                                "CustomerManaged"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "storageAccountType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "image": {
+            "description": "Image is the OS image to use to create the instance.",
+            "properties": {
+                "offer": {
+                    "description": "Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer",
+                    "type": "string"
+                },
+                "publisher": {
+                    "description": "Publisher is the name of the organization that created the image",
+                    "type": "string"
+                },
+                "resourceID": {
+                    "description": "ResourceID specifies an image to use by ID",
+                    "type": "string"
+                },
+                "sku": {
+                    "description": "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type identifies the source of the image and related information, such as purchase plans. Valid values are \"ID\", \"MarketplaceWithPlan\", \"MarketplaceNoPlan\", and omitted, which means no opinion and the platform chooses a good default which may change over time. Currently that default is \"MarketplaceNoPlan\" if publisher data is supplied, or \"ID\" if not. For more information about purchase plans, see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#check-the-purchase-plan-information",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "internalLoadBalancer": {
+            "description": "InternalLoadBalancerName to use for this instance",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "location": {
+            "description": "Location is the region to use to create the instance",
+            "type": "string"
+        },
+        "managedIdentity": {
+            "description": "ManagedIdentity to set managed identity name",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "natRule": {
+            "description": "NatRule to set inbound NAT rule of the load balancer",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "networkResourceGroup": {
+            "description": "NetworkResourceGroup is the resource group for the virtual machine's network",
+            "type": "string"
+        },
+        "osDisk": {
+            "description": "OSDisk represents the parameters for creating the OS disk.",
+            "properties": {
+                "cachingType": {
+                    "description": "CachingType specifies the caching requirements. Possible values include: 'None', 'ReadOnly', 'ReadWrite'. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is `None`.",
+                    "enum": [
+                        "None",
+                        "ReadOnly",
+                        "ReadWrite"
+                    ],
+                    "type": "string"
+                },
+                "diskSettings": {
+                    "description": "DiskSettings describe ephemeral disk settings for the os disk.",
+                    "properties": {
+                        "ephemeralStorageLocation": {
+                            "description": "EphemeralStorageLocation enables ephemeral OS when set to 'Local'. Possible values include: 'Local'. See https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks for full details. Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is that disks are saved to remote Azure storage.",
+                            "enum": [
+                                "Local"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "diskSizeGB": {
+                    "description": "DiskSizeGB is the size in GB to assign to the data disk.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "managedDisk": {
+                    "description": "ManagedDisk specifies the Managed Disk parameters for the OS disk.",
+                    "properties": {
+                        "diskEncryptionSet": {
+                            "description": "DiskEncryptionSet is the disk encryption set properties",
+                            "properties": {
+                                "id": {
+                                    "description": "ID is the disk encryption set ID Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is: \"Default\".",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "securityProfile": {
+                            "description": "securityProfile specifies the security profile for the managed disk.",
+                            "properties": {
+                                "diskEncryptionSet": {
+                                    "description": "diskEncryptionSet specifies the customer managed disk encryption set resource id for the managed disk that is used for Customer Managed Key encrypted ConfidentialVM OS Disk and VMGuest blob.",
+                                    "properties": {
+                                        "id": {
+                                            "description": "ID is the disk encryption set ID Empty value means no opinion and the platform chooses a default, which is subject to change over time. Currently the default is: \"Default\".",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "securityEncryptionType": {
+                                    "description": "securityEncryptionType specifies the encryption type of the managed disk. It is set to DiskWithVMGuestState to encrypt the managed disk along with the VMGuestState blob, and to VMGuestStateOnly to encrypt the VMGuestState blob only. When set to VMGuestStateOnly, the vTPM should be enabled. When set to DiskWithVMGuestState, both SecureBoot and vTPM should be enabled. If the above conditions are not fulfilled, the VM will not be created and the respective error will be returned. It can be set only for Confidential VMs. Confidential VMs are defined by their SecurityProfile.SecurityType being set to ConfidentialVM, the SecurityEncryptionType of their OS disk being set to one of the allowed values and by enabling the respective SecurityProfile.UEFISettings of the VM (i.e. vTPM and SecureBoot), depending on the selected SecurityEncryptionType. For further details on Azure Confidential VMs, please refer to the respective documentation: https://learn.microsoft.com/azure/confidential-computing/confidential-vm-overview",
+                                    "enum": [
+                                        "VMGuestStateOnly",
+                                        "DiskWithVMGuestState"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "storageAccountType": {
+                            "description": "StorageAccountType is the storage account type to use. Possible values include \"Standard_LRS\", \"Premium_LRS\".",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "osType": {
+                    "description": "OSType is the operating system type of the OS disk. Possible values include \"Linux\" and \"Windows\".",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "publicIP": {
+            "description": "PublicIP if true a public IP will be used",
+            "type": "boolean"
+        },
+        "publicLoadBalancer": {
+            "description": "PublicLoadBalancer to use for this instance",
+            "type": "string"
+        },
+        "resourceGroup": {
+            "description": "ResourceGroup is the resource group for the virtual machine",
+            "type": "string"
+        },
+        "securityGroup": {
+            "description": "Network Security Group that needs to be attached to the machine's interface. No security group will be attached if empty.",
+            "type": "string"
+        },
+        "securityProfile": {
+            "description": "SecurityProfile specifies the Security profile settings for a virtual machine.",
+            "properties": {
+                "encryptionAtHost": {
+                    "description": "encryptionAtHost indicates whether Host Encryption should be enabled or disabled for a virtual machine or virtual machine scale set. This should be disabled when SecurityEncryptionType is set to DiskWithVMGuestState. Default is disabled.",
+                    "type": "boolean"
+                },
+                "settings": {
+                    "description": "settings specify the security type and the UEFI settings of the virtual machine. This field can be set for Confidential VMs and Trusted Launch for VMs.",
+                    "properties": {
+                        "confidentialVM": {
+                            "description": "confidentialVM specifies the security configuration of the virtual machine. For more information regarding Confidential VMs, please refer to: https://learn.microsoft.com/azure/confidential-computing/confidential-vm-overview",
+                            "properties": {
+                                "uefiSettings": {
+                                    "description": "uefiSettings specifies the security settings like secure boot and vTPM used while creating the virtual machine.",
+                                    "properties": {
+                                        "secureBoot": {
+                                            "description": "secureBoot specifies whether secure boot should be enabled on the virtual machine. Secure Boot verifies the digital signature of all boot components and halts the boot process if signature verification fails. If omitted, the platform chooses a default, which is subject to change over time, currently that default is disabled.",
+                                            "enum": [
+                                                "Enabled",
+                                                "Disabled"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "virtualizedTrustedPlatformModule": {
+                                            "description": "virtualizedTrustedPlatformModule specifies whether vTPM should be enabled on the virtual machine. When enabled the virtualized trusted platform module measurements are used to create a known good boot integrity policy baseline. The integrity policy baseline is used for comparison with measurements from subsequent VM boots to determine if anything has changed. This is required to be enabled if SecurityEncryptionType is defined. If omitted, the platform chooses a default, which is subject to change over time, currently that default is disabled.",
+                                            "enum": [
+                                                "Enabled",
+                                                "Disabled"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "uefiSettings"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "securityType": {
+                            "description": "securityType specifies the SecurityType of the virtual machine. It has to be set to any specified value to enable UEFISettings. The default behavior is: UEFISettings will not be enabled unless this property is set.",
+                            "enum": [
+                                "ConfidentialVM",
+                                "TrustedLaunch"
+                            ],
+                            "type": "string"
+                        },
+                        "trustedLaunch": {
+                            "description": "trustedLaunch specifies the security configuration of the virtual machine. For more information regarding TrustedLaunch for VMs, please refer to: https://learn.microsoft.com/azure/virtual-machines/trusted-launch",
+                            "properties": {
+                                "uefiSettings": {
+                                    "description": "uefiSettings specifies the security settings like secure boot and vTPM used while creating the virtual machine.",
+                                    "properties": {
+                                        "secureBoot": {
+                                            "description": "secureBoot specifies whether secure boot should be enabled on the virtual machine. Secure Boot verifies the digital signature of all boot components and halts the boot process if signature verification fails. If omitted, the platform chooses a default, which is subject to change over time, currently that default is disabled.",
+                                            "enum": [
+                                                "Enabled",
+                                                "Disabled"
+                                            ],
+                                            "type": "string"
+                                        },
+                                        "virtualizedTrustedPlatformModule": {
+                                            "description": "virtualizedTrustedPlatformModule specifies whether vTPM should be enabled on the virtual machine. When enabled the virtualized trusted platform module measurements are used to create a known good boot integrity policy baseline. The integrity policy baseline is used for comparison with measurements from subsequent VM boots to determine if anything has changed. This is required to be enabled if SecurityEncryptionType is defined. If omitted, the platform chooses a default, which is subject to change over time, currently that default is disabled.",
+                                            "enum": [
+                                                "Enabled",
+                                                "Disabled"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "uefiSettings"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "securityType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "spotVMOptions": {
+            "description": "SpotVMOptions allows the ability to specify the Machine should use a Spot VM",
+            "properties": {
+                "maxPrice": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "MaxPrice defines the maximum price the user is willing to pay for Spot VM instances",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "sshPublicKey": {
+            "description": "SSHPublicKey is the public key to use to SSH to the virtual machine.",
+            "type": "string"
+        },
+        "subnet": {
+            "description": "Subnet to use for this instance",
+            "type": "string"
+        },
+        "tags": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Tags is a list of tags to apply to the machine.",
+            "type": "object"
+        },
+        "ultraSSDCapability": {
+            "description": "UltraSSDCapability enables or disables Azure UltraSSD capability for a virtual machine. This can be used to allow/disallow binding of Azure UltraSSD to the Machine both as Data Disks or via Persistent Volumes. This Azure feature is subject to a specific scope and certain limitations. More informations on this can be found in the official Azure documentation for Ultra Disks: (https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd?tabs=azure-portal#ga-scope-and-limitations). \n When omitted, if at least one Data Disk of type UltraSSD is specified, the platform will automatically enable the capability. If a Perisistent Volume backed by an UltraSSD is bound to a Pod on the Machine, when this field is ommitted, the platform will *not* automatically enable the capability (unless already enabled by the presence of an UltraSSD as Data Disk). This may manifest in the Pod being stuck in `ContainerCreating` phase. This defaulting behaviour may be subject to change in future. \n When set to \"Enabled\", if the capability is available for the Machine based on the scope and limitations described above, the capability will be set on the Machine. This will thus allow UltraSSD both as Data Disks and Persistent Volumes. If set to \"Enabled\" when the capability can't be available due to scope and limitations, the Machine will go into \"Failed\" state. \n When set to \"Disabled\", UltraSSDs will not be allowed either as Data Disks nor as Persistent Volumes. In this case if any UltraSSDs are specified as Data Disks on a Machine, the Machine will go into a \"Failed\" state. If instead any UltraSSDs are backing the volumes (via Persistent Volumes) of any Pods scheduled on a Node which is backed by the Machine, the Pod may get stuck in `ContainerCreating` phase.",
+            "enum": [
+                "Enabled",
+                "Disabled"
+            ],
+            "type": "string"
+        },
+        "userDataSecret": {
+            "description": "UserDataSecret contains a local reference to a secret that contains the UserData to apply to the instance",
+            "properties": {
+                "name": {
+                    "description": "name is unique within a namespace to reference a secret resource.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "namespace defines the space within which the secret name must be unique.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "vmSize": {
+            "description": "VMSize is the size of the VM to create.",
+            "type": "string"
+        },
+        "vnet": {
+            "description": "Vnet to set virtual network name",
+            "type": "string"
+        },
+        "zone": {
+            "description": "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/azuremachineproviderstatus_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/azuremachineproviderstatus_machine.openshift.io_v1beta1.json
@@ -1,0 +1,73 @@
+{
+    "description": "AzureMachineProviderStatus is the type that will be embedded in a Machine.Status.ProviderStatus field. It contains Azure-specific status information. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "conditions": {
+            "description": "Conditions is a set of conditions associated with the Machine to indicate errors or other status.",
+            "items": {
+                "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                "properties": {
+                    "lastTransitionTime": {
+                        "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                        "type": "string"
+                    },
+                    "observedGeneration": {
+                        "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "reason": {
+                        "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "status of the condition, one of True, False, Unknown.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "vmId": {
+            "description": "VMID is the ID of the virtual machine created in Azure.",
+            "type": "string"
+        },
+        "vmState": {
+            "description": "VMState is the provisioning state of the Azure virtual machine.",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/backup_config.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/backup_config.openshift.io_v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "description": "Backup provides configuration for performing backups of the openshift cluster. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "etcd": {
+                    "description": "etcd specifies the configuration for periodic backups of the etcd cluster",
+                    "properties": {
+                        "pvcName": {
+                            "description": "PVCName specifies the name of the PersistentVolumeClaim (PVC) which binds a PersistentVolume where the etcd backup files would be saved The PVC itself must always be created in the \"openshift-etcd\" namespace If the PVC is left unspecified \"\" then the platform will choose a reasonable default location to save the backup. In the future this would be backups saved across the control-plane master nodes.",
+                            "type": "string"
+                        },
+                        "retentionPolicy": {
+                            "description": "RetentionPolicy defines the retention policy for retaining and deleting existing backups.",
+                            "properties": {
+                                "retentionNumber": {
+                                    "description": "RetentionNumber configures the retention policy based on the number of backups",
+                                    "properties": {
+                                        "maxNumberOfBackups": {
+                                            "description": "MaxNumberOfBackups defines the maximum number of backups to retain. If the existing number of backups saved is equal to MaxNumberOfBackups then the oldest backup will be removed before a new backup is initiated.",
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "maxNumberOfBackups"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "retentionSize": {
+                                    "description": "RetentionSize configures the retention policy based on the size of backups",
+                                    "properties": {
+                                        "maxSizeOfBackupsGb": {
+                                            "description": "MaxSizeOfBackupsGb defines the total size in GB of backups to retain. If the current total size backups exceeds MaxSizeOfBackupsGb then the oldest backup will be removed before a new backup is initiated.",
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "maxSizeOfBackupsGb"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "retentionType": {
+                                    "allOf": [
+                                        {
+                                            "enum": [
+                                                "RetentionNumber",
+                                                "RetentionSize"
+                                            ]
+                                        },
+                                        {
+                                            "enum": [
+                                                "",
+                                                "RetentionNumber",
+                                                "RetentionSize"
+                                            ]
+                                        }
+                                    ],
+                                    "description": "RetentionType sets the type of retention policy. Currently, the only valid policies are retention by number of backups (RetentionNumber), by the size of backups (RetentionSize). More policies or types may be added in the future. Empty string means no opinion and the platform is left to choose a reasonable default which is subject to change without notice. The current default is RetentionNumber with 15 backups kept.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "retentionType"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "schedule": {
+                            "description": "Schedule defines the recurring backup schedule in Cron format every 2 hours: 0 */2 * * * every day at 3am: 0 3 * * * Empty string means no opinion and the platform is left to choose a reasonable default which is subject to change without notice. The current default is \"no backups\", but will change in the future.",
+                            "pattern": "^(@(annually|yearly|monthly|weekly|daily|hourly))|(\\*|(?:\\*|(?:[0-9]|(?:[1-5][0-9])))\\/(?:[0-9]|(?:[1-5][0-9]))|(?:[0-9]|(?:[1-5][0-9]))(?:(?:\\-[0-9]|\\-(?:[1-5][0-9]))?|(?:\\,(?:[0-9]|(?:[1-5][0-9])))*)) (\\*|(?:\\*|(?:\\*|(?:[0-9]|1[0-9]|2[0-3])))\\/(?:[0-9]|1[0-9]|2[0-3])|(?:[0-9]|1[0-9]|2[0-3])(?:(?:\\-(?:[0-9]|1[0-9]|2[0-3]))?|(?:\\,(?:[0-9]|1[0-9]|2[0-3]))*)) (\\*|(?:[1-9]|(?:[12][0-9])|3[01])(?:(?:\\-(?:[1-9]|(?:[12][0-9])|3[01]))?|(?:\\,(?:[1-9]|(?:[12][0-9])|3[01]))*)) (\\*|(?:[1-9]|1[012]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(?:(?:\\-(?:[1-9]|1[012]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))?|(?:\\,(?:[1-9]|1[012]|JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC))*)) (\\*|(?:[0-6]|SUN|MON|TUE|WED|THU|FRI|SAT)(?:(?:\\-(?:[0-6]|SUN|MON|TUE|WED|THU|FRI|SAT))?|(?:\\,(?:[0-6]|SUN|MON|TUE|WED|THU|FRI|SAT))*))$",
+                            "type": "string"
+                        },
+                        "timeZone": {
+                            "description": "The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones. If not specified, this will default to the time zone of the kube-controller-manager process. See https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones",
+                            "pattern": "^([A-Za-z_]+([+-]*0)*|[A-Za-z_]+(\\/[A-Za-z_]+){1,2})(\\/GMT[+-]\\d{1,2})?$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "etcd"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/binarybuildrequestoptions_build.openshift.io_v1.json
+++ b/openshift/v4.14-strict/binarybuildrequestoptions_build.openshift.io_v1.json
@@ -1,0 +1,47 @@
+{
+    "description": "BinaryBuildRequestOptions are the options required to fully speficy a binary build request \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "asFile": {
+            "description": "asFile determines if the binary should be created as a file within the source rather than extracted as an archive",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "revision.authorEmail": {
+            "description": "revision.authorEmail of the source control user",
+            "type": "string"
+        },
+        "revision.authorName": {
+            "description": "revision.authorName of the source control user",
+            "type": "string"
+        },
+        "revision.commit": {
+            "description": "revision.commit is the value identifying a specific commit",
+            "type": "string"
+        },
+        "revision.committerEmail": {
+            "description": "revision.committerEmail of the source control user",
+            "type": "string"
+        },
+        "revision.committerName": {
+            "description": "revision.committerName of the source control user",
+            "type": "string"
+        },
+        "revision.message": {
+            "description": "revision.message is the description of a specific commit",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/brokertemplateinstance_template.openshift.io_v1.json
+++ b/openshift/v4.14-strict/brokertemplateinstance_template.openshift.io_v1.json
@@ -1,0 +1,110 @@
+{
+    "description": "BrokerTemplateInstance holds the service broker-related state associated with a TemplateInstance.  BrokerTemplateInstance is part of an experimental API. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec describes the state of this BrokerTemplateInstance.",
+            "properties": {
+                "bindingIDs": {
+                    "description": "bindingids is a list of 'binding_id's provided during successive bind calls to the template service broker.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "secret": {
+                    "description": "secret is a reference to a Secret object residing in a namespace, containing the necessary template parameters.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "templateInstance": {
+                    "description": "templateinstance is a reference to a TemplateInstance object residing in a namespace.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "secret",
+                "templateInstance"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/build_build.openshift.io_v1.json
+++ b/openshift/v4.14-strict/build_build.openshift.io_v1.json
@@ -1,0 +1,2305 @@
+{
+    "description": "Build encapsulates the inputs needed to produce a new deployable image, as well as the status of the execution and a reference to the Pod which executed the build. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is all the inputs used to execute the build.",
+            "properties": {
+                "completionDeadlineSeconds": {
+                    "description": "completionDeadlineSeconds is an optional duration in seconds, counted from the time when a build pod gets scheduled in the system, that the build may be active on a node before the system actively tries to terminate the build; value must be positive integer",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "mountTrustedCA": {
+                    "description": "mountTrustedCA bind mounts the cluster's trusted certificate authorities, as defined in the cluster's proxy configuration, into the build. This lets processes within a build trust components signed by custom PKI certificate authorities, such as private artifact repositories and HTTPS proxies. \n When this field is set to true, the contents of `/etc/pki/ca-trust` within the build are managed by the build container, and any changes to this directory or its subdirectories (for example - within a Dockerfile `RUN` instruction) are not persisted in the build's output image.",
+                    "type": "boolean"
+                },
+                "nodeSelector": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "nodeSelector is a selector which must be true for the build pod to fit on a node If nil, it can be overridden by default build nodeselector values for the cluster. If set to an empty map or a map with any values, default build nodeselector values are ignored.",
+                    "type": "object"
+                },
+                "output": {
+                    "description": "output describes the container image the Strategy should produce.",
+                    "properties": {
+                        "imageLabels": {
+                            "description": "imageLabels define a list of labels that are applied to the resulting image. If there are multiple labels with the same name then the last one in the list is used.",
+                            "items": {
+                                "description": "ImageLabel represents a label applied to the resulting image.",
+                                "properties": {
+                                    "name": {
+                                        "description": "name defines the name of the label. It must have non-zero length.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "value defines the literal value of the label.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "pushSecret": {
+                            "description": "PushSecret is the name of a Secret that would be used for setting up the authentication for executing the Docker push to authentication enabled Docker Registry (or Docker Hub).",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "to": {
+                            "description": "to defines an optional location to push the output of this build to. Kind must be one of 'ImageStreamTag' or 'DockerImage'. This value will be used to look up a container image repository to push to. In the case of an ImageStreamTag, the ImageStreamTag will be looked for in the namespace of the build unless Namespace is specified.",
+                            "properties": {
+                                "apiVersion": {
+                                    "description": "API version of the referent.",
+                                    "type": "string"
+                                },
+                                "fieldPath": {
+                                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                    "type": "string"
+                                },
+                                "kind": {
+                                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                    "type": "string"
+                                },
+                                "resourceVersion": {
+                                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                    "type": "string"
+                                },
+                                "uid": {
+                                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "postCommit": {
+                    "description": "postCommit is a build hook executed after the build output image is committed, before it is pushed to a registry.",
+                    "properties": {
+                        "args": {
+                            "description": "args is a list of arguments that are provided to either Command, Script or the container image's default entrypoint. The arguments are placed immediately after the command to be run.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "command": {
+                            "description": "command is the command to run. It may not be specified with Script. This might be needed if the image doesn't have `/bin/sh`, or if you do not want to use a shell. In all other cases, using Script might be more convenient.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "script": {
+                            "description": "script is a shell script to be run with `/bin/sh -ic`. It may not be specified with Command. Use Script when a shell script is appropriate to execute the post build hook, for example for running unit tests with `rake test`. If you need control over the image entrypoint, or if the image does not have `/bin/sh`, use Command and/or Args. The `-i` flag is needed to support CentOS and RHEL images that use Software Collections (SCL), in order to have the appropriate collections enabled in the shell. E.g., in the Ruby image, this is necessary to make `ruby`, `bundle` and other binaries available in the PATH.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "resources": {
+                    "description": "resources computes resource requirements to execute the build.",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "limits": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        },
+                        "requests": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "revision": {
+                    "description": "revision is the information from the source for a specific repo snapshot. This is optional.",
+                    "properties": {
+                        "git": {
+                            "description": "Git contains information about git-based build source",
+                            "properties": {
+                                "author": {
+                                    "description": "author is the author of a specific commit",
+                                    "properties": {
+                                        "email": {
+                                            "description": "email of the source control user",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of the source control user",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "commit": {
+                                    "description": "commit is the commit hash identifying a specific commit",
+                                    "type": "string"
+                                },
+                                "committer": {
+                                    "description": "committer is the committer of a specific commit",
+                                    "properties": {
+                                        "email": {
+                                            "description": "email of the source control user",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of the source control user",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "message": {
+                                    "description": "message is the description of a specific commit",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "serviceAccount": {
+                    "description": "serviceAccount is the name of the ServiceAccount to use to run the pod created by this build. The pod will be allowed to use secrets referenced by the ServiceAccount",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "source describes the SCM in use.",
+                    "properties": {
+                        "binary": {
+                            "description": "binary builds accept a binary as their input. The binary is generally assumed to be a tar, gzipped tar, or zip file depending on the strategy. For container image builds, this is the build context and an optional Dockerfile may be specified to override any Dockerfile in the build context. For Source builds, this is assumed to be an archive as described above. For Source and container image builds, if binary.asFile is set the build will receive a directory with a single file. contextDir may be used when an archive is provided. Custom builds will receive this binary as input on STDIN.",
+                            "properties": {
+                                "asFile": {
+                                    "description": "asFile indicates that the provided binary input should be considered a single file within the build input. For example, specifying \"webapp.war\" would place the provided binary as `/webapp.war` for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "configMaps": {
+                            "description": "configMaps represents a list of configMaps and their destinations that will be used for the build.",
+                            "items": {
+                                "description": "ConfigMapBuildSource describes a configmap and its destination directory that will be used only at the build time. The content of the configmap referenced here will be copied into the destination directory instead of mounting.",
+                                "properties": {
+                                    "configMap": {
+                                        "description": "configMap is a reference to an existing configmap that you want to use in your build.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "destinationDir": {
+                                        "description": "destinationDir is the directory where the files from the configmap should be available for the build time. For the Source build strategy, these will be injected into a container where the assemble script runs. For the container image build strategy, these will be copied into the build directory, where the Dockerfile is located, so users can ADD or COPY them during container image build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "configMap"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "contextDir": {
+                            "description": "contextDir specifies the sub-directory where the source code for the application exists. This allows to have buildable sources in directory other than root of repository.",
+                            "type": "string"
+                        },
+                        "dockerfile": {
+                            "description": "dockerfile is the raw contents of a Dockerfile which should be built. When this option is specified, the FROM may be modified based on your strategy base image and additional ENV stanzas from your strategy environment will be added after the FROM, but before the rest of your Dockerfile stanzas. The Dockerfile source type may be used with other options like git - in those cases the Git repo will have any innate Dockerfile replaced in the context dir.",
+                            "type": "string"
+                        },
+                        "git": {
+                            "description": "git contains optional information about git build source",
+                            "properties": {
+                                "httpProxy": {
+                                    "description": "httpProxy is a proxy used to reach the git repository over http",
+                                    "type": "string"
+                                },
+                                "httpsProxy": {
+                                    "description": "httpsProxy is a proxy used to reach the git repository over https",
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "description": "noProxy is the list of domains for which the proxy should not be used",
+                                    "type": "string"
+                                },
+                                "ref": {
+                                    "description": "ref is the branch/tag/ref to build.",
+                                    "type": "string"
+                                },
+                                "uri": {
+                                    "description": "uri points to the source that will be built. The structure of the source will depend on the type of build to run",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "uri"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "images": {
+                            "description": "images describes a set of images to be used to provide source for the build",
+                            "items": {
+                                "description": "ImageSource is used to describe build source that will be extracted from an image or used during a multi stage build. A reference of type ImageStreamTag, ImageStreamImage or DockerImage may be used. A pull secret can be specified to pull the image from an external registry or override the default service account secret if pulling from the internal registry. Image sources can either be used to extract content from an image and place it into the build context along with the repository source, or used directly during a multi-stage container image build to allow content to be copied without overwriting the contents of the repository source (see the 'paths' and 'as' fields).",
+                                "properties": {
+                                    "as": {
+                                        "description": "A list of image names that this source will be used in place of during a multi-stage container image build. For instance, a Dockerfile that uses \"COPY --from=nginx:latest\" will first check for an image source that has \"nginx:latest\" in this field before attempting to pull directly. If the Dockerfile does not reference an image source it is ignored. This field and paths may both be set, in which case the contents will be used twice.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "from": {
+                                        "description": "from is a reference to an ImageStreamTag, ImageStreamImage, or DockerImage to copy source from.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                "type": "string"
+                                            },
+                                            "resourceVersion": {
+                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "paths": {
+                                        "description": "paths is a list of source and destination paths to copy from the image. This content will be copied into the build context prior to starting the build. If no paths are set, the build context will not be altered.",
+                                        "items": {
+                                            "description": "ImageSourcePath describes a path to be copied from a source image and its destination within the build directory.",
+                                            "properties": {
+                                                "destinationDir": {
+                                                    "description": "destinationDir is the relative directory within the build directory where files copied from the image are placed.",
+                                                    "type": "string"
+                                                },
+                                                "sourcePath": {
+                                                    "description": "sourcePath is the absolute path of the file or directory inside the image to copy to the build directory.  If the source path ends in /. then the content of the directory will be copied, but the directory itself will not be created at the destination.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "destinationDir",
+                                                "sourcePath"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "pullSecret": {
+                                        "description": "pullSecret is a reference to a secret to be used to pull the image from a registry If the image is pulled from the OpenShift registry, this field does not need to be set.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "from"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "secrets": {
+                            "description": "secrets represents a list of secrets and their destinations that will be used only for the build.",
+                            "items": {
+                                "description": "SecretBuildSource describes a secret and its destination directory that will be used only at the build time. The content of the secret referenced here will be copied into the destination directory instead of mounting.",
+                                "properties": {
+                                    "destinationDir": {
+                                        "description": "destinationDir is the directory where the files from the secret should be available for the build time. For the Source build strategy, these will be injected into a container where the assemble script runs. Later, when the script finishes, all files injected will be truncated to zero length. For the container image build strategy, these will be copied into the build directory, where the Dockerfile is located, so users can ADD or COPY them during container image build.",
+                                        "type": "string"
+                                    },
+                                    "secret": {
+                                        "description": "secret is a reference to an existing secret that you want to use in your build.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "secret"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "sourceSecret": {
+                            "description": "sourceSecret is the name of a Secret that would be used for setting up the authentication for cloning private repository. The secret contains valid credentials for remote repository, where the data's key represent the authentication method to be used and value is the base64 encoded credentials. Supported auth methods are: ssh-privatekey.",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type of build input to accept",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "strategy": {
+                    "description": "strategy defines how to perform a build.",
+                    "properties": {
+                        "customStrategy": {
+                            "description": "customStrategy holds the parameters to the Custom build strategy",
+                            "properties": {
+                                "buildAPIVersion": {
+                                    "description": "buildAPIVersion is the requested API version for the Build object serialized and passed to the custom builder",
+                                    "type": "string"
+                                },
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "exposeDockerSocket": {
+                                    "description": "exposeDockerSocket will allow running Docker commands (and build container images) from inside the container. TODO: Allow admins to enforce 'false' for this option",
+                                    "type": "boolean"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the controller should configure the build pod to always pull the images for the builder or only pull if it is not present locally",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the container image should be pulled",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "secrets": {
+                                    "description": "secrets is a list of additional secrets that will be included in the build pod",
+                                    "items": {
+                                        "description": "SecretSpec specifies a secret to be included in a build pod and its corresponding mount point",
+                                        "properties": {
+                                            "mountPath": {
+                                                "description": "mountPath is the path at which to mount the secret",
+                                                "type": "string"
+                                            },
+                                            "secretSource": {
+                                                "description": "secretSource is a reference to the secret",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mountPath",
+                                            "secretSource"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "from"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "dockerStrategy": {
+                            "description": "dockerStrategy holds the parameters to the container image build strategy.",
+                            "properties": {
+                                "buildArgs": {
+                                    "description": "buildArgs contains build arguments that will be resolved in the Dockerfile.  See https://docs.docker.com/engine/reference/builder/#/arg for more details. NOTE: Only the 'name' and 'value' fields are supported. Any settings on the 'valueFrom' field are ignored.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "dockerfilePath": {
+                                    "description": "dockerfilePath is the path of the Dockerfile that will be used to build the container image, relative to the root of the context (contextDir). Defaults to `Dockerfile` if unset.",
+                                    "type": "string"
+                                },
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the builder should pull the images from registry prior to building.",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is a reference to an DockerImage, ImageStreamTag, or ImageStreamImage which overrides the FROM image in the Dockerfile for the build. If the Dockerfile uses multi-stage builds, this will replace the image in the last FROM directive of the file.",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "imageOptimizationPolicy": {
+                                    "description": "imageOptimizationPolicy describes what optimizations the system can use when building images to reduce the final size or time spent building the image. The default policy is 'None' which means the final build image will be equivalent to an image created by the container image build API. The experimental policy 'SkipLayers' will avoid commiting new layers in between each image step, and will fail if the Dockerfile cannot provide compatibility with the 'None' policy. An additional experimental policy 'SkipLayersAndWarn' is the same as 'SkipLayers' but simply warns if compatibility cannot be preserved.",
+                                    "type": "string"
+                                },
+                                "noCache": {
+                                    "description": "noCache if set to true indicates that the container image build must be executed with the --no-cache=true flag",
+                                    "type": "boolean"
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "volumes": {
+                                    "description": "volumes is a list of input volumes that can be mounted into the builds runtime environment. Only a subset of Kubernetes Volume sources are supported by builds. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                    "items": {
+                                        "description": "BuildVolume describes a volume that is made available to build pods, such that it can be mounted into buildah's runtime environment. Only a subset of Kubernetes Volume sources are supported.",
+                                        "properties": {
+                                            "mounts": {
+                                                "description": "mounts represents the location of the volume in the image build container",
+                                                "items": {
+                                                    "description": "BuildVolumeMount describes the mounting of a Volume within buildah's runtime environment.",
+                                                    "properties": {
+                                                        "destinationPath": {
+                                                            "description": "destinationPath is the path within the buildah runtime environment at which the volume should be mounted. The transient mount within the build image and the backing volume will both be mounted read only. Must be an absolute path, must not contain '..' or ':', and must not collide with a destination path generated by the builder process Paths that collide with those added by the build controller will result in a failed build with an error message detailing which path caused the error.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "destinationPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                    "destinationPath"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
+                                            },
+                                            "name": {
+                                                "description": "name is a unique identifier for this BuildVolume. It must conform to the Kubernetes DNS label standard and be unique within the pod. Names that collide with those added by the build controller will result in a failed build with an error message detailing which name caused the error. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "description": "source represents the location and type of the mounted volume.",
+                                                "properties": {
+                                                    "configMap": {
+                                                        "description": "configMap represents a ConfigMap that should populate this volume",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "csi": {
+                                                        "description": "csi represents ephemeral storage provided by external CSI drivers which support this capability",
+                                                        "properties": {
+                                                            "driver": {
+                                                                "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                                                "type": "string"
+                                                            },
+                                                            "fsType": {
+                                                                "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                                                "type": "string"
+                                                            },
+                                                            "nodePublishSecretRef": {
+                                                                "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "readOnly": {
+                                                                "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                                                "type": "boolean"
+                                                            },
+                                                            "volumeAttributes": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "driver"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secret": {
+                                                        "description": "secret represents a Secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional field specify whether the Secret or its keys must be defined",
+                                                                "type": "boolean"
+                                                            },
+                                                            "secretName": {
+                                                                "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type is the BuildVolumeSourceType for the volume source. Type must match the populated volume source. Valid types are: Secret, ConfigMap",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mounts",
+                                            "name",
+                                            "source"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "jenkinsPipelineStrategy": {
+                            "description": "JenkinsPipelineStrategy holds the parameters to the Jenkins Pipeline build strategy. Deprecated: use OpenShift Pipelines",
+                            "properties": {
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a build pipeline.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "jenkinsfile": {
+                                    "description": "Jenkinsfile defines the optional raw contents of a Jenkinsfile which defines a Jenkins pipeline build.",
+                                    "type": "string"
+                                },
+                                "jenkinsfilePath": {
+                                    "description": "JenkinsfilePath is the optional path of the Jenkinsfile that will be used to configure the pipeline relative to the root of the context (contextDir). If both JenkinsfilePath & Jenkinsfile are both not specified, this defaults to Jenkinsfile in the root of the specified contextDir.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "sourceStrategy": {
+                            "description": "sourceStrategy holds the parameters to the Source build strategy.",
+                            "properties": {
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the builder should pull the images from registry prior to building.",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the container image should be pulled",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "incremental": {
+                                    "description": "incremental flag forces the Source build to do incremental builds if true.",
+                                    "type": "boolean"
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "scripts": {
+                                    "description": "scripts is the location of Source scripts",
+                                    "type": "string"
+                                },
+                                "volumes": {
+                                    "description": "volumes is a list of input volumes that can be mounted into the builds runtime environment. Only a subset of Kubernetes Volume sources are supported by builds. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                    "items": {
+                                        "description": "BuildVolume describes a volume that is made available to build pods, such that it can be mounted into buildah's runtime environment. Only a subset of Kubernetes Volume sources are supported.",
+                                        "properties": {
+                                            "mounts": {
+                                                "description": "mounts represents the location of the volume in the image build container",
+                                                "items": {
+                                                    "description": "BuildVolumeMount describes the mounting of a Volume within buildah's runtime environment.",
+                                                    "properties": {
+                                                        "destinationPath": {
+                                                            "description": "destinationPath is the path within the buildah runtime environment at which the volume should be mounted. The transient mount within the build image and the backing volume will both be mounted read only. Must be an absolute path, must not contain '..' or ':', and must not collide with a destination path generated by the builder process Paths that collide with those added by the build controller will result in a failed build with an error message detailing which path caused the error.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "destinationPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                    "destinationPath"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
+                                            },
+                                            "name": {
+                                                "description": "name is a unique identifier for this BuildVolume. It must conform to the Kubernetes DNS label standard and be unique within the pod. Names that collide with those added by the build controller will result in a failed build with an error message detailing which name caused the error. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "description": "source represents the location and type of the mounted volume.",
+                                                "properties": {
+                                                    "configMap": {
+                                                        "description": "configMap represents a ConfigMap that should populate this volume",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "csi": {
+                                                        "description": "csi represents ephemeral storage provided by external CSI drivers which support this capability",
+                                                        "properties": {
+                                                            "driver": {
+                                                                "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                                                "type": "string"
+                                                            },
+                                                            "fsType": {
+                                                                "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                                                "type": "string"
+                                                            },
+                                                            "nodePublishSecretRef": {
+                                                                "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "readOnly": {
+                                                                "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                                                "type": "boolean"
+                                                            },
+                                                            "volumeAttributes": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "driver"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secret": {
+                                                        "description": "secret represents a Secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional field specify whether the Secret or its keys must be defined",
+                                                                "type": "boolean"
+                                                            },
+                                                            "secretName": {
+                                                                "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type is the BuildVolumeSourceType for the volume source. Type must match the populated volume source. Valid types are: Secret, ConfigMap",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mounts",
+                                            "name",
+                                            "source"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "required": [
+                                "from"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the kind of build strategy.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "triggeredBy": {
+                    "description": "triggeredBy describes which triggers started the most recent update to the build configuration and contains information about those triggers.",
+                    "items": {
+                        "description": "BuildTriggerCause holds information about a triggered build. It is used for displaying build trigger data for each build and build configuration in oc describe. It is also used to describe which triggers led to the most recent update in the build configuration.",
+                        "properties": {
+                            "bitbucketWebHook": {
+                                "description": "BitbucketWebHook represents data for a Bitbucket webhook that fired a specific build.",
+                                "properties": {
+                                    "revision": {
+                                        "description": "Revision is the git source revision information of the trigger.",
+                                        "properties": {
+                                            "git": {
+                                                "description": "Git contains information about git-based build source",
+                                                "properties": {
+                                                    "author": {
+                                                        "description": "author is the author of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "commit": {
+                                                        "description": "commit is the commit hash identifying a specific commit",
+                                                        "type": "string"
+                                                    },
+                                                    "committer": {
+                                                        "description": "committer is the committer of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "message": {
+                                                        "description": "message is the description of a specific commit",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "secret": {
+                                        "description": "Secret is the obfuscated webhook secret that triggered a build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "genericWebHook": {
+                                "description": "genericWebHook holds data about a builds generic webhook trigger.",
+                                "properties": {
+                                    "revision": {
+                                        "description": "revision is an optional field that stores the git source revision information of the generic webhook trigger when it is available.",
+                                        "properties": {
+                                            "git": {
+                                                "description": "Git contains information about git-based build source",
+                                                "properties": {
+                                                    "author": {
+                                                        "description": "author is the author of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "commit": {
+                                                        "description": "commit is the commit hash identifying a specific commit",
+                                                        "type": "string"
+                                                    },
+                                                    "committer": {
+                                                        "description": "committer is the committer of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "message": {
+                                                        "description": "message is the description of a specific commit",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "secret": {
+                                        "description": "secret is the obfuscated webhook secret that triggered a build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "githubWebHook": {
+                                "description": "gitHubWebHook represents data for a GitHub webhook that fired a specific build.",
+                                "properties": {
+                                    "revision": {
+                                        "description": "revision is the git revision information of the trigger.",
+                                        "properties": {
+                                            "git": {
+                                                "description": "Git contains information about git-based build source",
+                                                "properties": {
+                                                    "author": {
+                                                        "description": "author is the author of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "commit": {
+                                                        "description": "commit is the commit hash identifying a specific commit",
+                                                        "type": "string"
+                                                    },
+                                                    "committer": {
+                                                        "description": "committer is the committer of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "message": {
+                                                        "description": "message is the description of a specific commit",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "secret": {
+                                        "description": "secret is the obfuscated webhook secret that triggered a build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "gitlabWebHook": {
+                                "description": "GitLabWebHook represents data for a GitLab webhook that fired a specific build.",
+                                "properties": {
+                                    "revision": {
+                                        "description": "Revision is the git source revision information of the trigger.",
+                                        "properties": {
+                                            "git": {
+                                                "description": "Git contains information about git-based build source",
+                                                "properties": {
+                                                    "author": {
+                                                        "description": "author is the author of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "commit": {
+                                                        "description": "commit is the commit hash identifying a specific commit",
+                                                        "type": "string"
+                                                    },
+                                                    "committer": {
+                                                        "description": "committer is the committer of a specific commit",
+                                                        "properties": {
+                                                            "email": {
+                                                                "description": "email of the source control user",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "name of the source control user",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "message": {
+                                                        "description": "message is the description of a specific commit",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "type"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "secret": {
+                                        "description": "Secret is the obfuscated webhook secret that triggered a build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "imageChangeBuild": {
+                                "description": "imageChangeBuild stores information about an imagechange event that triggered a new build.",
+                                "properties": {
+                                    "fromRef": {
+                                        "description": "fromRef contains detailed information about an image that triggered a build.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                "type": "string"
+                                            },
+                                            "resourceVersion": {
+                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "imageID": {
+                                        "description": "imageID is the ID of the image that triggered a new build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "message": {
+                                "description": "message is used to store a human readable message for why the build was triggered. E.g.: \"Manually triggered by user\", \"Configuration change\",etc.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "strategy"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the current status of the build.",
+            "properties": {
+                "cancelled": {
+                    "description": "cancelled describes if a cancel event was triggered for the build.",
+                    "type": "boolean"
+                },
+                "completionTimestamp": {
+                    "description": "completionTimestamp is a timestamp representing the server time when this Build was finished, whether that build failed or succeeded.  It reflects the time at which the Pod running the Build terminated. It is represented in RFC3339 form and is in UTC.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "Conditions represents the latest available observations of a build's current state.",
+                    "items": {
+                        "description": "BuildCondition describes the state of a build at a certain point.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "The last time the condition transitioned from one status to another.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastUpdateTime": {
+                                "description": "The last time this condition was updated.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "A human readable message indicating details about the transition.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "The reason for the condition's last transition.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of build condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "config": {
+                    "description": "config is an ObjectReference to the BuildConfig this Build is based on.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "duration": {
+                    "description": "duration contains time.Duration object describing build time.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "logSnippet": {
+                    "description": "logSnippet is the last few lines of the build log.  This value is only set for builds that failed.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "message is a human-readable message indicating details about why the build has this status.",
+                    "type": "string"
+                },
+                "output": {
+                    "description": "output describes the container image the build has produced.",
+                    "properties": {
+                        "to": {
+                            "description": "to describes the status of the built image being pushed to a registry.",
+                            "properties": {
+                                "imageDigest": {
+                                    "description": "imageDigest is the digest of the built container image. The digest uniquely identifies the image in the registry to which it was pushed. \n Please note that this field may not always be set even if the push completes successfully - e.g. when the registry returns no digest or returns it in a format that the builder doesn't understand.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "outputDockerImageReference": {
+                    "description": "outputDockerImageReference contains a reference to the container image that will be built by this build. Its value is computed from Build.Spec.Output.To, and should include the registry address, so that it can be used to push and pull the image.",
+                    "type": "string"
+                },
+                "phase": {
+                    "description": "phase is the point in the build lifecycle. Possible values are \"New\", \"Pending\", \"Running\", \"Complete\", \"Failed\", \"Error\", and \"Cancelled\".",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
+                    "type": "string"
+                },
+                "stages": {
+                    "description": "stages contains details about each stage that occurs during the build including start time, duration (in milliseconds), and the steps that occured within each stage.",
+                    "items": {
+                        "description": "StageInfo contains details about a build stage.",
+                        "properties": {
+                            "durationMilliseconds": {
+                                "description": "durationMilliseconds identifies how long the stage took to complete in milliseconds. Note: the duration of a stage can exceed the sum of the duration of the steps within the stage as not all actions are accounted for in explicit build steps.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is a unique identifier for each build stage that occurs.",
+                                "type": "string"
+                            },
+                            "startTime": {
+                                "description": "startTime is a timestamp representing the server time when this Stage started. It is represented in RFC3339 form and is in UTC.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "steps": {
+                                "description": "steps contains details about each step that occurs during a build stage including start time and duration in milliseconds.",
+                                "items": {
+                                    "description": "StepInfo contains details about a build step.",
+                                    "properties": {
+                                        "durationMilliseconds": {
+                                            "description": "durationMilliseconds identifies how long the step took to complete in milliseconds.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "name": {
+                                            "description": "name is a unique identifier for each build step.",
+                                            "type": "string"
+                                        },
+                                        "startTime": {
+                                            "description": "startTime is a timestamp representing the server time when this Step started. it is represented in RFC3339 form and is in UTC.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "startTimestamp": {
+                    "description": "startTimestamp is a timestamp representing the server time when this Build started running in a Pod. It is represented in RFC3339 form and is in UTC.",
+                    "format": "date-time",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "phase"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/build_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/build_config.openshift.io_v1.json
@@ -1,0 +1,397 @@
+{
+    "description": "Build configures the behavior of OpenShift builds for the entire cluster. This includes default settings that can be overridden in BuildConfig objects, and overrides which are applied to all builds. \n The canonical name is \"cluster\" \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec holds user-settable values for the build controller configuration",
+            "properties": {
+                "additionalTrustedCA": {
+                    "description": "AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted for image pushes and pulls during builds. The namespace for this config map is openshift-config. \n DEPRECATED: Additional CAs for image pull and push should be set on image.config.openshift.io/cluster instead.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "buildDefaults": {
+                    "description": "BuildDefaults controls the default information for Builds",
+                    "properties": {
+                        "defaultProxy": {
+                            "description": "DefaultProxy contains the default proxy settings for all build operations, including image pull/push and source download. \n Values can be overrode by setting the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables in the build config's strategy.",
+                            "properties": {
+                                "httpProxy": {
+                                    "description": "httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "httpsProxy": {
+                                    "description": "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "description": "noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "readinessEndpoints": {
+                                    "description": "readinessEndpoints is a list of endpoints used to verify readiness of the proxy.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "trustedCA": {
+                                    "description": "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----",
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the metadata.name of the referenced config map",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "env": {
+                            "description": "Env is a set of default environment variables that will be applied to the build if the specified variables do not exist on the build",
+                            "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                        "type": "string"
+                                    },
+                                    "valueFrom": {
+                                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                        "properties": {
+                                            "configMapKeyRef": {
+                                                "description": "Selects a key of a ConfigMap.",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key to select.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                        "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                        "description": "Path of the field to select in the specified API version.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "fieldPath"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "Container name: required for volumes, optional for env vars",
+                                                        "type": "string"
+                                                    },
+                                                    "divisor": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ],
+                                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                        "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "resource": {
+                                                        "description": "Required: resource to select",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "resource"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                                "description": "Selects a key of a secret in the pod's namespace",
+                                                "properties": {
+                                                    "key": {
+                                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "Specify whether the Secret or its key must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "gitProxy": {
+                            "description": "GitProxy contains the proxy settings for git operations only. If set, this will override any Proxy settings for all git commands, such as git clone. \n Values that are not set here will be inherited from DefaultProxy.",
+                            "properties": {
+                                "httpProxy": {
+                                    "description": "httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "httpsProxy": {
+                                    "description": "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "description": "noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.",
+                                    "type": "string"
+                                },
+                                "readinessEndpoints": {
+                                    "description": "readinessEndpoints is a list of endpoints used to verify readiness of the proxy.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "trustedCA": {
+                                    "description": "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----",
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the metadata.name of the referenced config map",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "imageLabels": {
+                            "description": "ImageLabels is a list of docker labels that are applied to the resulting image. User can override a default label by providing a label with the same name in their Build/BuildConfig.",
+                            "items": {
+                                "properties": {
+                                    "name": {
+                                        "description": "Name defines the name of the label. It must have non-zero length.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value defines the literal value of the label.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "resources": {
+                            "description": "Resources defines resource requirements to execute the build.",
+                            "properties": {
+                                "claims": {
+                                    "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                    "items": {
+                                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "limits": {
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                },
+                                "requests": {
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "buildOverrides": {
+                    "description": "BuildOverrides controls override settings for builds",
+                    "properties": {
+                        "forcePull": {
+                            "description": "ForcePull overrides, if set, the equivalent value in the builds, i.e. false disables force pull for all builds, true enables force pull for all builds, independently of what each build specifies itself",
+                            "type": "boolean"
+                        },
+                        "imageLabels": {
+                            "description": "ImageLabels is a list of docker labels that are applied to the resulting image. If user provided a label in their Build/BuildConfig with the same name as one in this list, the user's label will be overwritten.",
+                            "items": {
+                                "properties": {
+                                    "name": {
+                                        "description": "Name defines the name of the label. It must have non-zero length.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "Value defines the literal value of the label.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "nodeSelector": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "NodeSelector is a selector which must be true for the build pod to fit on a node",
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "description": "Tolerations is a list of Tolerations that will override any existing tolerations set on a build pod.",
+                            "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                    "effect": {
+                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                        "type": "string"
+                                    },
+                                    "key": {
+                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                        "type": "string"
+                                    },
+                                    "tolerationSeconds": {
+                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                        "format": "int64",
+                                        "type": "integer",
+                                        "minimum": -9223372036854776000,
+                                        "maximum": 9223372036854776000
+                                    },
+                                    "value": {
+                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/buildconfig_build.openshift.io_v1.json
+++ b/openshift/v4.14-strict/buildconfig_build.openshift.io_v1.json
@@ -1,0 +1,2022 @@
+{
+    "description": "Build configurations define a build process for new container images. There are three types of builds possible - a container image build using a Dockerfile, a Source-to-Image build that uses a specially prepared base image that accepts source code that it can make runnable, and a custom build that can run // arbitrary container images as a base and accept the build parameters. Builds run on the cluster and on completion are pushed to the container image registry specified in the \"output\" section. A build can be triggered via a webhook, when the base image changes, or when a user manually requests a new build be // created. \n Each build created by a build configuration is numbered and refers back to its parent configuration. Multiple builds can be triggered at once. Builds that do not have \"output\" set can be used to test code or run a verification build. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds all the input necessary to produce a new build, and the conditions when to trigger them.",
+            "properties": {
+                "completionDeadlineSeconds": {
+                    "description": "completionDeadlineSeconds is an optional duration in seconds, counted from the time when a build pod gets scheduled in the system, that the build may be active on a node before the system actively tries to terminate the build; value must be positive integer",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "failedBuildsHistoryLimit": {
+                    "description": "failedBuildsHistoryLimit is the number of old failed builds to retain. When a BuildConfig is created, the 5 most recent failed builds are retained unless this value is set. If removed after the BuildConfig has been created, all failed builds are retained.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "mountTrustedCA": {
+                    "description": "mountTrustedCA bind mounts the cluster's trusted certificate authorities, as defined in the cluster's proxy configuration, into the build. This lets processes within a build trust components signed by custom PKI certificate authorities, such as private artifact repositories and HTTPS proxies. \n When this field is set to true, the contents of `/etc/pki/ca-trust` within the build are managed by the build container, and any changes to this directory or its subdirectories (for example - within a Dockerfile `RUN` instruction) are not persisted in the build's output image.",
+                    "type": "boolean"
+                },
+                "nodeSelector": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "nodeSelector is a selector which must be true for the build pod to fit on a node If nil, it can be overridden by default build nodeselector values for the cluster. If set to an empty map or a map with any values, default build nodeselector values are ignored.",
+                    "type": "object"
+                },
+                "output": {
+                    "description": "output describes the container image the Strategy should produce.",
+                    "properties": {
+                        "imageLabels": {
+                            "description": "imageLabels define a list of labels that are applied to the resulting image. If there are multiple labels with the same name then the last one in the list is used.",
+                            "items": {
+                                "description": "ImageLabel represents a label applied to the resulting image.",
+                                "properties": {
+                                    "name": {
+                                        "description": "name defines the name of the label. It must have non-zero length.",
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "description": "value defines the literal value of the label.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "pushSecret": {
+                            "description": "PushSecret is the name of a Secret that would be used for setting up the authentication for executing the Docker push to authentication enabled Docker Registry (or Docker Hub).",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "to": {
+                            "description": "to defines an optional location to push the output of this build to. Kind must be one of 'ImageStreamTag' or 'DockerImage'. This value will be used to look up a container image repository to push to. In the case of an ImageStreamTag, the ImageStreamTag will be looked for in the namespace of the build unless Namespace is specified.",
+                            "properties": {
+                                "apiVersion": {
+                                    "description": "API version of the referent.",
+                                    "type": "string"
+                                },
+                                "fieldPath": {
+                                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                    "type": "string"
+                                },
+                                "kind": {
+                                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                    "type": "string"
+                                },
+                                "resourceVersion": {
+                                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                    "type": "string"
+                                },
+                                "uid": {
+                                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "postCommit": {
+                    "description": "postCommit is a build hook executed after the build output image is committed, before it is pushed to a registry.",
+                    "properties": {
+                        "args": {
+                            "description": "args is a list of arguments that are provided to either Command, Script or the container image's default entrypoint. The arguments are placed immediately after the command to be run.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "command": {
+                            "description": "command is the command to run. It may not be specified with Script. This might be needed if the image doesn't have `/bin/sh`, or if you do not want to use a shell. In all other cases, using Script might be more convenient.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "script": {
+                            "description": "script is a shell script to be run with `/bin/sh -ic`. It may not be specified with Command. Use Script when a shell script is appropriate to execute the post build hook, for example for running unit tests with `rake test`. If you need control over the image entrypoint, or if the image does not have `/bin/sh`, use Command and/or Args. The `-i` flag is needed to support CentOS and RHEL images that use Software Collections (SCL), in order to have the appropriate collections enabled in the shell. E.g., in the Ruby image, this is necessary to make `ruby`, `bundle` and other binaries available in the PATH.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "resources": {
+                    "description": "resources computes resource requirements to execute the build.",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "limits": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        },
+                        "requests": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "revision": {
+                    "description": "revision is the information from the source for a specific repo snapshot. This is optional.",
+                    "properties": {
+                        "git": {
+                            "description": "Git contains information about git-based build source",
+                            "properties": {
+                                "author": {
+                                    "description": "author is the author of a specific commit",
+                                    "properties": {
+                                        "email": {
+                                            "description": "email of the source control user",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of the source control user",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "commit": {
+                                    "description": "commit is the commit hash identifying a specific commit",
+                                    "type": "string"
+                                },
+                                "committer": {
+                                    "description": "committer is the committer of a specific commit",
+                                    "properties": {
+                                        "email": {
+                                            "description": "email of the source control user",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of the source control user",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "message": {
+                                    "description": "message is the description of a specific commit",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "runPolicy": {
+                    "description": "RunPolicy describes how the new build created from this build configuration will be scheduled for execution. This is optional, if not specified we default to \"Serial\".",
+                    "type": "string"
+                },
+                "serviceAccount": {
+                    "description": "serviceAccount is the name of the ServiceAccount to use to run the pod created by this build. The pod will be allowed to use secrets referenced by the ServiceAccount",
+                    "type": "string"
+                },
+                "source": {
+                    "description": "source describes the SCM in use.",
+                    "properties": {
+                        "binary": {
+                            "description": "binary builds accept a binary as their input. The binary is generally assumed to be a tar, gzipped tar, or zip file depending on the strategy. For container image builds, this is the build context and an optional Dockerfile may be specified to override any Dockerfile in the build context. For Source builds, this is assumed to be an archive as described above. For Source and container image builds, if binary.asFile is set the build will receive a directory with a single file. contextDir may be used when an archive is provided. Custom builds will receive this binary as input on STDIN.",
+                            "properties": {
+                                "asFile": {
+                                    "description": "asFile indicates that the provided binary input should be considered a single file within the build input. For example, specifying \"webapp.war\" would place the provided binary as `/webapp.war` for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "configMaps": {
+                            "description": "configMaps represents a list of configMaps and their destinations that will be used for the build.",
+                            "items": {
+                                "description": "ConfigMapBuildSource describes a configmap and its destination directory that will be used only at the build time. The content of the configmap referenced here will be copied into the destination directory instead of mounting.",
+                                "properties": {
+                                    "configMap": {
+                                        "description": "configMap is a reference to an existing configmap that you want to use in your build.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "destinationDir": {
+                                        "description": "destinationDir is the directory where the files from the configmap should be available for the build time. For the Source build strategy, these will be injected into a container where the assemble script runs. For the container image build strategy, these will be copied into the build directory, where the Dockerfile is located, so users can ADD or COPY them during container image build.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "configMap"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "contextDir": {
+                            "description": "contextDir specifies the sub-directory where the source code for the application exists. This allows to have buildable sources in directory other than root of repository.",
+                            "type": "string"
+                        },
+                        "dockerfile": {
+                            "description": "dockerfile is the raw contents of a Dockerfile which should be built. When this option is specified, the FROM may be modified based on your strategy base image and additional ENV stanzas from your strategy environment will be added after the FROM, but before the rest of your Dockerfile stanzas. The Dockerfile source type may be used with other options like git - in those cases the Git repo will have any innate Dockerfile replaced in the context dir.",
+                            "type": "string"
+                        },
+                        "git": {
+                            "description": "git contains optional information about git build source",
+                            "properties": {
+                                "httpProxy": {
+                                    "description": "httpProxy is a proxy used to reach the git repository over http",
+                                    "type": "string"
+                                },
+                                "httpsProxy": {
+                                    "description": "httpsProxy is a proxy used to reach the git repository over https",
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "description": "noProxy is the list of domains for which the proxy should not be used",
+                                    "type": "string"
+                                },
+                                "ref": {
+                                    "description": "ref is the branch/tag/ref to build.",
+                                    "type": "string"
+                                },
+                                "uri": {
+                                    "description": "uri points to the source that will be built. The structure of the source will depend on the type of build to run",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "uri"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "images": {
+                            "description": "images describes a set of images to be used to provide source for the build",
+                            "items": {
+                                "description": "ImageSource is used to describe build source that will be extracted from an image or used during a multi stage build. A reference of type ImageStreamTag, ImageStreamImage or DockerImage may be used. A pull secret can be specified to pull the image from an external registry or override the default service account secret if pulling from the internal registry. Image sources can either be used to extract content from an image and place it into the build context along with the repository source, or used directly during a multi-stage container image build to allow content to be copied without overwriting the contents of the repository source (see the 'paths' and 'as' fields).",
+                                "properties": {
+                                    "as": {
+                                        "description": "A list of image names that this source will be used in place of during a multi-stage container image build. For instance, a Dockerfile that uses \"COPY --from=nginx:latest\" will first check for an image source that has \"nginx:latest\" in this field before attempting to pull directly. If the Dockerfile does not reference an image source it is ignored. This field and paths may both be set, in which case the contents will be used twice.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "from": {
+                                        "description": "from is a reference to an ImageStreamTag, ImageStreamImage, or DockerImage to copy source from.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                "type": "string"
+                                            },
+                                            "resourceVersion": {
+                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "paths": {
+                                        "description": "paths is a list of source and destination paths to copy from the image. This content will be copied into the build context prior to starting the build. If no paths are set, the build context will not be altered.",
+                                        "items": {
+                                            "description": "ImageSourcePath describes a path to be copied from a source image and its destination within the build directory.",
+                                            "properties": {
+                                                "destinationDir": {
+                                                    "description": "destinationDir is the relative directory within the build directory where files copied from the image are placed.",
+                                                    "type": "string"
+                                                },
+                                                "sourcePath": {
+                                                    "description": "sourcePath is the absolute path of the file or directory inside the image to copy to the build directory.  If the source path ends in /. then the content of the directory will be copied, but the directory itself will not be created at the destination.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "destinationDir",
+                                                "sourcePath"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "pullSecret": {
+                                        "description": "pullSecret is a reference to a secret to be used to pull the image from a registry If the image is pulled from the OpenShift registry, this field does not need to be set.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "from"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "secrets": {
+                            "description": "secrets represents a list of secrets and their destinations that will be used only for the build.",
+                            "items": {
+                                "description": "SecretBuildSource describes a secret and its destination directory that will be used only at the build time. The content of the secret referenced here will be copied into the destination directory instead of mounting.",
+                                "properties": {
+                                    "destinationDir": {
+                                        "description": "destinationDir is the directory where the files from the secret should be available for the build time. For the Source build strategy, these will be injected into a container where the assemble script runs. Later, when the script finishes, all files injected will be truncated to zero length. For the container image build strategy, these will be copied into the build directory, where the Dockerfile is located, so users can ADD or COPY them during container image build.",
+                                        "type": "string"
+                                    },
+                                    "secret": {
+                                        "description": "secret is a reference to an existing secret that you want to use in your build.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "secret"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "sourceSecret": {
+                            "description": "sourceSecret is the name of a Secret that would be used for setting up the authentication for cloning private repository. The secret contains valid credentials for remote repository, where the data's key represent the authentication method to be used and value is the base64 encoded credentials. Supported auth methods are: ssh-privatekey.",
+                            "properties": {
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type of build input to accept",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "strategy": {
+                    "description": "strategy defines how to perform a build.",
+                    "properties": {
+                        "customStrategy": {
+                            "description": "customStrategy holds the parameters to the Custom build strategy",
+                            "properties": {
+                                "buildAPIVersion": {
+                                    "description": "buildAPIVersion is the requested API version for the Build object serialized and passed to the custom builder",
+                                    "type": "string"
+                                },
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "exposeDockerSocket": {
+                                    "description": "exposeDockerSocket will allow running Docker commands (and build container images) from inside the container. TODO: Allow admins to enforce 'false' for this option",
+                                    "type": "boolean"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the controller should configure the build pod to always pull the images for the builder or only pull if it is not present locally",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the container image should be pulled",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "secrets": {
+                                    "description": "secrets is a list of additional secrets that will be included in the build pod",
+                                    "items": {
+                                        "description": "SecretSpec specifies a secret to be included in a build pod and its corresponding mount point",
+                                        "properties": {
+                                            "mountPath": {
+                                                "description": "mountPath is the path at which to mount the secret",
+                                                "type": "string"
+                                            },
+                                            "secretSource": {
+                                                "description": "secretSource is a reference to the secret",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mountPath",
+                                            "secretSource"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "from"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "dockerStrategy": {
+                            "description": "dockerStrategy holds the parameters to the container image build strategy.",
+                            "properties": {
+                                "buildArgs": {
+                                    "description": "buildArgs contains build arguments that will be resolved in the Dockerfile.  See https://docs.docker.com/engine/reference/builder/#/arg for more details. NOTE: Only the 'name' and 'value' fields are supported. Any settings on the 'valueFrom' field are ignored.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "dockerfilePath": {
+                                    "description": "dockerfilePath is the path of the Dockerfile that will be used to build the container image, relative to the root of the context (contextDir). Defaults to `Dockerfile` if unset.",
+                                    "type": "string"
+                                },
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the builder should pull the images from registry prior to building.",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is a reference to an DockerImage, ImageStreamTag, or ImageStreamImage which overrides the FROM image in the Dockerfile for the build. If the Dockerfile uses multi-stage builds, this will replace the image in the last FROM directive of the file.",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "imageOptimizationPolicy": {
+                                    "description": "imageOptimizationPolicy describes what optimizations the system can use when building images to reduce the final size or time spent building the image. The default policy is 'None' which means the final build image will be equivalent to an image created by the container image build API. The experimental policy 'SkipLayers' will avoid commiting new layers in between each image step, and will fail if the Dockerfile cannot provide compatibility with the 'None' policy. An additional experimental policy 'SkipLayersAndWarn' is the same as 'SkipLayers' but simply warns if compatibility cannot be preserved.",
+                                    "type": "string"
+                                },
+                                "noCache": {
+                                    "description": "noCache if set to true indicates that the container image build must be executed with the --no-cache=true flag",
+                                    "type": "boolean"
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "volumes": {
+                                    "description": "volumes is a list of input volumes that can be mounted into the builds runtime environment. Only a subset of Kubernetes Volume sources are supported by builds. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                    "items": {
+                                        "description": "BuildVolume describes a volume that is made available to build pods, such that it can be mounted into buildah's runtime environment. Only a subset of Kubernetes Volume sources are supported.",
+                                        "properties": {
+                                            "mounts": {
+                                                "description": "mounts represents the location of the volume in the image build container",
+                                                "items": {
+                                                    "description": "BuildVolumeMount describes the mounting of a Volume within buildah's runtime environment.",
+                                                    "properties": {
+                                                        "destinationPath": {
+                                                            "description": "destinationPath is the path within the buildah runtime environment at which the volume should be mounted. The transient mount within the build image and the backing volume will both be mounted read only. Must be an absolute path, must not contain '..' or ':', and must not collide with a destination path generated by the builder process Paths that collide with those added by the build controller will result in a failed build with an error message detailing which path caused the error.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "destinationPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                    "destinationPath"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
+                                            },
+                                            "name": {
+                                                "description": "name is a unique identifier for this BuildVolume. It must conform to the Kubernetes DNS label standard and be unique within the pod. Names that collide with those added by the build controller will result in a failed build with an error message detailing which name caused the error. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "description": "source represents the location and type of the mounted volume.",
+                                                "properties": {
+                                                    "configMap": {
+                                                        "description": "configMap represents a ConfigMap that should populate this volume",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "csi": {
+                                                        "description": "csi represents ephemeral storage provided by external CSI drivers which support this capability",
+                                                        "properties": {
+                                                            "driver": {
+                                                                "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                                                "type": "string"
+                                                            },
+                                                            "fsType": {
+                                                                "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                                                "type": "string"
+                                                            },
+                                                            "nodePublishSecretRef": {
+                                                                "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "readOnly": {
+                                                                "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                                                "type": "boolean"
+                                                            },
+                                                            "volumeAttributes": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "driver"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secret": {
+                                                        "description": "secret represents a Secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional field specify whether the Secret or its keys must be defined",
+                                                                "type": "boolean"
+                                                            },
+                                                            "secretName": {
+                                                                "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type is the BuildVolumeSourceType for the volume source. Type must match the populated volume source. Valid types are: Secret, ConfigMap",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mounts",
+                                            "name",
+                                            "source"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "jenkinsPipelineStrategy": {
+                            "description": "JenkinsPipelineStrategy holds the parameters to the Jenkins Pipeline build strategy. Deprecated: use OpenShift Pipelines",
+                            "properties": {
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a build pipeline.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "jenkinsfile": {
+                                    "description": "Jenkinsfile defines the optional raw contents of a Jenkinsfile which defines a Jenkins pipeline build.",
+                                    "type": "string"
+                                },
+                                "jenkinsfilePath": {
+                                    "description": "JenkinsfilePath is the optional path of the Jenkinsfile that will be used to configure the pipeline relative to the root of the context (contextDir). If both JenkinsfilePath & Jenkinsfile are both not specified, this defaults to Jenkinsfile in the root of the specified contextDir.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "sourceStrategy": {
+                            "description": "sourceStrategy holds the parameters to the Source build strategy.",
+                            "properties": {
+                                "env": {
+                                    "description": "env contains additional environment variables you want to pass into a builder container.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "forcePull": {
+                                    "description": "forcePull describes if the builder should pull the images from registry prior to building.",
+                                    "type": "boolean"
+                                },
+                                "from": {
+                                    "description": "from is reference to an DockerImage, ImageStreamTag, or ImageStreamImage from which the container image should be pulled",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "API version of the referent.",
+                                            "type": "string"
+                                        },
+                                        "fieldPath": {
+                                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                            "type": "string"
+                                        },
+                                        "resourceVersion": {
+                                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "uid": {
+                                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "incremental": {
+                                    "description": "incremental flag forces the Source build to do incremental builds if true.",
+                                    "type": "boolean"
+                                },
+                                "pullSecret": {
+                                    "description": "pullSecret is the name of a Secret that would be used for setting up the authentication for pulling the container images from the private Docker registries",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "scripts": {
+                                    "description": "scripts is the location of Source scripts",
+                                    "type": "string"
+                                },
+                                "volumes": {
+                                    "description": "volumes is a list of input volumes that can be mounted into the builds runtime environment. Only a subset of Kubernetes Volume sources are supported by builds. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                    "items": {
+                                        "description": "BuildVolume describes a volume that is made available to build pods, such that it can be mounted into buildah's runtime environment. Only a subset of Kubernetes Volume sources are supported.",
+                                        "properties": {
+                                            "mounts": {
+                                                "description": "mounts represents the location of the volume in the image build container",
+                                                "items": {
+                                                    "description": "BuildVolumeMount describes the mounting of a Volume within buildah's runtime environment.",
+                                                    "properties": {
+                                                        "destinationPath": {
+                                                            "description": "destinationPath is the path within the buildah runtime environment at which the volume should be mounted. The transient mount within the build image and the backing volume will both be mounted read only. Must be an absolute path, must not contain '..' or ':', and must not collide with a destination path generated by the builder process Paths that collide with those added by the build controller will result in a failed build with an error message detailing which path caused the error.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "destinationPath"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-map-keys": [
+                                                    "destinationPath"
+                                                ],
+                                                "x-kubernetes-list-type": "map"
+                                            },
+                                            "name": {
+                                                "description": "name is a unique identifier for this BuildVolume. It must conform to the Kubernetes DNS label standard and be unique within the pod. Names that collide with those added by the build controller will result in a failed build with an error message detailing which name caused the error. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "description": "source represents the location and type of the mounted volume.",
+                                                "properties": {
+                                                    "configMap": {
+                                                        "description": "configMap represents a ConfigMap that should populate this volume",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "csi": {
+                                                        "description": "csi represents ephemeral storage provided by external CSI drivers which support this capability",
+                                                        "properties": {
+                                                            "driver": {
+                                                                "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                                                "type": "string"
+                                                            },
+                                                            "fsType": {
+                                                                "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                                                "type": "string"
+                                                            },
+                                                            "nodePublishSecretRef": {
+                                                                "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                                                "properties": {
+                                                                    "name": {
+                                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "readOnly": {
+                                                                "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                                                "type": "boolean"
+                                                            },
+                                                            "volumeAttributes": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "driver"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secret": {
+                                                        "description": "secret represents a Secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                        "properties": {
+                                                            "defaultMode": {
+                                                                "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "items": {
+                                                                "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                "items": {
+                                                                    "description": "Maps a string key to a path within a volume.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the key to project.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "mode": {
+                                                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                            "format": "int32",
+                                                                            "type": "integer",
+                                                                            "minimum": -2147483648,
+                                                                            "maximum": 2147483647
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "optional": {
+                                                                "description": "optional field specify whether the Secret or its keys must be defined",
+                                                                "type": "boolean"
+                                                            },
+                                                            "secretName": {
+                                                                "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type is the BuildVolumeSourceType for the volume source. Type must match the populated volume source. Valid types are: Secret, ConfigMap",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "mounts",
+                                            "name",
+                                            "source"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "required": [
+                                "from"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the kind of build strategy.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "successfulBuildsHistoryLimit": {
+                    "description": "successfulBuildsHistoryLimit is the number of old successful builds to retain. When a BuildConfig is created, the 5 most recent successful builds are retained unless this value is set. If removed after the BuildConfig has been created, all successful builds are retained.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "triggers": {
+                    "description": "triggers determine how new Builds can be launched from a BuildConfig. If no triggers are defined, a new build can only occur as a result of an explicit client build creation.",
+                    "items": {
+                        "description": "BuildTriggerPolicy describes a policy for a single trigger that results in a new Build.",
+                        "properties": {
+                            "bitbucket": {
+                                "description": "BitbucketWebHook contains the parameters for a Bitbucket webhook type of trigger",
+                                "properties": {
+                                    "allowEnv": {
+                                        "description": "allowEnv determines whether the webhook can set environment variables; can only be set to true for GenericWebHook.",
+                                        "type": "boolean"
+                                    },
+                                    "secret": {
+                                        "description": "secret used to validate requests. Deprecated: use SecretReference instead.",
+                                        "type": "string"
+                                    },
+                                    "secretReference": {
+                                        "description": "secretReference is a reference to a secret in the same namespace, containing the value to be validated when the webhook is invoked. The secret being referenced must contain a key named \"WebHookSecretKey\", the value of which will be checked against the value supplied in the webhook invocation.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name is the name of the resource in the same namespace being referenced",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "generic": {
+                                "description": "generic contains the parameters for a Generic webhook type of trigger",
+                                "properties": {
+                                    "allowEnv": {
+                                        "description": "allowEnv determines whether the webhook can set environment variables; can only be set to true for GenericWebHook.",
+                                        "type": "boolean"
+                                    },
+                                    "secret": {
+                                        "description": "secret used to validate requests. Deprecated: use SecretReference instead.",
+                                        "type": "string"
+                                    },
+                                    "secretReference": {
+                                        "description": "secretReference is a reference to a secret in the same namespace, containing the value to be validated when the webhook is invoked. The secret being referenced must contain a key named \"WebHookSecretKey\", the value of which will be checked against the value supplied in the webhook invocation.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name is the name of the resource in the same namespace being referenced",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "github": {
+                                "description": "github contains the parameters for a GitHub webhook type of trigger",
+                                "properties": {
+                                    "allowEnv": {
+                                        "description": "allowEnv determines whether the webhook can set environment variables; can only be set to true for GenericWebHook.",
+                                        "type": "boolean"
+                                    },
+                                    "secret": {
+                                        "description": "secret used to validate requests. Deprecated: use SecretReference instead.",
+                                        "type": "string"
+                                    },
+                                    "secretReference": {
+                                        "description": "secretReference is a reference to a secret in the same namespace, containing the value to be validated when the webhook is invoked. The secret being referenced must contain a key named \"WebHookSecretKey\", the value of which will be checked against the value supplied in the webhook invocation.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name is the name of the resource in the same namespace being referenced",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "gitlab": {
+                                "description": "GitLabWebHook contains the parameters for a GitLab webhook type of trigger",
+                                "properties": {
+                                    "allowEnv": {
+                                        "description": "allowEnv determines whether the webhook can set environment variables; can only be set to true for GenericWebHook.",
+                                        "type": "boolean"
+                                    },
+                                    "secret": {
+                                        "description": "secret used to validate requests. Deprecated: use SecretReference instead.",
+                                        "type": "string"
+                                    },
+                                    "secretReference": {
+                                        "description": "secretReference is a reference to a secret in the same namespace, containing the value to be validated when the webhook is invoked. The secret being referenced must contain a key named \"WebHookSecretKey\", the value of which will be checked against the value supplied in the webhook invocation.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name is the name of the resource in the same namespace being referenced",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "imageChange": {
+                                "description": "imageChange contains parameters for an ImageChange type of trigger",
+                                "properties": {
+                                    "from": {
+                                        "description": "from is a reference to an ImageStreamTag that will trigger a build when updated It is optional. If no From is specified, the From image from the build strategy will be used. Only one ImageChangeTrigger with an empty From reference is allowed in a build configuration.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                "type": "string"
+                                            },
+                                            "resourceVersion": {
+                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "lastTriggeredImageID": {
+                                        "description": "lastTriggeredImageID is used internally by the ImageChangeController to save last used image ID for build This field is deprecated and will be removed in a future release. Deprecated",
+                                        "type": "string"
+                                    },
+                                    "paused": {
+                                        "description": "paused is true if this trigger is temporarily disabled. Optional.",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": {
+                                "description": "type is the type of build trigger. Valid values: \n - GitHub GitHubWebHookBuildTriggerType represents a trigger that launches builds on GitHub webhook invocations \n - Generic GenericWebHookBuildTriggerType represents a trigger that launches builds on generic webhook invocations \n - GitLab GitLabWebHookBuildTriggerType represents a trigger that launches builds on GitLab webhook invocations \n - Bitbucket BitbucketWebHookBuildTriggerType represents a trigger that launches builds on Bitbucket webhook invocations \n - ImageChange ImageChangeBuildTriggerType represents a trigger that launches builds on availability of a new version of an image \n - ConfigChange ConfigChangeBuildTriggerType will trigger a build on an initial build config creation WARNING: In the future the behavior will change to trigger a build on any config change",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "strategy"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds any relevant information about a build config",
+            "properties": {
+                "imageChangeTriggers": {
+                    "description": "ImageChangeTriggers captures the runtime state of any ImageChangeTrigger specified in the BuildConfigSpec, including the value reconciled by the OpenShift APIServer for the lastTriggeredImageID. There is a single entry in this array for each image change trigger in spec. Each trigger status references the ImageStreamTag that acts as the source of the trigger.",
+                    "items": {
+                        "description": "ImageChangeTriggerStatus tracks the latest resolved status of the associated ImageChangeTrigger policy specified in the BuildConfigSpec.Triggers struct.",
+                        "properties": {
+                            "from": {
+                                "description": "from is the ImageStreamTag that is the source of the trigger.",
+                                "properties": {
+                                    "name": {
+                                        "description": "name is the name of the ImageStreamTag for an ImageChangeTrigger",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "namespace is the namespace where the ImageStreamTag for an ImageChangeTrigger is located",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "lastTriggerTime": {
+                                "description": "lastTriggerTime is the last time this particular ImageStreamTag triggered a Build to start. This field is only updated when this trigger specifically started a Build.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastTriggeredImageID": {
+                                "description": "lastTriggeredImageID represents the sha/id of the ImageStreamTag when a Build for this BuildConfig was started. The lastTriggeredImageID is updated each time a Build for this BuildConfig is started, even if this ImageStreamTag is not the reason the Build is started.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "lastVersion": {
+                    "description": "lastVersion is used to inform about number of last triggered build.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                }
+            },
+            "required": [
+                "lastVersion"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/buildrequest_build.openshift.io_v1.json
+++ b/openshift/v4.14-strict/buildrequest_build.openshift.io_v1.json
@@ -1,0 +1,773 @@
+{
+    "description": "BuildRequest is the resource used to pass parameters to build generator \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "binary": {
+            "description": "binary indicates a request to build from a binary provided to the builder",
+            "properties": {
+                "asFile": {
+                    "description": "asFile indicates that the provided binary input should be considered a single file within the build input. For example, specifying \"webapp.war\" would place the provided binary as `/webapp.war` for the builder. If left empty, the Docker and Source build strategies assume this file is a zip, tar, or tar.gz file and extract it as the source. The custom strategy receives this binary as standard input. This filename may not contain slashes or be '..' or '.'.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "dockerStrategyOptions": {
+            "description": "DockerStrategyOptions contains additional docker-strategy specific options for the build",
+            "properties": {
+                "buildArgs": {
+                    "description": "Args contains any build arguments that are to be passed to Docker.  See https://docs.docker.com/engine/reference/builder/#/arg for more details",
+                    "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "properties": {
+                            "name": {
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                "type": "string"
+                            },
+                            "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "properties": {
+                                    "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key to select.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "fieldPath"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                        "properties": {
+                                            "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                            },
+                                            "divisor": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "integer"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "resource"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "properties": {
+                                            "key": {
+                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            },
+                                            "optional": {
+                                                "description": "Specify whether the Secret or its key must be defined",
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": [
+                                            "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "noCache": {
+                    "description": "noCache overrides the docker-strategy noCache option in the build config",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "env": {
+            "description": "env contains additional environment variables you want to pass into a builder container.",
+            "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "properties": {
+                    "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                        "type": "string"
+                    },
+                    "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "properties": {
+                            "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "properties": {
+                                    "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                    },
+                                    "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "fieldPath"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                "properties": {
+                                    "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                    },
+                                    "divisor": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "resource"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "properties": {
+                                    "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "required": [
+                                    "key"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "from": {
+            "description": "from is the reference to the ImageStreamTag that triggered the build.",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "lastVersion": {
+            "description": "lastVersion (optional) is the LastVersion of the BuildConfig that was used to generate the build. If the BuildConfig in the generator doesn't match, a build will not be generated.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "revision": {
+            "description": "revision is the information from the source for a specific repo snapshot.",
+            "properties": {
+                "git": {
+                    "description": "Git contains information about git-based build source",
+                    "properties": {
+                        "author": {
+                            "description": "author is the author of a specific commit",
+                            "properties": {
+                                "email": {
+                                    "description": "email of the source control user",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "name of the source control user",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "commit": {
+                            "description": "commit is the commit hash identifying a specific commit",
+                            "type": "string"
+                        },
+                        "committer": {
+                            "description": "committer is the committer of a specific commit",
+                            "properties": {
+                                "email": {
+                                    "description": "email of the source control user",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "name of the source control user",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "message": {
+                            "description": "message is the description of a specific commit",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "type": {
+                    "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "sourceStrategyOptions": {
+            "description": "SourceStrategyOptions contains additional source-strategy specific options for the build",
+            "properties": {
+                "incremental": {
+                    "description": "incremental overrides the source-strategy incremental option in the build config",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "triggeredBy": {
+            "description": "triggeredBy describes which triggers started the most recent update to the build configuration and contains information about those triggers.",
+            "items": {
+                "description": "BuildTriggerCause holds information about a triggered build. It is used for displaying build trigger data for each build and build configuration in oc describe. It is also used to describe which triggers led to the most recent update in the build configuration.",
+                "properties": {
+                    "bitbucketWebHook": {
+                        "description": "BitbucketWebHook represents data for a Bitbucket webhook that fired a specific build.",
+                        "properties": {
+                            "revision": {
+                                "description": "Revision is the git source revision information of the trigger.",
+                                "properties": {
+                                    "git": {
+                                        "description": "Git contains information about git-based build source",
+                                        "properties": {
+                                            "author": {
+                                                "description": "author is the author of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "commit": {
+                                                "description": "commit is the commit hash identifying a specific commit",
+                                                "type": "string"
+                                            },
+                                            "committer": {
+                                                "description": "committer is the committer of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "message": {
+                                                "description": "message is the description of a specific commit",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "description": "Secret is the obfuscated webhook secret that triggered a build.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "genericWebHook": {
+                        "description": "genericWebHook holds data about a builds generic webhook trigger.",
+                        "properties": {
+                            "revision": {
+                                "description": "revision is an optional field that stores the git source revision information of the generic webhook trigger when it is available.",
+                                "properties": {
+                                    "git": {
+                                        "description": "Git contains information about git-based build source",
+                                        "properties": {
+                                            "author": {
+                                                "description": "author is the author of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "commit": {
+                                                "description": "commit is the commit hash identifying a specific commit",
+                                                "type": "string"
+                                            },
+                                            "committer": {
+                                                "description": "committer is the committer of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "message": {
+                                                "description": "message is the description of a specific commit",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "description": "secret is the obfuscated webhook secret that triggered a build.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "githubWebHook": {
+                        "description": "gitHubWebHook represents data for a GitHub webhook that fired a specific build.",
+                        "properties": {
+                            "revision": {
+                                "description": "revision is the git revision information of the trigger.",
+                                "properties": {
+                                    "git": {
+                                        "description": "Git contains information about git-based build source",
+                                        "properties": {
+                                            "author": {
+                                                "description": "author is the author of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "commit": {
+                                                "description": "commit is the commit hash identifying a specific commit",
+                                                "type": "string"
+                                            },
+                                            "committer": {
+                                                "description": "committer is the committer of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "message": {
+                                                "description": "message is the description of a specific commit",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "description": "secret is the obfuscated webhook secret that triggered a build.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "gitlabWebHook": {
+                        "description": "GitLabWebHook represents data for a GitLab webhook that fired a specific build.",
+                        "properties": {
+                            "revision": {
+                                "description": "Revision is the git source revision information of the trigger.",
+                                "properties": {
+                                    "git": {
+                                        "description": "Git contains information about git-based build source",
+                                        "properties": {
+                                            "author": {
+                                                "description": "author is the author of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "commit": {
+                                                "description": "commit is the commit hash identifying a specific commit",
+                                                "type": "string"
+                                            },
+                                            "committer": {
+                                                "description": "committer is the committer of a specific commit",
+                                                "properties": {
+                                                    "email": {
+                                                        "description": "email of the source control user",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "name of the source control user",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "message": {
+                                                "description": "message is the description of a specific commit",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "type of the build source, may be one of 'Source', 'Dockerfile', 'Binary', or 'Images'",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "description": "Secret is the obfuscated webhook secret that triggered a build.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "imageChangeBuild": {
+                        "description": "imageChangeBuild stores information about an imagechange event that triggered a new build.",
+                        "properties": {
+                            "fromRef": {
+                                "description": "fromRef contains detailed information about an image that triggered a build.",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "API version of the referent.",
+                                        "type": "string"
+                                    },
+                                    "fieldPath": {
+                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                        "type": "string"
+                                    },
+                                    "resourceVersion": {
+                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                        "type": "string"
+                                    },
+                                    "uid": {
+                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "imageID": {
+                                "description": "imageID is the ID of the image that triggered a new build.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "message": {
+                        "description": "message is used to store a human readable message for why the build was triggered. E.g.: \"Manually triggered by user\", \"Configuration change\",etc.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "triggeredByImage": {
+            "description": "triggeredByImage is the Image that triggered this build.",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/cloudcredential_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/cloudcredential_operator.openshift.io_v1.json
@@ -1,0 +1,174 @@
+{
+    "description": "CloudCredential provides a means to configure an operator to manage CredentialsRequests. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "CloudCredentialSpec is the specification of the desired behavior of the cloud-credential-operator.",
+            "properties": {
+                "credentialsMode": {
+                    "description": "CredentialsMode allows informing CCO that it should not attempt to dynamically determine the root cloud credentials capabilities, and it should just run in the specified mode. It also allows putting the operator into \"manual\" mode if desired. Leaving the field in default mode runs CCO so that the cluster's cloud credentials will be dynamically probed for capabilities (on supported clouds/platforms). Supported modes: AWS/Azure/GCP: \"\" (Default), \"Mint\", \"Passthrough\", \"Manual\" Others: Do not set value as other platforms only support running in \"Passthrough\"",
+                    "enum": [
+                        "",
+                        "Manual",
+                        "Mint",
+                        "Passthrough"
+                    ],
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "CloudCredentialStatus defines the observed status of the cloud-credential-operator.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/cloudprivateipconfig_cloud.network.openshift.io_v1.json
+++ b/openshift/v4.14-strict/cloudprivateipconfig_cloud.network.openshift.io_v1.json
@@ -1,0 +1,93 @@
+{
+    "description": "CloudPrivateIPConfig performs an assignment of a private IP address to the primary NIC associated with cloud VMs. This is done by specifying the IP and Kubernetes node which the IP should be assigned to. This CRD is intended to be used by the network plugin which manages the cluster network. The spec side represents the desired state requested by the network plugin, and the status side represents the current state that this CRD's controller has executed. No users will have permission to modify it, and if a cluster-admin decides to edit it for some reason, their changes will be overwritten the next time the network plugin reconciles the object. Note: the CR's name must specify the requested private IP address (can be IPv4 or IPv6). \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the definition of the desired private IP request.",
+            "properties": {
+                "node": {
+                    "description": "node is the node name, as specified by the Kubernetes field: node.metadata.name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the observed status of the desired private IP request. Read-only.",
+            "properties": {
+                "conditions": {
+                    "description": "condition is the assignment condition of the private IP and its status",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "node": {
+                    "description": "node is the node name, as specified by the Kubernetes field: node.metadata.name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "conditions"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clustercsidriver_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clustercsidriver_operator.openshift.io_v1.json
@@ -1,0 +1,303 @@
+{
+    "description": "ClusterCSIDriver object allows management and configuration of a CSI driver operator installed by default in OpenShift. Name of the object must be name of the CSI driver it operates. See CSIDriverName type for list of allowed values. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "driverConfig": {
+                    "description": "driverConfig can be used to specify platform specific driver configuration. When omitted, this means no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.",
+                    "properties": {
+                        "aws": {
+                            "description": "aws is used to configure the AWS CSI driver.",
+                            "properties": {
+                                "kmsKeyARN": {
+                                    "description": "kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key, rather than the default KMS key used by AWS. The value may be either the ARN or Alias ARN of a KMS key.",
+                                    "pattern": "^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\\/.*$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "azure": {
+                            "description": "azure is used to configure the Azure CSI driver.",
+                            "properties": {
+                                "diskEncryptionSet": {
+                                    "description": "diskEncryptionSet sets the cluster default storage class to encrypt volumes with a customer-managed encryption set, rather than the default platform-managed keys.",
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the name of the disk encryption set that will be set on the default storage class. The value should consist of only alphanumberic characters, underscores (_), hyphens, and be at most 80 characters in length.",
+                                            "maxLength": 80,
+                                            "pattern": "^[a-zA-Z0-9\\_-]+$",
+                                            "type": "string"
+                                        },
+                                        "resourceGroup": {
+                                            "description": "resourceGroup defines the Azure resource group that contains the disk encryption set. The value should consist of only alphanumberic characters, underscores (_), parentheses, hyphens and periods. The value should not end in a period and be at most 90 characters in length.",
+                                            "maxLength": 90,
+                                            "pattern": "^[\\w\\.\\-\\(\\)]*[\\w\\-\\(\\)]$",
+                                            "type": "string"
+                                        },
+                                        "subscriptionID": {
+                                            "description": "subscriptionID defines the Azure subscription that contains the disk encryption set. The value should meet the following conditions: 1. It should be a 128-bit number. 2. It should be 36 characters (32 hexadecimal characters and 4 hyphens) long. 3. It should be displayed in five groups separated by hyphens (-). 4. The first group should be 8 characters long. 5. The second, third, and fourth groups should be 4 characters long. 6. The fifth group should be 12 characters long. An Example SubscrionID: f2007bbf-f802-4a47-9336-cf7c6b89b378",
+                                            "maxLength": 36,
+                                            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name",
+                                        "resourceGroup",
+                                        "subscriptionID"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "driverType": {
+                            "description": "driverType indicates type of CSI driver for which the driverConfig is being applied to. Valid values are: AWS, Azure, GCP, vSphere and omitted. Consumers should treat unknown values as a NO-OP.",
+                            "enum": [
+                                "",
+                                "AWS",
+                                "Azure",
+                                "GCP",
+                                "vSphere"
+                            ],
+                            "type": "string"
+                        },
+                        "gcp": {
+                            "description": "gcp is used to configure the GCP CSI driver.",
+                            "properties": {
+                                "kmsKey": {
+                                    "description": "kmsKey sets the cluster default storage class to encrypt volumes with customer-supplied encryption keys, rather than the default keys managed by GCP.",
+                                    "properties": {
+                                        "keyRing": {
+                                            "description": "keyRing is the name of the KMS Key Ring which the KMS Key belongs to. The value should correspond to an existing KMS key ring and should consist of only alphanumeric characters, hyphens (-) and underscores (_), and be at most 63 characters in length.",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z0-9\\_-]+$",
+                                            "type": "string"
+                                        },
+                                        "location": {
+                                            "description": "location is the GCP location in which the Key Ring exists. The value must match an existing GCP location, or \"global\". Defaults to global, if not set.",
+                                            "pattern": "^[a-zA-Z0-9\\_-]+$",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name is the name of the customer-managed encryption key to be used for disk encryption. The value should correspond to an existing KMS key and should consist of only alphanumeric characters, hyphens (-) and underscores (_), and be at most 63 characters in length.",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z0-9\\_-]+$",
+                                            "type": "string"
+                                        },
+                                        "projectID": {
+                                            "description": "projectID is the ID of the Project in which the KMS Key Ring exists. It must be 6 to 30 lowercase letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited.",
+                                            "maxLength": 30,
+                                            "minLength": 6,
+                                            "pattern": "^[a-z][a-z0-9-]+[a-z0-9]$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "keyRing",
+                                        "name",
+                                        "projectID"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "vSphere": {
+                            "description": "vsphere is used to configure the vsphere CSI driver.",
+                            "properties": {
+                                "topologyCategories": {
+                                    "description": "topologyCategories indicates tag categories with which vcenter resources such as hostcluster or datacenter were tagged with. If cluster Infrastructure object has a topology, values specified in Infrastructure object will be used and modifications to topologyCategories will be rejected.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "driverType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "storageClassState": {
+                    "description": "StorageClassState determines if CSI operator should create and manage storage classes. If this field value is empty or Managed - CSI operator will continuously reconcile storage class and create if necessary. If this field value is Unmanaged - CSI operator will not reconcile any previously created storage class. If this field value is Removed - CSI operator will delete the storage class it created previously. When omitted, this means the user has no opinion and the platform chooses a reasonable default, which is subject to change over time. The current default behaviour is Managed.",
+                    "enum": [
+                        "",
+                        "Managed",
+                        "Unmanaged",
+                        "Removed"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusternetwork_network.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusternetwork_network.openshift.io_v1.json
@@ -1,0 +1,85 @@
+{
+    "description": "ClusterNetwork describes the cluster network. There is normally only one object of this type, named \"default\", which is created by the SDN network plugin based on the master configuration when the cluster is brought up for the first time. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "clusterNetworks": {
+            "description": "ClusterNetworks is a list of ClusterNetwork objects that defines the global overlay network's L3 space by specifying a set of CIDR and netmasks that the SDN can allocate addresses from.",
+            "items": {
+                "description": "ClusterNetworkEntry defines an individual cluster network. The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved for external ips, CIDRs reserved for service networks, and CIDRs reserved for ingress ips.",
+                "properties": {
+                    "CIDR": {
+                        "description": "CIDR defines the total range of a cluster networks address space.",
+                        "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+                        "type": "string"
+                    },
+                    "hostSubnetLength": {
+                        "description": "HostSubnetLength is the number of bits of the accompanying CIDR address to allocate to each node. eg, 8 would mean that each node would have a /24 slice of the overlay network for its pods.",
+                        "format": "int32",
+                        "maximum": 30,
+                        "minimum": 2,
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "CIDR",
+                    "hostSubnetLength"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "hostsubnetlength": {
+            "description": "HostSubnetLength is the number of bits of network to allocate to each node. eg, 8 would mean that each node would have a /24 slice of the overlay network for its pods",
+            "format": "int32",
+            "maximum": 30,
+            "minimum": 2,
+            "type": "integer"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "mtu": {
+            "description": "MTU is the MTU for the overlay network. This should be 50 less than the MTU of the network connecting the nodes. It is normally autodetected by the cluster network operator.",
+            "format": "int32",
+            "maximum": 65536,
+            "minimum": 576,
+            "type": "integer"
+        },
+        "network": {
+            "description": "Network is a CIDR string specifying the global overlay network's L3 space",
+            "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+            "type": "string"
+        },
+        "pluginName": {
+            "description": "PluginName is the name of the network plugin being used",
+            "type": "string"
+        },
+        "serviceNetwork": {
+            "description": "ServiceNetwork is the CIDR range that Service IP addresses are allocated from",
+            "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+            "type": "string"
+        },
+        "vxlanPort": {
+            "description": "VXLANPort sets the VXLAN destination port used by the cluster. It is set by the master configuration file on startup and cannot be edited manually. Valid values for VXLANPort are integers 1-65535 inclusive and if unset defaults to 4789. Changing VXLANPort allows users to resolve issues between openshift SDN and other software trying to use the same VXLAN destination port.",
+            "format": "int32",
+            "maximum": 65535,
+            "minimum": 1,
+            "type": "integer"
+        }
+    },
+    "required": [
+        "clusterNetworks",
+        "serviceNetwork"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusteroperator_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusteroperator_config.openshift.io_v1.json
@@ -1,0 +1,132 @@
+{
+    "description": "ClusterOperator is the Custom Resource object which holds the current state of an operator. This object is used by operators to convey their state to the rest of the cluster. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds configuration that could apply to any operator.",
+            "type": "object"
+        },
+        "status": {
+            "description": "status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions describes the state of the operator's managed and monitored components.",
+                    "items": {
+                        "description": "ClusterOperatorStatusCondition represents the state of the operator's managed and monitored components.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the time of the last update to the current status property.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "reason is the CamelCase reason for the condition's current status.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type specifies the aspect reported by this condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "extension": {
+                    "description": "extension contains any additional status information specific to the operator which owns this status object.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "relatedObjects": {
+                    "description": "relatedObjects is a list of objects that are \"interesting\" or related to this operator.  Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces",
+                    "items": {
+                        "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                        "properties": {
+                            "group": {
+                                "description": "group of the referent.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the referent.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace of the referent.",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource of the referent.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "group",
+                            "name",
+                            "resource"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "versions": {
+                    "description": "versions is a slice of operator and operand version tuples.  Operators which manage multiple operands will have multiple operand entries in the array.  Available operators must report the version of the operator itself with the name \"operator\". An operator reports a new \"operator\" version when it has rolled out the new version to all of its operands.",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "description": "name is the name of the particular operand this version is for.  It usually matches container images, not operators.",
+                                "type": "string"
+                            },
+                            "version": {
+                                "description": "version indicates which version of a particular operand is currently being managed.  It must always match the Available operand.  If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout 1.1.0",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "version"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusterresourcequota_quota.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusterresourcequota_quota.openshift.io_v1.json
@@ -1,0 +1,276 @@
+{
+    "description": "ClusterResourceQuota mirrors ResourceQuota at a cluster scope.  This object is easily convertible to synthetic ResourceQuota object to allow quota evaluation re-use. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec defines the desired quota",
+            "properties": {
+                "quota": {
+                    "description": "Quota defines the desired quota",
+                    "properties": {
+                        "hard": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                            "type": "object"
+                        },
+                        "scopeSelector": {
+                            "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "A list of scope selector requirements by scope of the resources.",
+                                    "items": {
+                                        "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+                                        "properties": {
+                                            "operator": {
+                                                "description": "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "scopeName": {
+                                                "description": "The name of the scope that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "operator",
+                                            "scopeName"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "scopes": {
+                            "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
+                            "items": {
+                                "description": "A ResourceQuotaScope defines a filter that must match each object tracked by a quota",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "selector": {
+                    "description": "Selector is the selector used to match projects. It should only select active projects on the scale of dozens (though it can select many more less active projects).  These projects will contend on object creation through this resource.",
+                    "properties": {
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "AnnotationSelector is used to select projects by annotation.",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "labels": {
+                            "description": "LabelSelector is used to select projects by label.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "quota",
+                "selector"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status defines the actual enforced quota and its current usage",
+            "properties": {
+                "namespaces": {
+                    "description": "Namespaces slices the usage by project.  This division allows for quick resolution of deletion reconciliation inside of a single project without requiring a recalculation across all projects.  This can be used to pull the deltas for a given project.",
+                    "items": {
+                        "description": "ResourceQuotaStatusByNamespace gives status for a particular project",
+                        "properties": {
+                            "namespace": {
+                                "description": "Namespace the project this status applies to",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status indicates how many resources have been consumed by this project",
+                                "properties": {
+                                    "hard": {
+                                        "additionalProperties": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                                        "type": "object"
+                                    },
+                                    "used": {
+                                        "additionalProperties": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                        },
+                                        "description": "Used is the current observed total usage of the resource in the namespace.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "namespace",
+                            "status"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "total": {
+                    "description": "Total defines the actual enforced quota and its current usage across all projects",
+                    "properties": {
+                        "hard": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                            "type": "object"
+                        },
+                        "used": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Used is the current observed total usage of the resource in the namespace.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "total"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusterrole_authorization.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusterrole_authorization.openshift.io_v1.json
@@ -1,0 +1,128 @@
+{
+    "description": "ClusterRole is a logical grouping of PolicyRules that can be referenced as a unit by ClusterRoleBindings. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "aggregationRule": {
+            "description": "AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.",
+            "properties": {
+                "clusterRoleSelectors": {
+                    "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
+                    "items": {
+                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                        "properties": {
+                            "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                    "properties": {
+                                        "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                        },
+                                        "operator": {
+                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                        },
+                                        "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "operator"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "matchLabels": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "rules": {
+            "description": "Rules holds all the PolicyRules for this ClusterRole",
+            "items": {
+                "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+                "properties": {
+                    "apiGroups": {
+                        "description": "APIGroups is the name of the APIGroup that contains the resources.  If this field is empty, then both kubernetes and origin API groups are assumed. That means that if an action is requested against one of the enumerated resources in either the kubernetes or the origin API group, the request will be allowed",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": [
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "attributeRestrictions": {
+                        "description": "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "nonResourceURLs": {
+                        "description": "NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "resourceNames": {
+                        "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "resources": {
+                        "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "verbs": {
+                        "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusterrolebinding_authorization.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusterrolebinding_authorization.openshift.io_v1.json
@@ -1,0 +1,107 @@
+{
+    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace. It adds who information via (Users and Groups) OR Subjects and namespace information by which namespace it exists in. ClusterRoleBindings in a given namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces). \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "groupNames": {
+            "description": "GroupNames holds all the groups directly bound to the role. This field should only be specified when supporting legacy clients and servers. See Subjects for further details.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "roleRef": {
+            "description": "RoleRef can only reference the current namespace and the global namespace. If the ClusterRoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "subjects": {
+            "description": "Subjects hold object references to authorize with this rule. This field is ignored if UserNames or GroupNames are specified to support legacy clients and servers. Thus newer clients that do not need to support backwards compatibility should send only fully qualified Subjects and should omit the UserNames and GroupNames fields. Clients that need to support backwards compatibility can use this field to build the UserNames and GroupNames.",
+            "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. \n Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+                "properties": {
+                    "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                    },
+                    "fieldPath": {
+                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                        "type": "string"
+                    },
+                    "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                        "type": "string"
+                    },
+                    "resourceVersion": {
+                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                        "type": "string"
+                    },
+                    "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "userNames": {
+            "description": "UserNames holds all the usernames directly bound to the role. This field should only be specified when supporting legacy clients and servers. See Subjects for further details.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/clusterversion_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/clusterversion_config.openshift.io_v1.json
@@ -1,0 +1,559 @@
+{
+    "description": "ClusterVersion is the configuration for the ClusterVersionOperator. This is where parameters related to automatic updates can be set. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the desired state of the cluster version - the operator will work to ensure that the desired version is applied to the cluster.",
+            "properties": {
+                "capabilities": {
+                    "description": "capabilities configures the installation of optional, core cluster components.  A null value here is identical to an empty object; see the child properties for default semantics.",
+                    "properties": {
+                        "additionalEnabledCapabilities": {
+                            "description": "additionalEnabledCapabilities extends the set of managed capabilities beyond the baseline defined in baselineCapabilitySet.  The default is an empty set.",
+                            "items": {
+                                "description": "ClusterVersionCapability enumerates optional, core cluster components.",
+                                "enum": [
+                                    "openshift-samples",
+                                    "baremetal",
+                                    "marketplace",
+                                    "Console",
+                                    "Insights",
+                                    "Storage",
+                                    "CSISnapshot",
+                                    "NodeTuning",
+                                    "MachineAPI",
+                                    "Build",
+                                    "DeploymentConfig",
+                                    "ImageRegistry"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        },
+                        "baselineCapabilitySet": {
+                            "description": "baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.",
+                            "enum": [
+                                "None",
+                                "v4.11",
+                                "v4.12",
+                                "v4.13",
+                                "v4.14",
+                                "vCurrent"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "channel": {
+                    "description": "channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.",
+                    "type": "string"
+                },
+                "clusterID": {
+                    "description": "clusterID uniquely identifies this cluster. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values). This is a required field.",
+                    "type": "string"
+                },
+                "desiredUpdate": {
+                    "description": "desiredUpdate is an optional field that indicates the desired value of the cluster version. Setting this value will trigger an upgrade (if the current version does not match the desired version). The set of recommended update values is listed as part of available updates in status, and setting values outside that range may cause the upgrade to fail. \n Some of the fields are inter-related with restrictions and meanings described here. 1. image is specified, version is specified, architecture is specified. API validation error. 2. image is specified, version is specified, architecture is not specified. You should not do this. version is silently ignored and image is used. 3. image is specified, version is not specified, architecture is specified. API validation error. 4. image is specified, version is not specified, architecture is not specified. image is used. 5. image is not specified, version is specified, architecture is specified. version and desired architecture are used to select an image. 6. image is not specified, version is specified, architecture is not specified. version and current architecture are used to select an image. 7. image is not specified, version is not specified, architecture is specified. API validation error. 8. image is not specified, version is not specified, architecture is not specified. API validation error. \n If an upgrade fails the operator will halt and report status about the failing component. Setting the desired update value back to the previous version will cause a rollback to be attempted. Not all rollbacks will succeed.",
+                    "properties": {
+                        "architecture": {
+                            "description": "architecture is an optional field that indicates the desired value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. architecture can only be set to Multi thereby only allowing updates from single to multi architecture. If architecture is set, image cannot be set and version must be set. Valid values are 'Multi' and empty.",
+                            "enum": [
+                                "Multi",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "force": {
+                            "description": "force allows an administrator to update to an image that has failed verification or upgradeable checks. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.",
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "description": "image is a container image location that contains the update. image should be used when the desired version does not exist in availableUpdates or history. When image is set, version is ignored. When image is set, version should be empty. When image is set, architecture cannot be specified.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "version is a semantic version identifying the update version. version is ignored if image is specified and required if architecture is specified.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "cannot set both Architecture and Image",
+                            "rule": "has(self.architecture) && has(self.image) ? (self.architecture == '' || self.image == '') : true"
+                        },
+                        {
+                            "message": "Version must be set if Architecture is set",
+                            "rule": "has(self.architecture) && self.architecture != '' ? self.version != '' : true"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "overrides": {
+                    "description": "overrides is list of overides for components that are managed by cluster version operator. Marking a component unmanaged will prevent the operator from creating or updating the object.",
+                    "items": {
+                        "description": "ComponentOverride allows overriding cluster version operator's behavior for a component.",
+                        "properties": {
+                            "group": {
+                                "description": "group identifies the API group that the kind is in.",
+                                "type": "string"
+                            },
+                            "kind": {
+                                "description": "kind indentifies which object to override.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the component's name.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is the component's namespace. If the resource is cluster scoped, the namespace should be empty.",
+                                "type": "string"
+                            },
+                            "unmanaged": {
+                                "description": "unmanaged controls if cluster version operator should stop managing the resources in this cluster. Default: false",
+                                "type": "boolean"
+                            }
+                        },
+                        "required": [
+                            "group",
+                            "kind",
+                            "name",
+                            "namespace",
+                            "unmanaged"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "upstream": {
+                    "description": "upstream may be used to specify the preferred update server. By default it will use the appropriate update server for the cluster and region.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "clusterID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status contains information about the available updates and any in-progress updates.",
+            "properties": {
+                "availableUpdates": {
+                    "description": "availableUpdates contains updates recommended for this cluster. Updates which appear in conditionalUpdates but not in availableUpdates may expose this cluster to known issues. This list may be empty if no updates are recommended, if the update service is unavailable, or if an invalid channel has been specified.",
+                    "items": {
+                        "description": "Release represents an OpenShift release image and associated metadata.",
+                        "properties": {
+                            "channels": {
+                                "description": "channels is the set of Cincinnati channels to which the release currently belongs.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "image": {
+                                "description": "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
+                                "type": "string"
+                            },
+                            "url": {
+                                "description": "url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.",
+                                "type": "string"
+                            },
+                            "version": {
+                                "description": "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "capabilities": {
+                    "description": "capabilities describes the state of optional, core cluster components.",
+                    "properties": {
+                        "enabledCapabilities": {
+                            "description": "enabledCapabilities lists all the capabilities that are currently managed.",
+                            "items": {
+                                "description": "ClusterVersionCapability enumerates optional, core cluster components.",
+                                "enum": [
+                                    "openshift-samples",
+                                    "baremetal",
+                                    "marketplace",
+                                    "Console",
+                                    "Insights",
+                                    "Storage",
+                                    "CSISnapshot",
+                                    "NodeTuning",
+                                    "MachineAPI",
+                                    "Build",
+                                    "DeploymentConfig",
+                                    "ImageRegistry"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        },
+                        "knownCapabilities": {
+                            "description": "knownCapabilities lists all the capabilities known to the current cluster.",
+                            "items": {
+                                "description": "ClusterVersionCapability enumerates optional, core cluster components.",
+                                "enum": [
+                                    "openshift-samples",
+                                    "baremetal",
+                                    "marketplace",
+                                    "Console",
+                                    "Insights",
+                                    "Storage",
+                                    "CSISnapshot",
+                                    "NodeTuning",
+                                    "MachineAPI",
+                                    "Build",
+                                    "DeploymentConfig",
+                                    "ImageRegistry"
+                                ],
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "conditionalUpdates": {
+                    "description": "conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.",
+                    "items": {
+                        "description": "ConditionalUpdate represents an update which is recommended to some clusters on the version the current cluster is reconciling, but which may not be recommended for the current cluster.",
+                        "properties": {
+                            "conditions": {
+                                "description": "conditions represents the observations of the conditional update's current status. Known types are: * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules. * Recommended, for whether the update is recommended for the current cluster.",
+                                "items": {
+                                    "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                            "type": "string"
+                                        },
+                                        "observedGeneration": {
+                                            "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "reason": {
+                                            "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "lastTransitionTime",
+                                        "message",
+                                        "reason",
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "type"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                            },
+                            "release": {
+                                "description": "release is the target of the update.",
+                                "properties": {
+                                    "channels": {
+                                        "description": "channels is the set of Cincinnati channels to which the release currently belongs.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "image": {
+                                        "description": "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
+                                        "type": "string"
+                                    },
+                                    "url": {
+                                        "description": "url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.",
+                                        "type": "string"
+                                    },
+                                    "version": {
+                                        "description": "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "risks": {
+                                "description": "risks represents the range of issues associated with updating to the target release. The cluster-version operator will evaluate all entries, and only recommend the update if there is at least one entry and all entries recommend the update.",
+                                "items": {
+                                    "description": "ConditionalUpdateRisk represents a reason and cluster-state for not recommending a conditional update.",
+                                    "properties": {
+                                        "matchingRules": {
+                                            "description": "matchingRules is a slice of conditions for deciding which clusters match the risk and which do not. The slice is ordered by decreasing precedence. The cluster-version operator will walk the slice in order, and stop after the first it can successfully evaluate. If no condition can be successfully evaluated, the update will not be recommended.",
+                                            "items": {
+                                                "description": "ClusterCondition is a union of typed cluster conditions.  The 'type' property determines which of the type-specific properties are relevant. When evaluated on a cluster, the condition may match, not match, or fail to evaluate.",
+                                                "properties": {
+                                                    "promql": {
+                                                        "description": "promQL represents a cluster condition based on PromQL.",
+                                                        "properties": {
+                                                            "promql": {
+                                                                "description": "PromQL is a PromQL query classifying clusters. This query query should return a 1 in the match case and a 0 in the does-not-match case. Queries which return no time series, or which return values besides 0 or 1, are evaluation failures.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "promql"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type represents the cluster-condition type. This defines the members and semantics of any additional properties.",
+                                                        "enum": [
+                                                            "Always",
+                                                            "PromQL"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "minItems": 1,
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "message": {
+                                            "description": "message provides additional information about the risk of updating, in the event that matchingRules match the cluster state. This is only to be consumed by humans. It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.",
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "description": "url contains information about this risk.",
+                                            "format": "uri",
+                                            "minLength": 1,
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "matchingRules",
+                                        "message",
+                                        "name",
+                                        "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                            }
+                        },
+                        "required": [
+                            "release",
+                            "risks"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                },
+                "conditions": {
+                    "description": "conditions provides information about the cluster version. The condition \"Available\" is set to true if the desiredUpdate has been reached. The condition \"Progressing\" is set to true if an update is being applied. The condition \"Degraded\" is set to true if an update is currently blocked by a temporary or permanent error. Conditions are only valid for the current desiredUpdate when metadata.generation is equal to status.generation.",
+                    "items": {
+                        "description": "ClusterOperatorStatusCondition represents the state of the operator's managed and monitored components.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the time of the last update to the current status property.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "reason is the CamelCase reason for the condition's current status.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type specifies the aspect reported by this condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "desired": {
+                    "description": "desired is the version that the cluster is reconciling towards. If the cluster is not yet fully initialized desired will be set with the information available, which may be an image or a tag.",
+                    "properties": {
+                        "channels": {
+                            "description": "channels is the set of Cincinnati channels to which the release currently belongs.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "image": {
+                            "description": "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
+                            "type": "string"
+                        },
+                        "url": {
+                            "description": "url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.",
+                            "type": "string"
+                        },
+                        "version": {
+                            "description": "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "history": {
+                    "description": "history contains a list of the most recent versions applied to the cluster. This value may be empty during cluster startup, and then will be updated when a new update is being applied. The newest update is first in the list and it is ordered by recency. Updates in the history have state Completed if the rollout completed - if an update was failing or halfway applied the state will be Partial. Only a limited amount of update history is preserved.",
+                    "items": {
+                        "description": "UpdateHistory is a single attempted update to the cluster.",
+                        "properties": {
+                            "acceptedRisks": {
+                                "description": "acceptedRisks records risks which were accepted to initiate the update. For example, it may menition an Upgradeable=False or missing signature that was overriden via desiredUpdate.force, or an update that was initiated despite not being in the availableUpdates set of recommended update targets.",
+                                "type": "string"
+                            },
+                            "completionTime": {
+                                "description": "completionTime, if set, is when the update was fully applied. The update that is currently being applied will have a null completion time. Completion time will always be set for entries that are not the current update (usually to the started time of the next update).",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "image": {
+                                "description": "image is a container image location that contains the update. This value is always populated.",
+                                "type": "string"
+                            },
+                            "startedTime": {
+                                "description": "startedTime is the time at which the update was started.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "state reflects whether the update was fully applied. The Partial state indicates the update is not fully applied, while the Completed state indicates the update was successfully rolled out at least once (all parts of the update successfully applied).",
+                                "type": "string"
+                            },
+                            "verified": {
+                                "description": "verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted. Verified does not cover upgradeable checks that depend on the cluster state at the time when the update target was accepted.",
+                                "type": "boolean"
+                            },
+                            "version": {
+                                "description": "version is a semantic version identifying the update version. If the requested image does not define a version, or if a failure occurs retrieving the image, this value may be empty.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "completionTime",
+                            "image",
+                            "startedTime",
+                            "state",
+                            "verified"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration reports which version of the spec is being synced. If this value is not equal to metadata.generation, then the desired and conditions fields may represent a previous version.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "versionHash": {
+                    "description": "versionHash is a fingerprint of the content that the cluster will be updated with. It is used by the operator to avoid unnecessary work and is for internal use only.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "availableUpdates",
+                "desired",
+                "observedGeneration",
+                "versionHash"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "x-kubernetes-validations": [
+        {
+            "message": "the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability",
+            "rule": "has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'baremetal' in self.spec.capabilities.additionalEnabledCapabilities ? 'MachineAPI' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'MachineAPI' in self.status.capabilities.enabledCapabilities) : true"
+        }
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/config_imageregistry.operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/config_imageregistry.operator.openshift.io_v1.json
@@ -1,0 +1,1764 @@
+{
+    "description": "Config is the configuration object for a registry instance managed by the registry operator \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ImageRegistrySpec defines the specs for the running registry.",
+            "properties": {
+                "affinity": {
+                    "description": "affinity is a group of node affinity scheduling rules for the image registry pod(s).",
+                    "properties": {
+                        "nodeAffinity": {
+                            "description": "Describes node affinity scheduling rules for the pod.",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                            "preference": {
+                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "preference",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                    "properties": {
+                                        "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "items": {
+                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "nodeSelectorTerms"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAffinity": {
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "defaultRoute": {
+                    "description": "defaultRoute indicates whether an external facing route for the registry should be created using the default generated hostname.",
+                    "type": "boolean"
+                },
+                "disableRedirect": {
+                    "description": "disableRedirect controls whether to route all data through the Registry, rather than redirecting to the backend.",
+                    "type": "boolean"
+                },
+                "httpSecret": {
+                    "description": "httpSecret is the value needed by the registry to secure uploads, generated by default.",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "logging": {
+                    "description": "logging is deprecated, use logLevel instead.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "nodeSelector defines the node selection constraints for the registry pod.",
+                    "type": "object"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "proxy": {
+                    "description": "proxy defines the proxy to be used when calling master api, upstream registries, etc.",
+                    "properties": {
+                        "http": {
+                            "description": "http defines the proxy to be used by the image registry when accessing HTTP endpoints.",
+                            "type": "string"
+                        },
+                        "https": {
+                            "description": "https defines the proxy to be used by the image registry when accessing HTTPS endpoints.",
+                            "type": "string"
+                        },
+                        "noProxy": {
+                            "description": "noProxy defines a comma-separated list of host names that shouldn't go through any proxy.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "readOnly": {
+                    "description": "readOnly indicates whether the registry instance should reject attempts to push new images or delete existing ones.",
+                    "type": "boolean"
+                },
+                "replicas": {
+                    "description": "replicas determines the number of registry instances to run.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "requests": {
+                    "description": "requests controls how many parallel requests a given registry instance will handle before queuing additional requests.",
+                    "properties": {
+                        "read": {
+                            "description": "read defines limits for image registry's reads.",
+                            "properties": {
+                                "maxInQueue": {
+                                    "description": "maxInQueue sets the maximum queued api requests to the registry.",
+                                    "type": "integer"
+                                },
+                                "maxRunning": {
+                                    "description": "maxRunning sets the maximum in flight api requests to the registry.",
+                                    "type": "integer"
+                                },
+                                "maxWaitInQueue": {
+                                    "description": "maxWaitInQueue sets the maximum time a request can wait in the queue before being rejected.",
+                                    "format": "duration",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "write": {
+                            "description": "write defines limits for image registry's writes.",
+                            "properties": {
+                                "maxInQueue": {
+                                    "description": "maxInQueue sets the maximum queued api requests to the registry.",
+                                    "type": "integer"
+                                },
+                                "maxRunning": {
+                                    "description": "maxRunning sets the maximum in flight api requests to the registry.",
+                                    "type": "integer"
+                                },
+                                "maxWaitInQueue": {
+                                    "description": "maxWaitInQueue sets the maximum time a request can wait in the queue before being rejected.",
+                                    "format": "duration",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "resources": {
+                    "description": "resources defines the resource requests+limits for the registry pod.",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "limits": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        },
+                        "requests": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "rolloutStrategy": {
+                    "description": "rolloutStrategy defines rollout strategy for the image registry deployment.",
+                    "pattern": "^(RollingUpdate|Recreate)$",
+                    "type": "string"
+                },
+                "routes": {
+                    "description": "routes defines additional external facing routes which should be created for the registry.",
+                    "items": {
+                        "description": "ImageRegistryConfigRoute holds information on external route access to image registry.",
+                        "properties": {
+                            "hostname": {
+                                "description": "hostname for the route.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the route to be created.",
+                                "type": "string"
+                            },
+                            "secretName": {
+                                "description": "secretName points to secret containing the certificates to be used by the route.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "storage": {
+                    "description": "storage details for configuring registry storage, e.g. S3 bucket coordinates.",
+                    "properties": {
+                        "azure": {
+                            "description": "azure represents configuration that uses Azure Blob Storage.",
+                            "properties": {
+                                "accountName": {
+                                    "description": "accountName defines the account to be used by the registry.",
+                                    "type": "string"
+                                },
+                                "cloudName": {
+                                    "description": "cloudName is the name of the Azure cloud environment to be used by the registry. If empty, the operator will set it based on the infrastructure object.",
+                                    "type": "string"
+                                },
+                                "container": {
+                                    "description": "container defines Azure's container to be used by registry.",
+                                    "maxLength": 63,
+                                    "minLength": 3,
+                                    "pattern": "^[0-9a-z]+(-[0-9a-z]+)*$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "emptyDir": {
+                            "description": "emptyDir represents ephemeral storage on the pod's host node. WARNING: this storage cannot be used with more than 1 replica and is not suitable for production use. When the pod is removed from a node for any reason, the data in the emptyDir is deleted forever.",
+                            "type": "object"
+                        },
+                        "gcs": {
+                            "description": "gcs represents configuration that uses Google Cloud Storage.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "keyID": {
+                                    "description": "keyID is the KMS key ID to use for encryption. Optional, buckets are encrypted by default on GCP. This allows for the use of a custom encryption key.",
+                                    "type": "string"
+                                },
+                                "projectID": {
+                                    "description": "projectID is the Project ID of the GCP project that this bucket should be associated with.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region is the GCS location in which your bucket exists. Optional, will be set based on the installed GCS Region.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ibmcos": {
+                            "description": "ibmcos represents configuration that uses IBM Cloud Object Storage.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "description": "location is the IBM Cloud location in which your bucket exists. Optional, will be set based on the installed IBM Cloud location.",
+                                    "type": "string"
+                                },
+                                "resourceGroupName": {
+                                    "description": "resourceGroupName is the name of the IBM Cloud resource group that this bucket and its service instance is associated with. Optional, will be set based on the installed IBM Cloud resource group.",
+                                    "type": "string"
+                                },
+                                "resourceKeyCRN": {
+                                    "description": "resourceKeyCRN is the CRN of the IBM Cloud resource key that is created for the service instance. Commonly referred as a service credential and must contain HMAC type credentials. Optional, will be computed if not provided.",
+                                    "pattern": "^crn:.+:.+:.+:cloud-object-storage:.+:.+:.+:resource-key:.+$",
+                                    "type": "string"
+                                },
+                                "serviceInstanceCRN": {
+                                    "description": "serviceInstanceCRN is the CRN of the IBM Cloud Object Storage service instance that this bucket is associated with. Optional, will be computed if not provided.",
+                                    "pattern": "^crn:.+:.+:.+:cloud-object-storage:.+:.+:.+::$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "managementState": {
+                            "description": "managementState indicates if the operator manages the underlying storage unit. If Managed the operator will remove the storage when this operator gets Removed.",
+                            "pattern": "^(Managed|Unmanaged)$",
+                            "type": "string"
+                        },
+                        "oss": {
+                            "description": "Oss represents configuration that uses Alibaba Cloud Object Storage Service.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "Bucket is the bucket name in which you want to store the registry's data. About Bucket naming, more details you can look at the [official documentation](https://www.alibabacloud.com/help/doc-detail/257087.htm) Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default will be autogenerated in the form of <clusterid>-image-registry-<region>-<random string 27 chars>",
+                                    "maxLength": 63,
+                                    "minLength": 3,
+                                    "pattern": "^[0-9a-z]+(-[0-9a-z]+)*$",
+                                    "type": "string"
+                                },
+                                "encryption": {
+                                    "description": "Encryption specifies whether you would like your data encrypted on the server side. More details, you can look cat the [official documentation](https://www.alibabacloud.com/help/doc-detail/117914.htm)",
+                                    "properties": {
+                                        "kms": {
+                                            "description": "KMS (key management service) is an encryption type that holds the struct for KMS KeyID",
+                                            "properties": {
+                                                "keyID": {
+                                                    "description": "KeyID holds the KMS encryption key ID",
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "keyID"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "method": {
+                                            "default": "AES256",
+                                            "description": "Method defines the different encrytion modes available Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `AES256`.",
+                                            "enum": [
+                                                "KMS",
+                                                "AES256"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "endpointAccessibility": {
+                                    "default": "Internal",
+                                    "description": "EndpointAccessibility specifies whether the registry use the OSS VPC internal endpoint Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `Internal`.",
+                                    "enum": [
+                                        "Internal",
+                                        "Public",
+                                        ""
+                                    ],
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region is the Alibaba Cloud Region in which your bucket exists. For a list of regions, you can look at the [official documentation](https://www.alibabacloud.com/help/doc-detail/31837.html). Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default will be based on the installed Alibaba Cloud Region.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "pvc": {
+                            "description": "pvc represents configuration that uses a PersistentVolumeClaim.",
+                            "properties": {
+                                "claim": {
+                                    "description": "claim defines the Persisent Volume Claim's name to be used.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "s3": {
+                            "description": "s3 represents configuration that uses Amazon Simple Storage Service.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "cloudFront": {
+                                    "description": "cloudFront configures Amazon Cloudfront as the storage middleware in a registry.",
+                                    "properties": {
+                                        "baseURL": {
+                                            "description": "baseURL contains the SCHEME://HOST[/PATH] at which Cloudfront is served.",
+                                            "type": "string"
+                                        },
+                                        "duration": {
+                                            "description": "duration is the duration of the Cloudfront session.",
+                                            "format": "duration",
+                                            "type": "string"
+                                        },
+                                        "keypairID": {
+                                            "description": "keypairID is key pair ID provided by AWS.",
+                                            "type": "string"
+                                        },
+                                        "privateKey": {
+                                            "description": "privateKey points to secret containing the private key, provided by AWS.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "baseURL",
+                                        "keypairID",
+                                        "privateKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "encrypt": {
+                                    "description": "encrypt specifies whether the registry stores the image in encrypted format or not. Optional, defaults to false.",
+                                    "type": "boolean"
+                                },
+                                "keyID": {
+                                    "description": "keyID is the KMS key ID to use for encryption. Optional, Encrypt must be true, or this parameter is ignored.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region is the AWS region in which your bucket exists. Optional, will be set based on the installed AWS Region.",
+                                    "type": "string"
+                                },
+                                "regionEndpoint": {
+                                    "description": "regionEndpoint is the endpoint for S3 compatible storage services. It should be a valid URL with scheme, e.g. https://s3.example.com. Optional, defaults based on the Region that is provided.",
+                                    "type": "string"
+                                },
+                                "trustedCA": {
+                                    "description": "trustedCA is a reference to a config map containing a CA bundle. The image registry and its operator use certificates from this bundle to verify S3 server certificates. \n The namespace for the config map referenced by trustedCA is \"openshift-config\". The key for the bundle in the config map is \"ca-bundle.crt\".",
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the metadata.name of the referenced config map. This field must adhere to standard config map naming restrictions. The name must consist solely of alphanumeric characters, hyphens (-) and periods (.). It has a maximum length of 253 characters. If this field is not specified or is empty string, the default trust bundle will be used.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "virtualHostedStyle": {
+                                    "description": "virtualHostedStyle enables using S3 virtual hosted style bucket paths with a custom RegionEndpoint Optional, defaults to false.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "swift": {
+                            "description": "swift represents configuration that uses OpenStack Object Storage.",
+                            "properties": {
+                                "authURL": {
+                                    "description": "authURL defines the URL for obtaining an authentication token.",
+                                    "type": "string"
+                                },
+                                "authVersion": {
+                                    "description": "authVersion specifies the OpenStack Auth's version.",
+                                    "type": "string"
+                                },
+                                "container": {
+                                    "description": "container defines the name of Swift container where to store the registry's data.",
+                                    "type": "string"
+                                },
+                                "domain": {
+                                    "description": "domain specifies Openstack's domain name for Identity v3 API.",
+                                    "type": "string"
+                                },
+                                "domainID": {
+                                    "description": "domainID specifies Openstack's domain id for Identity v3 API.",
+                                    "type": "string"
+                                },
+                                "regionName": {
+                                    "description": "regionName defines Openstack's region in which container exists.",
+                                    "type": "string"
+                                },
+                                "tenant": {
+                                    "description": "tenant defines Openstack tenant name to be used by registry.",
+                                    "type": "string"
+                                },
+                                "tenantID": {
+                                    "description": "tenant defines Openstack tenant id to be used by registry.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tolerations": {
+                    "description": "tolerations defines the tolerations for the registry pod.",
+                    "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                        "properties": {
+                            "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                            },
+                            "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                            },
+                            "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                            },
+                            "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "topologySpreadConstraints": {
+                    "description": "topologySpreadConstraints specify how to spread matching pods among the given topology.",
+                    "items": {
+                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                        "properties": {
+                            "labelSelector": {
+                                "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                                "properties": {
+                                    "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                },
+                                                "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "matchLabels": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "maxSkew": {
+                                "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "minDomains": {
+                                "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "nodeAffinityPolicy": {
+                                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                "type": "string"
+                            },
+                            "topologyKey": {
+                                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                                "type": "string"
+                            },
+                            "whenUnsatisfiable": {
+                                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "maxSkew",
+                            "topologyKey",
+                            "whenUnsatisfiable"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "required": [
+                "replicas"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "ImageRegistryStatus reports image registry operational status.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "storage": {
+                    "description": "storage indicates the current applied storage configuration of the registry.",
+                    "properties": {
+                        "azure": {
+                            "description": "azure represents configuration that uses Azure Blob Storage.",
+                            "properties": {
+                                "accountName": {
+                                    "description": "accountName defines the account to be used by the registry.",
+                                    "type": "string"
+                                },
+                                "cloudName": {
+                                    "description": "cloudName is the name of the Azure cloud environment to be used by the registry. If empty, the operator will set it based on the infrastructure object.",
+                                    "type": "string"
+                                },
+                                "container": {
+                                    "description": "container defines Azure's container to be used by registry.",
+                                    "maxLength": 63,
+                                    "minLength": 3,
+                                    "pattern": "^[0-9a-z]+(-[0-9a-z]+)*$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "emptyDir": {
+                            "description": "emptyDir represents ephemeral storage on the pod's host node. WARNING: this storage cannot be used with more than 1 replica and is not suitable for production use. When the pod is removed from a node for any reason, the data in the emptyDir is deleted forever.",
+                            "type": "object"
+                        },
+                        "gcs": {
+                            "description": "gcs represents configuration that uses Google Cloud Storage.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "keyID": {
+                                    "description": "keyID is the KMS key ID to use for encryption. Optional, buckets are encrypted by default on GCP. This allows for the use of a custom encryption key.",
+                                    "type": "string"
+                                },
+                                "projectID": {
+                                    "description": "projectID is the Project ID of the GCP project that this bucket should be associated with.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region is the GCS location in which your bucket exists. Optional, will be set based on the installed GCS Region.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ibmcos": {
+                            "description": "ibmcos represents configuration that uses IBM Cloud Object Storage.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "description": "location is the IBM Cloud location in which your bucket exists. Optional, will be set based on the installed IBM Cloud location.",
+                                    "type": "string"
+                                },
+                                "resourceGroupName": {
+                                    "description": "resourceGroupName is the name of the IBM Cloud resource group that this bucket and its service instance is associated with. Optional, will be set based on the installed IBM Cloud resource group.",
+                                    "type": "string"
+                                },
+                                "resourceKeyCRN": {
+                                    "description": "resourceKeyCRN is the CRN of the IBM Cloud resource key that is created for the service instance. Commonly referred as a service credential and must contain HMAC type credentials. Optional, will be computed if not provided.",
+                                    "pattern": "^crn:.+:.+:.+:cloud-object-storage:.+:.+:.+:resource-key:.+$",
+                                    "type": "string"
+                                },
+                                "serviceInstanceCRN": {
+                                    "description": "serviceInstanceCRN is the CRN of the IBM Cloud Object Storage service instance that this bucket is associated with. Optional, will be computed if not provided.",
+                                    "pattern": "^crn:.+:.+:.+:cloud-object-storage:.+:.+:.+::$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "managementState": {
+                            "description": "managementState indicates if the operator manages the underlying storage unit. If Managed the operator will remove the storage when this operator gets Removed.",
+                            "pattern": "^(Managed|Unmanaged)$",
+                            "type": "string"
+                        },
+                        "oss": {
+                            "description": "Oss represents configuration that uses Alibaba Cloud Object Storage Service.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "Bucket is the bucket name in which you want to store the registry's data. About Bucket naming, more details you can look at the [official documentation](https://www.alibabacloud.com/help/doc-detail/257087.htm) Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default will be autogenerated in the form of <clusterid>-image-registry-<region>-<random string 27 chars>",
+                                    "maxLength": 63,
+                                    "minLength": 3,
+                                    "pattern": "^[0-9a-z]+(-[0-9a-z]+)*$",
+                                    "type": "string"
+                                },
+                                "encryption": {
+                                    "description": "Encryption specifies whether you would like your data encrypted on the server side. More details, you can look cat the [official documentation](https://www.alibabacloud.com/help/doc-detail/117914.htm)",
+                                    "properties": {
+                                        "kms": {
+                                            "description": "KMS (key management service) is an encryption type that holds the struct for KMS KeyID",
+                                            "properties": {
+                                                "keyID": {
+                                                    "description": "KeyID holds the KMS encryption key ID",
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "keyID"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "method": {
+                                            "default": "AES256",
+                                            "description": "Method defines the different encrytion modes available Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `AES256`.",
+                                            "enum": [
+                                                "KMS",
+                                                "AES256"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "endpointAccessibility": {
+                                    "default": "Internal",
+                                    "description": "EndpointAccessibility specifies whether the registry use the OSS VPC internal endpoint Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default is `Internal`.",
+                                    "enum": [
+                                        "Internal",
+                                        "Public",
+                                        ""
+                                    ],
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region is the Alibaba Cloud Region in which your bucket exists. For a list of regions, you can look at the [official documentation](https://www.alibabacloud.com/help/doc-detail/31837.html). Empty value means no opinion and the platform chooses the a default, which is subject to change over time. Currently the default will be based on the installed Alibaba Cloud Region.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "pvc": {
+                            "description": "pvc represents configuration that uses a PersistentVolumeClaim.",
+                            "properties": {
+                                "claim": {
+                                    "description": "claim defines the Persisent Volume Claim's name to be used.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "s3": {
+                            "description": "s3 represents configuration that uses Amazon Simple Storage Service.",
+                            "properties": {
+                                "bucket": {
+                                    "description": "bucket is the bucket name in which you want to store the registry's data. Optional, will be generated if not provided.",
+                                    "type": "string"
+                                },
+                                "cloudFront": {
+                                    "description": "cloudFront configures Amazon Cloudfront as the storage middleware in a registry.",
+                                    "properties": {
+                                        "baseURL": {
+                                            "description": "baseURL contains the SCHEME://HOST[/PATH] at which Cloudfront is served.",
+                                            "type": "string"
+                                        },
+                                        "duration": {
+                                            "description": "duration is the duration of the Cloudfront session.",
+                                            "format": "duration",
+                                            "type": "string"
+                                        },
+                                        "keypairID": {
+                                            "description": "keypairID is key pair ID provided by AWS.",
+                                            "type": "string"
+                                        },
+                                        "privateKey": {
+                                            "description": "privateKey points to secret containing the private key, provided by AWS.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                },
+                                                "optional": {
+                                                    "description": "Specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                }
+                                            },
+                                            "required": [
+                                                "key"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "required": [
+                                        "baseURL",
+                                        "keypairID",
+                                        "privateKey"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "encrypt": {
+                                    "description": "encrypt specifies whether the registry stores the image in encrypted format or not. Optional, defaults to false.",
+                                    "type": "boolean"
+                                },
+                                "keyID": {
+                                    "description": "keyID is the KMS key ID to use for encryption. Optional, Encrypt must be true, or this parameter is ignored.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region is the AWS region in which your bucket exists. Optional, will be set based on the installed AWS Region.",
+                                    "type": "string"
+                                },
+                                "regionEndpoint": {
+                                    "description": "regionEndpoint is the endpoint for S3 compatible storage services. It should be a valid URL with scheme, e.g. https://s3.example.com. Optional, defaults based on the Region that is provided.",
+                                    "type": "string"
+                                },
+                                "trustedCA": {
+                                    "description": "trustedCA is a reference to a config map containing a CA bundle. The image registry and its operator use certificates from this bundle to verify S3 server certificates. \n The namespace for the config map referenced by trustedCA is \"openshift-config\". The key for the bundle in the config map is \"ca-bundle.crt\".",
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the metadata.name of the referenced config map. This field must adhere to standard config map naming restrictions. The name must consist solely of alphanumeric characters, hyphens (-) and periods (.). It has a maximum length of 253 characters. If this field is not specified or is empty string, the default trust bundle will be used.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "virtualHostedStyle": {
+                                    "description": "virtualHostedStyle enables using S3 virtual hosted style bucket paths with a custom RegionEndpoint Optional, defaults to false.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "swift": {
+                            "description": "swift represents configuration that uses OpenStack Object Storage.",
+                            "properties": {
+                                "authURL": {
+                                    "description": "authURL defines the URL for obtaining an authentication token.",
+                                    "type": "string"
+                                },
+                                "authVersion": {
+                                    "description": "authVersion specifies the OpenStack Auth's version.",
+                                    "type": "string"
+                                },
+                                "container": {
+                                    "description": "container defines the name of Swift container where to store the registry's data.",
+                                    "type": "string"
+                                },
+                                "domain": {
+                                    "description": "domain specifies Openstack's domain name for Identity v3 API.",
+                                    "type": "string"
+                                },
+                                "domainID": {
+                                    "description": "domainID specifies Openstack's domain id for Identity v3 API.",
+                                    "type": "string"
+                                },
+                                "regionName": {
+                                    "description": "regionName defines Openstack's region in which container exists.",
+                                    "type": "string"
+                                },
+                                "tenant": {
+                                    "description": "tenant defines Openstack tenant name to be used by registry.",
+                                    "type": "string"
+                                },
+                                "tenantID": {
+                                    "description": "tenant defines Openstack tenant id to be used by registry.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "storageManaged": {
+                    "description": "storageManaged is deprecated, please refer to Storage.managementState",
+                    "type": "boolean"
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "storage",
+                "storageManaged"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/config_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/config_operator.openshift.io_v1.json
@@ -1,0 +1,164 @@
+{
+    "description": "Config specifies the behavior of the config operator which is responsible for creating the initial configuration of other components on the cluster.  The operator also handles installation, migration or synchronization of cloud configurations for AWS and Azure cloud based clusters \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the Config Operator.",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status defines the observed status of the Config Operator.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/config_samples.operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/config_samples.operator.openshift.io_v1.json
@@ -1,0 +1,142 @@
+{
+    "description": "Config contains the configuration and detailed condition status for the Samples Operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConfigSpec contains the desired configuration and state for the Samples Operator, controlling various behavior around the imagestreams and templates it creates/updates in the openshift namespace.",
+            "properties": {
+                "architectures": {
+                    "description": "architectures determine which hardware architecture(s) to install, where x86_64, ppc64le, and s390x are the only supported choices currently.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "managementState": {
+                    "description": "managementState is top level on/off type of switch for all operators. When \"Managed\", this operator processes config and manipulates the samples accordingly. When \"Unmanaged\", this operator ignores any updates to the resources it watches. When \"Removed\", it reacts that same wasy as it does if the Config object is deleted, meaning any ImageStreams or Templates it manages (i.e. it honors the skipped lists) and the registry secret are deleted, along with the ConfigMap in the operator's namespace that represents the last config used to manipulate the samples,",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "samplesRegistry": {
+                    "description": "samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.",
+                    "type": "string"
+                },
+                "skippedImagestreams": {
+                    "description": "skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "skippedTemplates": {
+                    "description": "skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "ConfigStatus contains the actual configuration in effect, as well as various details that describe the state of the Samples Operator.",
+            "properties": {
+                "architectures": {
+                    "description": "architectures determine which hardware architecture(s) to install, where x86_64 and ppc64le are the supported choices.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "conditions": {
+                    "description": "conditions represents the available maintenance status of the sample imagestreams and templates.",
+                    "items": {
+                        "description": "ConfigCondition captures various conditions of the Config as entries are processed.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastUpdateTime": {
+                                "description": "lastUpdateTime is the last time this condition was updated.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "reason is what caused the condition's last transition.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "managementState": {
+                    "description": "managementState reflects the current operational status of the on/off switch for the operator.  This operator compares the ManagementState as part of determining that we are turning the operator back on (i.e. \"Managed\") when it was previously \"Unmanaged\".",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "samplesRegistry": {
+                    "description": "samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.",
+                    "type": "string"
+                },
+                "skippedImagestreams": {
+                    "description": "skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "skippedTemplates": {
+                    "description": "skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "version": {
+                    "description": "version is the value of the operator's payload based version indicator when it was last successfully processed",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/console_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/console_config.openshift.io_v1.json
@@ -1,0 +1,52 @@
+{
+    "description": "Console holds cluster-wide configuration for the web console, including the logout URL, and reports the public URL of the console. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "authentication": {
+                    "description": "ConsoleAuthentication defines a list of optional configuration for console authentication.",
+                    "properties": {
+                        "logoutRedirect": {
+                            "description": "An optional, absolute URL to redirect web browsers to after logging out of the console. If not specified, it will redirect to the default login page. This is required when using an identity provider that supports single sign-on (SSO) such as: - OpenID (Keycloak, Azure) - RequestHeader (GSSAPI, SSPI, SAML) - OAuth (GitHub, GitLab, Google) Logging out of the console will destroy the user's token. The logoutRedirect provides the user the option to perform single logout (SLO) through the identity provider to destroy their single sign-on session.",
+                            "pattern": "^$|^((https):\\/\\/?)[^\\s()<>]+(?:\\([\\w\\d]+\\)|([^[:punct:]\\s]|\\/?))$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "consoleURL": {
+                    "description": "The URL for the console. This will be derived from the host for the route that is created for the console.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/console_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/console_operator.openshift.io_v1.json
@@ -1,0 +1,600 @@
+{
+    "description": "Console provides a means to configure an operator to manage the console. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleSpec is the specification of the desired behavior of the Console.",
+            "properties": {
+                "customization": {
+                    "description": "customization is used to optionally provide a small set of customization options to the web console.",
+                    "properties": {
+                        "addPage": {
+                            "description": "addPage allows customizing actions on the Add page in developer perspective.",
+                            "properties": {
+                                "disabledActions": {
+                                    "description": "disabledActions is a list of actions that are not shown to users. Each action in the list is represented by its ID.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "brand": {
+                            "description": "brand is the default branding of the web console which can be overridden by providing the brand field.  There is a limited set of specific brand options. This field controls elements of the console such as the logo. Invalid value will prevent a console rollout.",
+                            "enum": [
+                                "openshift",
+                                "okd",
+                                "online",
+                                "ocp",
+                                "dedicated",
+                                "azure",
+                                "OpenShift",
+                                "OKD",
+                                "Online",
+                                "OCP",
+                                "Dedicated",
+                                "Azure",
+                                "ROSA"
+                            ],
+                            "type": "string"
+                        },
+                        "customLogoFile": {
+                            "description": "customLogoFile replaces the default OpenShift logo in the masthead and about dialog. It is a reference to a ConfigMap in the openshift-config namespace. This can be created with a command like 'oc create configmap custom-logo --from-file=/path/to/file -n openshift-config'. Image size must be less than 1 MB due to constraints on the ConfigMap size. The ConfigMap key should include a file extension so that the console serves the file with the correct MIME type. Recommended logo specifications: Dimensions: Max height of 68px and max width of 200px SVG format preferred",
+                            "properties": {
+                                "key": {
+                                    "description": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "customProductName": {
+                            "description": "customProductName is the name that will be displayed in page titles, logo alt text, and the about dialog instead of the normal OpenShift product name.",
+                            "type": "string"
+                        },
+                        "developerCatalog": {
+                            "description": "developerCatalog allows to configure the shown developer catalog categories (filters) and types (sub-catalogs).",
+                            "properties": {
+                                "categories": {
+                                    "description": "categories which are shown in the developer catalog.",
+                                    "items": {
+                                        "description": "DeveloperConsoleCatalogCategory for the developer console catalog.",
+                                        "properties": {
+                                            "id": {
+                                                "description": "ID is an identifier used in the URL to enable deep linking in console. ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.",
+                                                "maxLength": 32,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9-_]+$",
+                                                "type": "string"
+                                            },
+                                            "label": {
+                                                "description": "label defines a category display label. It is required and must have 1-64 characters.",
+                                                "maxLength": 64,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "subcategories": {
+                                                "description": "subcategories defines a list of child categories.",
+                                                "items": {
+                                                    "description": "DeveloperConsoleCatalogCategoryMeta are the key identifiers of a developer catalog category.",
+                                                    "properties": {
+                                                        "id": {
+                                                            "description": "ID is an identifier used in the URL to enable deep linking in console. ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.",
+                                                            "maxLength": 32,
+                                                            "minLength": 1,
+                                                            "pattern": "^[A-Za-z0-9-_]+$",
+                                                            "type": "string"
+                                                        },
+                                                        "label": {
+                                                            "description": "label defines a category display label. It is required and must have 1-64 characters.",
+                                                            "maxLength": 64,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                        },
+                                                        "tags": {
+                                                            "description": "tags is a list of strings that will match the category. A selected category show all items which has at least one overlapping tag between category and item.",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "id",
+                                                        "label"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "tags": {
+                                                "description": "tags is a list of strings that will match the category. A selected category show all items which has at least one overlapping tag between category and item.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "id",
+                                            "label"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "types": {
+                                    "description": "types allows enabling or disabling of sub-catalog types that user can see in the Developer catalog. When omitted, all the sub-catalog types will be shown.",
+                                    "properties": {
+                                        "disabled": {
+                                            "description": "disabled is a list of developer catalog types (sub-catalogs IDs) that are not shown to users. Types (sub-catalogs) are added via console plugins, the available types (sub-catalog IDs) are available in the console on the cluster configuration page, or when editing the YAML in the console. Example: \"Devfile\", \"HelmChart\", \"BuilderImage\" If the list is empty or all the available sub-catalog types are added, then the complete developer catalog should be hidden.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "set"
+                                        },
+                                        "enabled": {
+                                            "description": "enabled is a list of developer catalog types (sub-catalogs IDs) that will be shown to users. Types (sub-catalogs) are added via console plugins, the available types (sub-catalog IDs) are available in the console on the cluster configuration page, or when editing the YAML in the console. Example: \"Devfile\", \"HelmChart\", \"BuilderImage\" If the list is non-empty, a new type will not be shown to the user until it is added to list. If the list is empty the complete developer catalog will be shown.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "set"
+                                        },
+                                        "state": {
+                                            "default": "Enabled",
+                                            "description": "state defines if a list of catalog types should be enabled or disabled.",
+                                            "enum": [
+                                                "Enabled",
+                                                "Disabled"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "state"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "enabled is forbidden when state is not Enabled",
+                                            "rule": "self.state == 'Enabled' ? true : !has(self.enabled)"
+                                        },
+                                        {
+                                            "message": "disabled is forbidden when state is not Disabled",
+                                            "rule": "self.state == 'Disabled' ? true : !has(self.disabled)"
+                                        }
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "documentationBaseURL": {
+                            "description": "documentationBaseURL links to external documentation are shown in various sections of the web console.  Providing documentationBaseURL will override the default documentation URL. Invalid value will prevent a console rollout.",
+                            "pattern": "^$|^((https):\\/\\/?)[^\\s()<>]+(?:\\([\\w\\d]+\\)|([^[:punct:]\\s]|\\/?))\\/$",
+                            "type": "string"
+                        },
+                        "perspectives": {
+                            "description": "perspectives allows enabling/disabling of perspective(s) that user can see in the Perspective switcher dropdown.",
+                            "items": {
+                                "description": "Perspective defines a perspective that cluster admins want to show/hide in the perspective switcher dropdown",
+                                "properties": {
+                                    "id": {
+                                        "description": "id defines the id of the perspective. Example: \"dev\", \"admin\". The available perspective ids can be found in the code snippet section next to the yaml editor. Incorrect or unknown ids will be ignored.",
+                                        "type": "string"
+                                    },
+                                    "pinnedResources": {
+                                        "description": "pinnedResources defines the list of default pinned resources that users will see on the perspective navigation if they have not customized these pinned resources themselves. The list of available Kubernetes resources could be read via `kubectl api-resources`. The console will also provide a configuration UI and a YAML snippet that will list the available resources that can be pinned to the navigation. Incorrect or unknown resources will be ignored.",
+                                        "items": {
+                                            "description": "PinnedResourceReference includes the group, version and type of resource",
+                                            "properties": {
+                                                "group": {
+                                                    "description": "group is the API Group of the Resource. Enter empty string for the core group. This value should consist of only lowercase alphanumeric characters, hyphens and periods. Example: \"\", \"apps\", \"build.openshift.io\", etc.",
+                                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                    "type": "string"
+                                                },
+                                                "resource": {
+                                                    "description": "resource is the type that is being referenced. It is normally the plural form of the resource kind in lowercase. This value should consist of only lowercase alphanumeric characters and hyphens. Example: \"deployments\", \"deploymentconfigs\", \"pods\", etc.",
+                                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                    "type": "string"
+                                                },
+                                                "version": {
+                                                    "description": "version is the API Version of the Resource. This value should consist of only lowercase alphanumeric characters. Example: \"v1\", \"v1beta1\", etc.",
+                                                    "pattern": "^[a-z0-9]+$",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "group",
+                                                "resource",
+                                                "version"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "maxItems": 100,
+                                        "type": "array"
+                                    },
+                                    "visibility": {
+                                        "description": "visibility defines the state of perspective along with access review checks if needed for that perspective.",
+                                        "properties": {
+                                            "accessReview": {
+                                                "description": "accessReview defines required and missing access review checks.",
+                                                "minProperties": 1,
+                                                "properties": {
+                                                    "missing": {
+                                                        "description": "missing defines a list of permission checks. The perspective will only be shown when at least one check fails. When omitted, the access review is skipped and the perspective will not be shown unless it is required to do so based on the configuration of the required access review list.",
+                                                        "items": {
+                                                            "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+                                                            "properties": {
+                                                                "group": {
+                                                                    "description": "Group is the API Group of the Resource.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "namespace": {
+                                                                    "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+                                                                    "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                    "description": "Resource is one of the existing resource types.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "subresource": {
+                                                                    "description": "Subresource is one of the existing resource types.  \"\" means none.",
+                                                                    "type": "string"
+                                                                },
+                                                                "verb": {
+                                                                    "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "version": {
+                                                                    "description": "Version is the API Version of the Resource.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "required": {
+                                                        "description": "required defines a list of permission checks. The perspective will only be shown when all checks are successful. When omitted, the access review is skipped and the perspective will not be shown unless it is required to do so based on the configuration of the missing access review list.",
+                                                        "items": {
+                                                            "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+                                                            "properties": {
+                                                                "group": {
+                                                                    "description": "Group is the API Group of the Resource.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "name": {
+                                                                    "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "namespace": {
+                                                                    "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+                                                                    "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                    "description": "Resource is one of the existing resource types.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "subresource": {
+                                                                    "description": "Subresource is one of the existing resource types.  \"\" means none.",
+                                                                    "type": "string"
+                                                                },
+                                                                "verb": {
+                                                                    "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                },
+                                                                "version": {
+                                                                    "description": "Version is the API Version of the Resource.  \"*\" means all.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "state": {
+                                                "description": "state defines the perspective is enabled or disabled or access review check is required.",
+                                                "enum": [
+                                                    "Enabled",
+                                                    "Disabled",
+                                                    "AccessReview"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "state"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                            {
+                                                "message": "accessReview configuration is required when state is AccessReview, and forbidden otherwise",
+                                                "rule": "self.state == 'AccessReview' ?  has(self.accessReview) : !has(self.accessReview)"
+                                            }
+                                        ],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "visibility"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                    {
+                                        "message": "pinnedResources is allowed only for dev and forbidden for other perspectives",
+                                        "rule": "has(self.id) && self.id != 'dev'? !has(self.pinnedResources) : true"
+                                    }
+                                ],
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "id"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                        },
+                        "projectAccess": {
+                            "description": "projectAccess allows customizing the available list of ClusterRoles in the Developer perspective Project access page which can be used by a project admin to specify roles to other users and restrict access within the project. If set, the list will replace the default ClusterRole options.",
+                            "properties": {
+                                "availableClusterRoles": {
+                                    "description": "availableClusterRoles is the list of ClusterRole names that are assignable to users through the project access tab.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "quickStarts": {
+                            "description": "quickStarts allows customization of available ConsoleQuickStart resources in console.",
+                            "properties": {
+                                "disabled": {
+                                    "description": "disabled is a list of ConsoleQuickStart resource names that are not shown to users.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "plugins": {
+                    "description": "plugins defines a list of enabled console plugin names.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "providers": {
+                    "description": "providers contains configuration for using specific service providers.",
+                    "properties": {
+                        "statuspage": {
+                            "description": "statuspage contains ID for statuspage.io page that provides status info about.",
+                            "properties": {
+                                "pageID": {
+                                    "description": "pageID is the unique ID assigned by Statuspage for your page. This must be a public page.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "route": {
+                    "description": "route contains hostname and secret reference that contains the serving certificate. If a custom route is specified, a new route will be created with the provided hostname, under which console will be available. In case of custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed. In case of custom hostname points to an arbitrary domain, manual DNS configurations steps are necessary. The default console route will be maintained to reserve the default hostname for console if the custom route is removed. If not specified, default route will be used. DEPRECATED",
+                    "properties": {
+                        "hostname": {
+                            "description": "hostname is the desired custom domain under which console will be available.",
+                            "type": "string"
+                        },
+                        "secret": {
+                            "description": "secret points to secret in the openshift-config namespace that contains custom certificate and key and needs to be created manually by the cluster admin. Referenced Secret is required to contain following key value pairs: - \"tls.crt\" - to specifies custom certificate - \"tls.key\" - to specifies private key of the custom certificate If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "ConsoleStatus defines the observed status of the Console.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consoleclidownload_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consoleclidownload_console.openshift.io_v1.json
@@ -1,0 +1,64 @@
+{
+    "description": "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleCLIDownloadSpec is the desired cli download configuration.",
+            "properties": {
+                "description": {
+                    "description": "description is the description of the CLI download (can include markdown).",
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "displayName is the display name of the CLI download.",
+                    "type": "string"
+                },
+                "links": {
+                    "description": "links is a list of objects that provide CLI download link details.",
+                    "items": {
+                        "properties": {
+                            "href": {
+                                "description": "href is the absolute secure URL for the link (must use https)",
+                                "pattern": "^https://",
+                                "type": "string"
+                            },
+                            "text": {
+                                "description": "text is the display text for the link",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "href"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "description",
+                "displayName",
+                "links"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consoleexternalloglink_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consoleexternalloglink_console.openshift.io_v1.json
@@ -1,0 +1,46 @@
+{
+    "description": "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleExternalLogLinkSpec is the desired log link configuration. The log link will appear on the logs tab of the pod details page.",
+            "properties": {
+                "hrefTemplate": {
+                    "description": "hrefTemplate is an absolute secure URL (must use https) for the log link including variables to be replaced. Variables are specified in the URL with the format ${variableName}, for instance, ${containerName} and will be replaced with the corresponding values from the resource. Resource is a pod. Supported variables are: - ${resourceName} - name of the resource which containes the logs - ${resourceUID} - UID of the resource which contains the logs - e.g. `11111111-2222-3333-4444-555555555555` - ${containerName} - name of the resource's container that contains the logs - ${resourceNamespace} - namespace of the resource that contains the logs - ${resourceNamespaceUID} - namespace UID of the resource that contains the logs - ${podLabels} - JSON representation of labels matching the pod with the logs - e.g. `{\"key1\":\"value1\",\"key2\":\"value2\"}` \n e.g., https://example.com/logs?resourceName=${resourceName}&containerName=${containerName}&resourceNamespace=${resourceNamespace}&podLabels=${podLabels}",
+                    "pattern": "^https://",
+                    "type": "string"
+                },
+                "namespaceFilter": {
+                    "description": "namespaceFilter is a regular expression used to restrict a log link to a matching set of namespaces (e.g., `^openshift-`). The string is converted into a regular expression using the JavaScript RegExp constructor. If not specified, links will be displayed for all the namespaces.",
+                    "type": "string"
+                },
+                "text": {
+                    "description": "text is the display text for the link",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "hrefTemplate",
+                "text"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consolelink_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consolelink_console.openshift.io_v1.json
@@ -1,0 +1,124 @@
+{
+    "description": "ConsoleLink is an extension for customizing OpenShift web console links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleLinkSpec is the desired console link configuration.",
+            "properties": {
+                "applicationMenu": {
+                    "description": "applicationMenu holds information about section and icon used for the link in the application menu, and it is applicable only when location is set to ApplicationMenu.",
+                    "properties": {
+                        "imageURL": {
+                            "description": "imageUrl is the URL for the icon used in front of the link in the application menu. The URL must be an HTTPS URL or a Data URI. The image should be square and will be shown at 24x24 pixels.",
+                            "type": "string"
+                        },
+                        "section": {
+                            "description": "section is the section of the application menu in which the link should appear. This can be any text that will appear as a subheading in the application menu dropdown. A new section will be created if the text does not match text of an existing section.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "section"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "href": {
+                    "description": "href is the absolute secure URL for the link (must use https)",
+                    "pattern": "^https://",
+                    "type": "string"
+                },
+                "location": {
+                    "description": "location determines which location in the console the link will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).",
+                    "pattern": "^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$",
+                    "type": "string"
+                },
+                "namespaceDashboard": {
+                    "description": "namespaceDashboard holds information about namespaces in which the dashboard link should appear, and it is applicable only when location is set to NamespaceDashboard. If not specified, the link will appear in all namespaces.",
+                    "properties": {
+                        "namespaceSelector": {
+                            "description": "namespaceSelector is used to select the Namespaces that should contain dashboard link by label. If the namespace labels match, dashboard link will be shown for the namespaces.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "namespaces": {
+                            "description": "namespaces is an array of namespace names in which the dashboard link should appear.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "text": {
+                    "description": "text is the display text for the link",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "href",
+                "location",
+                "text"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consolenotification_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consolenotification_console.openshift.io_v1.json
@@ -1,0 +1,69 @@
+{
+    "description": "ConsoleNotification is the extension for configuring openshift web console notifications. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleNotificationSpec is the desired console notification configuration.",
+            "properties": {
+                "backgroundColor": {
+                    "description": "backgroundColor is the color of the background for the notification as CSS data type color.",
+                    "type": "string"
+                },
+                "color": {
+                    "description": "color is the color of the text for the notification as CSS data type color.",
+                    "type": "string"
+                },
+                "link": {
+                    "description": "link is an object that holds notification link details.",
+                    "properties": {
+                        "href": {
+                            "description": "href is the absolute secure URL for the link (must use https)",
+                            "pattern": "^https://",
+                            "type": "string"
+                        },
+                        "text": {
+                            "description": "text is the display text for the link",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "href",
+                        "text"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "location": {
+                    "description": "location is the location of the notification in the console. Valid values are: \"BannerTop\", \"BannerBottom\", \"BannerTopBottom\".",
+                    "pattern": "^(BannerTop|BannerBottom|BannerTopBottom)$",
+                    "type": "string"
+                },
+                "text": {
+                    "description": "text is the visible text of the notification.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "text"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consoleplugin_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consoleplugin_console.openshift.io_v1.json
@@ -1,0 +1,199 @@
+{
+    "description": "ConsolePlugin is an extension for customizing OpenShift web console by dynamically loading code from another service running on the cluster. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsolePluginSpec is the desired plugin configuration.",
+            "properties": {
+                "backend": {
+                    "description": "backend holds the configuration of backend which is serving console's plugin .",
+                    "properties": {
+                        "service": {
+                            "description": "service is a Kubernetes Service that exposes the plugin using a deployment with an HTTP server. The Service must use HTTPS and Service serving certificate. The console backend will proxy the plugins assets from the Service using the service CA bundle.",
+                            "properties": {
+                                "basePath": {
+                                    "default": "/",
+                                    "description": "basePath is the path to the plugin's assets. The primary asset it the manifest file called `plugin-manifest.json`, which is a JSON document that contains metadata about the plugin and the extensions.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z0-9.\\-_~!$&'()*+,;=:@\\/]*$",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "name of Service that is serving the plugin assets.",
+                                    "maxLength": 128,
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "description": "namespace of Service that is serving the plugin assets.",
+                                    "maxLength": 128,
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                "port": {
+                                    "description": "port on which the Service that is serving the plugin is listening to.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "name",
+                                "namespace",
+                                "port"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the backend type which servers the console's plugin. Currently only \"Service\" is supported. \n ---",
+                            "enum": [
+                                "Service"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "displayName": {
+                    "description": "displayName is the display name of the plugin. The dispalyName should be between 1 and 128 characters.",
+                    "maxLength": 128,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "i18n": {
+                    "description": "i18n is the configuration of plugin's localization resources.",
+                    "properties": {
+                        "loadType": {
+                            "description": "loadType indicates how the plugin's localization resource should be loaded. Valid values are Preload, Lazy and the empty string. When set to Preload, all localization resources are fetched when the plugin is loaded. When set to Lazy, localization resources are lazily loaded as and when they are required by the console. When omitted or set to the empty string, the behaviour is equivalent to Lazy type.",
+                            "enum": [
+                                "Preload",
+                                "Lazy",
+                                ""
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "loadType"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "proxy": {
+                    "description": "proxy is a list of proxies that describe various service type to which the plugin needs to connect to.",
+                    "items": {
+                        "description": "ConsolePluginProxy holds information on various service types to which console's backend will proxy the plugin's requests.",
+                        "properties": {
+                            "alias": {
+                                "description": "alias is a proxy name that identifies the plugin's proxy. An alias name should be unique per plugin. The console backend exposes following proxy endpoint: \n /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters> \n Request example path: \n /api/proxy/plugin/acm/search/pods?namespace=openshift-apiserver",
+                                "maxLength": 128,
+                                "minLength": 1,
+                                "pattern": "^[A-Za-z0-9-_]+$",
+                                "type": "string"
+                            },
+                            "authorization": {
+                                "default": "None",
+                                "description": "authorization provides information about authorization type, which the proxied request should contain",
+                                "enum": [
+                                    "UserToken",
+                                    "None"
+                                ],
+                                "type": "string"
+                            },
+                            "caCertificate": {
+                                "description": "caCertificate provides the cert authority certificate contents, in case the proxied Service is using custom service CA. By default, the service CA bundle provided by the service-ca operator is used.",
+                                "pattern": "^-----BEGIN CERTIFICATE-----([\\s\\S]*)-----END CERTIFICATE-----\\s?$",
+                                "type": "string"
+                            },
+                            "endpoint": {
+                                "description": "endpoint provides information about endpoint to which the request is proxied to.",
+                                "properties": {
+                                    "service": {
+                                        "description": "service is an in-cluster Service that the plugin will connect to. The Service must use HTTPS. The console backend exposes an endpoint in order to proxy communication between the plugin and the Service. Note: service field is required for now, since currently only \"Service\" type is supported.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name of Service that the plugin needs to connect to.",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "namespace of Service that the plugin needs to connect to",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "port": {
+                                                "description": "port on which the Service that the plugin needs to connect to is listening on.",
+                                                "format": "int32",
+                                                "maximum": 65535,
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "namespace",
+                                            "port"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "type is the type of the console plugin's proxy. Currently only \"Service\" is supported. \n ---",
+                                        "enum": [
+                                            "Service"
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "alias",
+                            "endpoint"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "backend",
+                "displayName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consolequickstart_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consolequickstart_console.openshift.io_v1.json
@@ -1,0 +1,194 @@
+{
+    "description": "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleQuickStartSpec is the desired quick start configuration.",
+            "properties": {
+                "accessReviewResources": {
+                    "description": "accessReviewResources contains a list of resources that the user's access will be reviewed against in order for the user to complete the Quick Start. The Quick Start will be hidden if any of the access reviews fail.",
+                    "items": {
+                        "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+                        "properties": {
+                            "group": {
+                                "description": "Group is the API Group of the Resource.  \"*\" means all.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "Resource is one of the existing resource types.  \"*\" means all.",
+                                "type": "string"
+                            },
+                            "subresource": {
+                                "description": "Subresource is one of the existing resource types.  \"\" means none.",
+                                "type": "string"
+                            },
+                            "verb": {
+                                "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+                                "type": "string"
+                            },
+                            "version": {
+                                "description": "Version is the API Version of the Resource.  \"*\" means all.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "conclusion": {
+                    "description": "conclusion sums up the Quick Start and suggests the possible next steps. (includes markdown)",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "description is the description of the Quick Start. (includes markdown)",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "displayName is the display name of the Quick Start.",
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "durationMinutes": {
+                    "description": "durationMinutes describes approximately how many minutes it will take to complete the Quick Start.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "icon": {
+                    "description": "icon is a base64 encoded image that will be displayed beside the Quick Start display name. The icon should be an vector image for easy scaling. The size of the icon should be 40x40.",
+                    "type": "string"
+                },
+                "introduction": {
+                    "description": "introduction describes the purpose of the Quick Start. (includes markdown)",
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "nextQuickStart": {
+                    "description": "nextQuickStart is a list of the following Quick Starts, suggested for the user to try.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "prerequisites": {
+                    "description": "prerequisites contains all prerequisites that need to be met before taking a Quick Start. (includes markdown)",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tags": {
+                    "description": "tags is a list of strings that describe the Quick Start.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "tasks": {
+                    "description": "tasks is the list of steps the user has to perform to complete the Quick Start.",
+                    "items": {
+                        "description": "ConsoleQuickStartTask is a single step in a Quick Start.",
+                        "properties": {
+                            "description": {
+                                "description": "description describes the steps needed to complete the task. (includes markdown)",
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "review": {
+                                "description": "review contains instructions to validate the task is complete. The user will select 'Yes' or 'No'. using a radio button, which indicates whether the step was completed successfully.",
+                                "properties": {
+                                    "failedTaskHelp": {
+                                        "description": "failedTaskHelp contains suggestions for a failed task review and is shown at the end of task. (includes markdown)",
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "instructions": {
+                                        "description": "instructions contains steps that user needs to take in order to validate his work after going through a task. (includes markdown)",
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "failedTaskHelp",
+                                    "instructions"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "summary": {
+                                "description": "summary contains information about the passed step.",
+                                "properties": {
+                                    "failed": {
+                                        "description": "failed briefly describes the unsuccessfully passed task. (includes markdown)",
+                                        "maxLength": 128,
+                                        "minLength": 1,
+                                        "type": "string"
+                                    },
+                                    "success": {
+                                        "description": "success describes the succesfully passed task.",
+                                        "minLength": 1,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "failed",
+                                    "success"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "title": {
+                                "description": "title describes the task and is displayed as a step heading.",
+                                "minLength": 1,
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "description",
+                            "title"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "description",
+                "displayName",
+                "durationMinutes",
+                "introduction",
+                "tasks"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consolesample_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consolesample_console.openshift.io_v1.json
@@ -1,0 +1,205 @@
+{
+    "description": "ConsoleSample is an extension to customizing OpenShift web console by adding samples. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec contains configuration for a console sample.",
+            "properties": {
+                "abstract": {
+                    "description": "abstract is a short introduction to the sample. \n It is required and must be no more than 100 characters in length. \n The abstract is shown on the sample card tile below the title and provider and is limited to three lines of content.",
+                    "maxLength": 100,
+                    "type": "string"
+                },
+                "description": {
+                    "description": "description is a long form explanation of the sample. \n It is required and can have a maximum length of **4096** characters. \n It is a README.md-like content for additional information, links, pre-conditions, and other instructions. It will be rendered as Markdown so that it can contain line breaks, links, and other simple formatting.",
+                    "maxLength": 4096,
+                    "type": "string"
+                },
+                "icon": {
+                    "description": "icon is an optional base64 encoded image and shown beside the sample title. \n The format must follow the data: URL format and can have a maximum size of **10 KB**. \n data:[<mediatype>][;base64],<base64 encoded image> \n For example: \n data:image;base64,             plus the base64 encoded image. \n Vector images can also be used. SVG icons must start with: \n data:image/svg+xml;base64,     plus the base64 encoded SVG image. \n All sample catalog icons will be shown on a white background (also when the dark theme is used). The web console ensures that different aspect ratios work correctly. Currently, the surface of the icon is at most 40x100px. \n For more information on the data URL format, please visit https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs.",
+                    "maxLength": 14000,
+                    "pattern": "^data:([a-z/\\.+0-9]*;(([-a-zA-Z0-9=])*;)?)?base64,",
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "provider is an optional label to honor who provides the sample. \n It is optional and must be no more than 50 characters in length. \n A provider can be a company like \"Red Hat\" or an organization like \"CNCF\" or \"Knative\". \n Currently, the provider is only shown on the sample card tile below the title with the prefix \"Provided by \"",
+                    "maxLength": 50,
+                    "type": "string"
+                },
+                "source": {
+                    "description": "source defines where to deploy the sample service from. The sample may be sourced from an external git repository or container image.",
+                    "properties": {
+                        "containerImport": {
+                            "description": "containerImport allows the user import a container image.",
+                            "properties": {
+                                "image": {
+                                    "description": "reference to a container image that provides a HTTP service. The service must be exposed on the default port (8080) unless otherwise configured with the port field. \n Supported formats: - <repository-name>/<image-name> - docker.io/<repository-name>/<image-name> - quay.io/<repository-name>/<image-name> - quay.io/<repository-name>/<image-name>@sha256:<image hash> - quay.io/<repository-name>/<image-name>:<tag>",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                },
+                                "service": {
+                                    "default": {
+                                        "targetPort": 8080
+                                    },
+                                    "description": "service contains configuration for the Service resource created for this sample.",
+                                    "properties": {
+                                        "targetPort": {
+                                            "default": 8080,
+                                            "description": "targetPort is the port that the service listens on for HTTP requests. This port will be used for Service and Route created for this sample. Port must be in the range 1 to 65535. Default port is 8080.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "image"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "gitImport": {
+                            "description": "gitImport allows the user to import code from a git repository.",
+                            "properties": {
+                                "repository": {
+                                    "description": "repository contains the reference to the actual Git repository.",
+                                    "properties": {
+                                        "contextDir": {
+                                            "description": "contextDir is used to specify a directory within the repository to build the component. Must start with `/` and have a maximum length of 256 characters. When omitted, the default value is to build from the root of the repository.",
+                                            "maxLength": 256,
+                                            "pattern": "^/",
+                                            "type": "string"
+                                        },
+                                        "revision": {
+                                            "description": "revision is the git revision at which to clone the git repository Can be used to clone a specific branch, tag or commit SHA. Must be at most 256 characters in length. When omitted the repository's default branch is used.",
+                                            "maxLength": 256,
+                                            "type": "string"
+                                        },
+                                        "url": {
+                                            "description": "url of the Git repository that contains a HTTP service. The HTTP service must be exposed on the default port (8080) unless otherwise configured with the port field. \n Only public repositories on GitHub, GitLab and Bitbucket are currently supported: \n - https://github.com/<org>/<repository> - https://gitlab.com/<org>/<repository> - https://bitbucket.org/<org>/<repository> \n The url must have a maximum length of 256 characters.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^https:\\/\\/(github.com|gitlab.com|bitbucket.org)\\/[a-zA-Z0-9-]+\\/[a-zA-Z0-9-]+(.git)?$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "url"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "service": {
+                                    "default": {
+                                        "targetPort": 8080
+                                    },
+                                    "description": "service contains configuration for the Service resource created for this sample.",
+                                    "properties": {
+                                        "targetPort": {
+                                            "default": 8080,
+                                            "description": "targetPort is the port that the service listens on for HTTP requests. This port will be used for Service created for this sample. Port must be in the range 1 to 65535. Default port is 8080.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "repository"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "allOf": [
+                                {
+                                    "enum": [
+                                        "GitImport",
+                                        "ContainerImport"
+                                    ]
+                                },
+                                {
+                                    "enum": [
+                                        "GitImport",
+                                        "ContainerImport"
+                                    ]
+                                }
+                            ],
+                            "description": "type of the sample, currently supported: \"GitImport\";\"ContainerImport\"",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "source.gitImport is required when source.type is GitImport, and forbidden otherwise",
+                            "rule": "self.type == 'GitImport' ? has(self.gitImport) : !has(self.gitImport)"
+                        },
+                        {
+                            "message": "source.containerImport is required when source.type is ContainerImport, and forbidden otherwise",
+                            "rule": "self.type == 'ContainerImport' ? has(self.containerImport) : !has(self.containerImport)"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "tags": {
+                    "description": "tags are optional string values that can be used to find samples in the samples catalog. \n Examples of common tags may be \"Java\", \"Quarkus\", etc. \n They will be displayed on the samples details page.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "maxItems": 10,
+                    "type": "array",
+                    "x-kubernetes-list-type": "set"
+                },
+                "title": {
+                    "description": "title is the display name of the sample. \n It is required and must be no more than 50 characters in length.",
+                    "maxLength": 50,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type is an optional label to group multiple samples. \n It is optional and must be no more than 20 characters in length. \n Recommendation is a singular term like \"Builder Image\", \"Devfile\" or \"Serverless Function\". \n Currently, the type is shown a badge on the sample card tile in the top right corner.",
+                    "maxLength": 20,
+                    "type": "string"
+                }
+            },
+            "required": [
+                "abstract",
+                "description",
+                "source",
+                "title"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/consoleyamlsample_console.openshift.io_v1.json
+++ b/openshift/v4.14-strict/consoleyamlsample_console.openshift.io_v1.json
@@ -1,0 +1,70 @@
+{
+    "description": "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ConsoleYAMLSampleSpec is the desired YAML sample configuration. Samples will appear with their descriptions in a samples sidebar when creating a resources in the web console.",
+            "properties": {
+                "description": {
+                    "description": "description of the YAML sample.",
+                    "pattern": "^(.|\\s)*\\S(.|\\s)*$",
+                    "type": "string"
+                },
+                "snippet": {
+                    "description": "snippet indicates that the YAML sample is not the full YAML resource definition, but a fragment that can be inserted into the existing YAML document at the user's cursor.",
+                    "type": "boolean"
+                },
+                "targetResource": {
+                    "description": "targetResource contains apiVersion and kind of the resource YAML sample is representating.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "title": {
+                    "description": "title of the YAML sample.",
+                    "pattern": "^(.|\\s)*\\S(.|\\s)*$",
+                    "type": "string"
+                },
+                "yaml": {
+                    "description": "yaml is the YAML sample to display.",
+                    "pattern": "^(.|\\s)*\\S(.|\\s)*$",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "description",
+                "targetResource",
+                "title",
+                "yaml"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/containerruntimeconfig_machineconfiguration.openshift.io_v1.json
+++ b/openshift/v4.14-strict/containerruntimeconfig_machineconfiguration.openshift.io_v1.json
@@ -1,0 +1,148 @@
+{
+  "description": "ContainerRuntimeConfig describes a customized Container Runtime configuration.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "ContainerRuntimeConfigSpec defines the desired state of ContainerRuntimeConfig",
+      "type": "object",
+      "required": [
+        "containerRuntimeConfig"
+      ],
+      "properties": {
+        "containerRuntimeConfig": {
+          "description": "ContainerRuntimeConfiguration defines the tuneables of the container runtime. It's important to note that, since the fields of the ContainerRuntimeConfiguration are directly read by the upstream kubernetes golang client, the validation of those values is handled directly by that golang client which is outside of the controller for ContainerRuntimeConfiguration. Please ensure the valid values are used for those fields as invalid values may render cluster nodes unusable.",
+          "type": "object",
+          "properties": {
+            "logLevel": {
+              "description": "logLevel specifies the verbosity of the logs based on the level it is set to. Options are fatal, panic, error, warn, info, and debug.",
+              "type": "string"
+            },
+            "logSizeMax": {
+              "description": "logSizeMax specifies the Maximum size allowed for the container log file. Negative numbers indicate that no size limit is imposed. If it is positive, it must be >= 8192 to match/exceed conmon's read buffer.",
+              "type": "string"
+            },
+            "overlaySize": {
+              "description": "overlaySize specifies the maximum size of a container image. This flag can be used to set quota on the size of container images.",
+              "type": "string"
+            },
+            "pidsLimit": {
+              "description": "pidsLimit specifies the maximum number of processes allowed in a container",
+              "type": "integer",
+              "format": "int64"
+            },
+            "defaultRuntime": {
+              "description": "defaultRuntime is the name of the OCI runtime to be used as the default.",
+              "type": "string",
+              "pattern": "^$|^(runc|crun)$"
+            }
+          },
+          "additionalProperties": false
+        },
+        "machineConfigPoolSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "ContainerRuntimeConfigStatus defines the observed state of a ContainerRuntimeConfig",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "ContainerRuntimeConfigCondition defines the state of the ContainerRuntimeConfig",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the time of the last update to the current status object.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message provides additional information about the current condition. This is only to be consumed by humans.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.  Reasons are PascalCase",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type specifies the state of the operator's reconciliation functionality.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.14-strict/controlplanemachineset_machine.openshift.io_v1.json
+++ b/openshift/v4.14-strict/controlplanemachineset_machine.openshift.io_v1.json
@@ -1,0 +1,730 @@
+{
+    "description": "ControlPlaneMachineSet ensures that a specified number of control plane machine replicas are running at any given time. Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ControlPlaneMachineSet represents the configuration of the ControlPlaneMachineSet.",
+            "properties": {
+                "replicas": {
+                    "default": 3,
+                    "description": "Replicas defines how many Control Plane Machines should be created by this ControlPlaneMachineSet. This field is immutable and cannot be changed after cluster installation. The ControlPlaneMachineSet only operates with 3 or 5 node control planes, 3 and 5 are the only valid values for this field.",
+                    "enum": [
+                        3,
+                        5
+                    ],
+                    "format": "int32",
+                    "type": "integer",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "replicas is immutable",
+                            "rule": "self == oldSelf"
+                        }
+                    ],
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "selector": {
+                    "description": "Label selector for Machines. Existing Machines selected by this selector will be the ones affected by this ControlPlaneMachineSet. It must match the template's labels. This field is considered immutable after creation of the resource.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "selector is immutable",
+                            "rule": "self == oldSelf"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "state": {
+                    "default": "Inactive",
+                    "description": "State defines whether the ControlPlaneMachineSet is Active or Inactive. When Inactive, the ControlPlaneMachineSet will not take any action on the state of the Machines within the cluster. When Active, the ControlPlaneMachineSet will reconcile the Machines and will update the Machines as necessary. Once Active, a ControlPlaneMachineSet cannot be made Inactive. To prevent further action please remove the ControlPlaneMachineSet.",
+                    "enum": [
+                        "Active",
+                        "Inactive"
+                    ],
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "state cannot be changed once Active",
+                            "rule": "oldSelf != 'Active' || self == oldSelf"
+                        }
+                    ]
+                },
+                "strategy": {
+                    "default": {
+                        "type": "RollingUpdate"
+                    },
+                    "description": "Strategy defines how the ControlPlaneMachineSet will update Machines when it detects a change to the ProviderSpec.",
+                    "properties": {
+                        "type": {
+                            "default": "RollingUpdate",
+                            "description": "Type defines the type of update strategy that should be used when updating Machines owned by the ControlPlaneMachineSet. Valid values are \"RollingUpdate\" and \"OnDelete\". The current default value is \"RollingUpdate\".",
+                            "enum": [
+                                "RollingUpdate",
+                                "OnDelete"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "template": {
+                    "description": "Template describes the Control Plane Machines that will be created by this ControlPlaneMachineSet.",
+                    "properties": {
+                        "machineType": {
+                            "description": "MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.",
+                            "enum": [
+                                "machines_v1beta1_machine_openshift_io"
+                            ],
+                            "type": "string"
+                        },
+                        "machines_v1beta1_machine_openshift_io": {
+                            "description": "OpenShiftMachineV1Beta1Machine defines the template for creating Machines from the v1beta1.machine.openshift.io API group.",
+                            "properties": {
+                                "failureDomains": {
+                                    "description": "FailureDomains is the list of failure domains (sometimes called availability zones) in which the ControlPlaneMachineSet should balance the Control Plane Machines. This will be merged into the ProviderSpec given in the template. This field is optional on platforms that do not require placement information.",
+                                    "properties": {
+                                        "aws": {
+                                            "description": "AWS configures failure domain information for the AWS platform.",
+                                            "items": {
+                                                "description": "AWSFailureDomain configures failure domain information for the AWS platform.",
+                                                "minProperties": 1,
+                                                "properties": {
+                                                    "placement": {
+                                                        "description": "Placement configures the placement information for this instance.",
+                                                        "properties": {
+                                                            "availabilityZone": {
+                                                                "description": "AvailabilityZone is the availability zone of the instance.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "availabilityZone"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "subnet": {
+                                                        "description": "Subnet is a reference to the subnet to use for this instance.",
+                                                        "properties": {
+                                                            "arn": {
+                                                                "description": "ARN of resource.",
+                                                                "type": "string"
+                                                            },
+                                                            "filters": {
+                                                                "description": "Filters is a set of filters used to identify a resource.",
+                                                                "items": {
+                                                                    "description": "AWSResourceFilter is a filter used to identify an AWS resource",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "Name of the filter. Filter names are case-sensitive.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "Values includes one or more filter values. Filter values are case-sensitive.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "id": {
+                                                                "description": "ID of resource.",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "Type determines how the reference will fetch the AWS resource.",
+                                                                "enum": [
+                                                                    "ID",
+                                                                    "ARN",
+                                                                    "Filters"
+                                                                ],
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                            {
+                                                                "message": "id is required when type is ID, and forbidden otherwise",
+                                                                "rule": "has(self.type) && self.type == 'ID' ?  has(self.id) : !has(self.id)"
+                                                            },
+                                                            {
+                                                                "message": "arn is required when type is ARN, and forbidden otherwise",
+                                                                "rule": "has(self.type) && self.type == 'ARN' ?  has(self.arn) : !has(self.arn)"
+                                                            },
+                                                            {
+                                                                "message": "filters is required when type is Filters, and forbidden otherwise",
+                                                                "rule": "has(self.type) && self.type == 'Filters' ?  has(self.filters) : !has(self.filters)"
+                                                            }
+                                                        ],
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "azure": {
+                                            "description": "Azure configures failure domain information for the Azure platform.",
+                                            "items": {
+                                                "description": "AzureFailureDomain configures failure domain information for the Azure platform.",
+                                                "properties": {
+                                                    "subnet": {
+                                                        "description": "subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.",
+                                                        "maxLength": 80,
+                                                        "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9_])?$",
+                                                        "type": "string"
+                                                    },
+                                                    "zone": {
+                                                        "description": "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "zone"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "gcp": {
+                                            "description": "GCP configures failure domain information for the GCP platform.",
+                                            "items": {
+                                                "description": "GCPFailureDomain configures failure domain information for the GCP platform",
+                                                "properties": {
+                                                    "zone": {
+                                                        "description": "Zone is the zone in which the GCP machine provider will create the VM.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "zone"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "openstack": {
+                                            "description": "OpenStack configures failure domain information for the OpenStack platform.",
+                                            "items": {
+                                                "description": "OpenStackFailureDomain configures failure domain information for the OpenStack platform.",
+                                                "minProperties": 1,
+                                                "properties": {
+                                                    "availabilityZone": {
+                                                        "description": "availabilityZone is the nova availability zone in which the OpenStack machine provider will create the VM. If not specified, the VM will be created in the default availability zone specified in the nova configuration. Availability zone names must NOT contain : since it is used by admin users to specify hosts where instances are launched in server creation. Also, it must not contain spaces otherwise it will lead to node that belongs to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information. The maximum length of availability zone name is 63 as per labels limits.",
+                                                        "maxLength": 63,
+                                                        "minLength": 1,
+                                                        "pattern": "^[^: ]*$",
+                                                        "type": "string"
+                                                    },
+                                                    "rootVolume": {
+                                                        "description": "rootVolume contains settings that will be used by the OpenStack machine provider to create the root volume attached to the VM. If not specified, no root volume will be created.",
+                                                        "properties": {
+                                                            "availabilityZone": {
+                                                                "description": "availabilityZone specifies the Cinder availability zone where the root volume will be created. If not specifified, the root volume will be created in the availability zone specified by the volume type in the cinder configuration. If the volume type (configured in the OpenStack cluster) does not specify an availability zone, the root volume will be created in the default availability zone specified in the cinder configuration. See https://docs.openstack.org/cinder/latest/admin/availability-zone-type.html for more details. If the OpenStack cluster is deployed with the cross_az_attach configuration option set to false, the root volume will have to be in the same availability zone as the VM (defined by OpenStackFailureDomain.AvailabilityZone). Availability zone names must NOT contain spaces otherwise it will lead to volume that belongs to this availability zone register failure, see kubernetes/cloud-provider-openstack#1379 for further information. The maximum length of availability zone name is 63 as per labels limits.",
+                                                                "maxLength": 63,
+                                                                "minLength": 1,
+                                                                "pattern": "^[^ ]*$",
+                                                                "type": "string"
+                                                            },
+                                                            "volumeType": {
+                                                                "description": "volumeType specifies the type of the root volume that will be provisioned. The maximum length of a volume type name is 255 characters, as per the OpenStack limit.",
+                                                                "maxLength": 255,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "volumeType"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "rootVolume.availabilityZone is required when availabilityZone is set",
+                                                        "rule": "!has(self.availabilityZone) || !has(self.rootVolume) || has(self.rootVolume.availabilityZone)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "platform": {
+                                            "description": "Platform identifies the platform for which the FailureDomain represents. Currently supported values are AWS, Azure, and GCP.",
+                                            "enum": [
+                                                "",
+                                                "AWS",
+                                                "Azure",
+                                                "BareMetal",
+                                                "GCP",
+                                                "Libvirt",
+                                                "OpenStack",
+                                                "None",
+                                                "VSphere",
+                                                "oVirt",
+                                                "IBMCloud",
+                                                "KubeVirt",
+                                                "EquinixMetal",
+                                                "PowerVS",
+                                                "AlibabaCloud",
+                                                "Nutanix",
+                                                "External"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "platform"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "aws configuration is required when platform is AWS, and forbidden otherwise",
+                                            "rule": "has(self.platform) && self.platform == 'AWS' ?  has(self.aws) : !has(self.aws)"
+                                        },
+                                        {
+                                            "message": "azure configuration is required when platform is Azure, and forbidden otherwise",
+                                            "rule": "has(self.platform) && self.platform == 'Azure' ?  has(self.azure) : !has(self.azure)"
+                                        },
+                                        {
+                                            "message": "gcp configuration is required when platform is GCP, and forbidden otherwise",
+                                            "rule": "has(self.platform) && self.platform == 'GCP' ?  has(self.gcp) : !has(self.gcp)"
+                                        },
+                                        {
+                                            "message": "openstack configuration is required when platform is OpenStack, and forbidden otherwise",
+                                            "rule": "has(self.platform) && self.platform == 'OpenStack' ?  has(self.openstack) : !has(self.openstack)"
+                                        }
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "metadata": {
+                                    "description": "ObjectMeta is the standard object metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata Labels are required to match the ControlPlaneMachineSet selector.",
+                                    "properties": {
+                                        "annotations": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                                            "type": "object"
+                                        },
+                                        "labels": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels. This field must contain both the 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels, both with a value of 'master'. It must also contain a label with the key 'machine.openshift.io/cluster-api-cluster'.",
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                                {
+                                                    "message": "label 'machine.openshift.io/cluster-api-machine-role' is required, and must have value 'master'",
+                                                    "rule": "'machine.openshift.io/cluster-api-machine-role' in self && self['machine.openshift.io/cluster-api-machine-role'] == 'master'"
+                                                },
+                                                {
+                                                    "message": "label 'machine.openshift.io/cluster-api-machine-type' is required, and must have value 'master'",
+                                                    "rule": "'machine.openshift.io/cluster-api-machine-type' in self && self['machine.openshift.io/cluster-api-machine-type'] == 'master'"
+                                                },
+                                                {
+                                                    "message": "label 'machine.openshift.io/cluster-api-cluster' is required",
+                                                    "rule": "'machine.openshift.io/cluster-api-cluster' in self"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "labels"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "spec": {
+                                    "description": "Spec contains the desired configuration of the Control Plane Machines. The ProviderSpec within contains platform specific details for creating the Control Plane Machines. The ProviderSe should be complete apart from the platform specific failure domain field. This will be overriden when the Machines are created based on the FailureDomains field.",
+                                    "properties": {
+                                        "lifecycleHooks": {
+                                            "description": "LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.",
+                                            "properties": {
+                                                "preDrain": {
+                                                    "description": "PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.",
+                                                    "items": {
+                                                        "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                                                "maxLength": 256,
+                                                                "minLength": 3,
+                                                                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                                                "type": "string"
+                                                            },
+                                                            "owner": {
+                                                                "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                                                "maxLength": 512,
+                                                                "minLength": 3,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name",
+                                                            "owner"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-map-keys": [
+                                                        "name"
+                                                    ],
+                                                    "x-kubernetes-list-type": "map"
+                                                },
+                                                "preTerminate": {
+                                                    "description": "PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.",
+                                                    "items": {
+                                                        "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                                                "maxLength": 256,
+                                                                "minLength": 3,
+                                                                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                                                "type": "string"
+                                                            },
+                                                            "owner": {
+                                                                "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                                                "maxLength": 512,
+                                                                "minLength": 3,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name",
+                                                            "owner"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array",
+                                                    "x-kubernetes-list-map-keys": [
+                                                        "name"
+                                                    ],
+                                                    "x-kubernetes-list-type": "map"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "metadata": {
+                                            "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+                                            "properties": {
+                                                "annotations": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                                                    "type": "object"
+                                                },
+                                                "generateName": {
+                                                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                                    "type": "string"
+                                                },
+                                                "labels": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                                                    "type": "object"
+                                                },
+                                                "name": {
+                                                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                                    "type": "string"
+                                                },
+                                                "namespace": {
+                                                    "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                                                    "type": "string"
+                                                },
+                                                "ownerReferences": {
+                                                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                                    "items": {
+                                                        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "blockOwnerDeletion": {
+                                                                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "controller": {
+                                                                "description": "If true, this reference points to the managing controller.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "apiVersion",
+                                                            "kind",
+                                                            "name",
+                                                            "uid"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "providerID": {
+                                            "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                                            "type": "string"
+                                        },
+                                        "providerSpec": {
+                                            "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+                                            "properties": {
+                                                "value": {
+                                                    "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+                                                    "type": "object",
+                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "taints": {
+                                            "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+                                            "items": {
+                                                "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                                "properties": {
+                                                    "effect": {
+                                                        "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                        "type": "string"
+                                                    },
+                                                    "key": {
+                                                        "description": "Required. The taint key to be applied to a node.",
+                                                        "type": "string"
+                                                    },
+                                                    "timeAdded": {
+                                                        "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "The taint value corresponding to the taint key.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "effect",
+                                                    "key"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "required": [
+                                "metadata",
+                                "spec"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "machineType"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "machines_v1beta1_machine_openshift_io configuration is required when machineType is machines_v1beta1_machine_openshift_io, and forbidden otherwise",
+                            "rule": "has(self.machineType) && self.machineType == 'machines_v1beta1_machine_openshift_io' ?  has(self.machines_v1beta1_machine_openshift_io) : !has(self.machines_v1beta1_machine_openshift_io)"
+                        }
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "replicas",
+                "selector",
+                "template"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "ControlPlaneMachineSetStatus represents the status of the ControlPlaneMachineSet CRD.",
+            "properties": {
+                "conditions": {
+                    "description": "Conditions represents the observations of the ControlPlaneMachineSet's current state. Known .status.conditions.type are: Available, Degraded and Progressing.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "observedGeneration": {
+                    "description": "ObservedGeneration is the most recent generation observed for this ControlPlaneMachineSet. It corresponds to the ControlPlaneMachineSets's generation, which is updated on mutation by the API Server.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "ReadyReplicas is the number of Control Plane Machines created by the ControlPlaneMachineSet controller which are ready. Note that this value may be higher than the desired number of replicas while rolling updates are in-progress.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "replicas": {
+                    "description": "Replicas is the number of Control Plane Machines created by the ControlPlaneMachineSet controller. Note that during update operations this value may differ from the desired replica count.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unavailableReplicas": {
+                    "description": "UnavailableReplicas is the number of Control Plane Machines that are still required before the ControlPlaneMachineSet reaches the desired available capacity. When this value is non-zero, the number of ReadyReplicas is less than the desired Replicas.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "updatedReplicas": {
+                    "description": "UpdatedReplicas is the number of non-terminated Control Plane Machines created by the ControlPlaneMachineSet controller that have the desired provider spec and are ready. This value is set to 0 when a change is detected to the desired spec. When the update strategy is RollingUpdate, this will also coincide with starting the process of updating the Machines. When the update strategy is OnDelete, this value will remain at 0 until a user deletes an existing replica and its replacement has become ready.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/csisnapshotcontroller_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/csisnapshotcontroller_operator.openshift.io_v1.json
@@ -1,0 +1,164 @@
+{
+    "description": "CSISnapshotController provides a means to configure an operator to manage the CSI snapshots. `cluster` is the canonical name. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/datagather_insights.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/datagather_insights.openshift.io_v1alpha1.json
@@ -1,0 +1,381 @@
+{
+    "description": "DataGather provides data gather configuration options and status for the particular Insights data gathering. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "dataPolicy": {
+                    "description": "dataPolicy allows user to enable additional global obfuscation of the IP addresses and base domain in the Insights archive data. Valid values are \"ClearText\" and \"ObfuscateNetworking\". When set to ClearText the data is not obfuscated. When set to ObfuscateNetworking the IP addresses and the cluster domain name are obfuscated. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is ClearText.",
+                    "enum": [
+                        "",
+                        "ClearText",
+                        "ObfuscateNetworking"
+                    ],
+                    "type": "string"
+                },
+                "gatherers": {
+                    "description": "gatherers is a list of gatherers configurations. The particular gatherers IDs can be found at https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md. Run the following command to get the names of last active gatherers: \"oc get insightsoperators.operator.openshift.io cluster -o json | jq '.status.gatherStatus.gatherers[].name'\"",
+                    "items": {
+                        "description": "gathererConfig allows to configure specific gatherers",
+                        "properties": {
+                            "name": {
+                                "description": "name is the name of specific gatherer",
+                                "type": "string"
+                            },
+                            "state": {
+                                "description": "state allows you to configure specific gatherer. Valid values are \"Enabled\", \"Disabled\" and omitted. When omitted, this means no opinion and the platform is left to choose a reasonable default. The current default is Enabled.",
+                                "enum": [
+                                    "",
+                                    "Enabled",
+                                    "Disabled"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions provide details on the status of the gatherer job.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "dataGatherState": {
+                    "description": "dataGatherState reflects the current state of the data gathering process.",
+                    "enum": [
+                        "Running",
+                        "Completed",
+                        "Failed",
+                        "Pending"
+                    ],
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "dataGatherState cannot transition from Running to Pending",
+                            "rule": "!(oldSelf == 'Running' && self == 'Pending')"
+                        },
+                        {
+                            "message": "dataGatherState cannot transition from Completed to Pending",
+                            "rule": "!(oldSelf == 'Completed' && self == 'Pending')"
+                        },
+                        {
+                            "message": "dataGatherState cannot transition from Failed to Pending",
+                            "rule": "!(oldSelf == 'Failed' && self == 'Pending')"
+                        },
+                        {
+                            "message": "dataGatherState cannot transition from Completed to Running",
+                            "rule": "!(oldSelf == 'Completed' && self == 'Running')"
+                        },
+                        {
+                            "message": "dataGatherState cannot transition from Failed to Running",
+                            "rule": "!(oldSelf == 'Failed' && self == 'Running')"
+                        }
+                    ]
+                },
+                "finishTime": {
+                    "description": "finishTime is the time when Insights data gathering finished.",
+                    "format": "date-time",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "finishTime is immutable once set",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                },
+                "gatherers": {
+                    "description": "gatherers is a list of active gatherers (and their statuses) in the last gathering.",
+                    "items": {
+                        "description": "gathererStatus represents information about a particular data gatherer.",
+                        "properties": {
+                            "conditions": {
+                                "description": "conditions provide details on the status of each gatherer.",
+                                "items": {
+                                    "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                            "type": "string"
+                                        },
+                                        "observedGeneration": {
+                                            "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "reason": {
+                                            "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "lastTransitionTime",
+                                        "message",
+                                        "reason",
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "type"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                            },
+                            "lastGatherDuration": {
+                                "description": "lastGatherDuration represents the time spent gathering.",
+                                "pattern": "^([1-9][0-9]*(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the name of the gatherer.",
+                                "maxLength": 256,
+                                "minLength": 5,
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "conditions",
+                            "lastGatherDuration",
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "insightsReport": {
+                    "description": "insightsReport provides general Insights analysis results. When omitted, this means no data gathering has taken place yet or the corresponding Insights analysis (identified by \"insightsRequestID\") is not available.",
+                    "properties": {
+                        "downloadedAt": {
+                            "description": "downloadedAt is the time when the last Insights report was downloaded. An empty value means that there has not been any Insights report downloaded yet and it usually appears in disconnected clusters (or clusters when the Insights data gathering is disabled).",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "healthChecks": {
+                            "description": "healthChecks provides basic information about active Insights health checks in a cluster.",
+                            "items": {
+                                "description": "healthCheck represents an Insights health check attributes.",
+                                "properties": {
+                                    "advisorURI": {
+                                        "description": "advisorURI provides the URL link to the Insights Advisor.",
+                                        "pattern": "^https:\\/\\/\\S+",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "description provides basic description of the healtcheck.",
+                                        "maxLength": 2048,
+                                        "minLength": 10,
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+                                        "enum": [
+                                            "Enabled",
+                                            "Disabled"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "totalRisk": {
+                                        "description": "totalRisk of the healthcheck. Indicator of the total risk posed by the detected issue; combination of impact and likelihood. The values can be from 1 to 4, and the higher the number, the more important the issue.",
+                                        "format": "int32",
+                                        "maximum": 4,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "advisorURI",
+                                    "description",
+                                    "state",
+                                    "totalRisk"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        },
+                        "uri": {
+                            "description": "uri provides the URL link from which the report was downloaded.",
+                            "pattern": "^https:\\/\\/\\S+",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "insightsRequestID": {
+                    "description": "insightsRequestID is an Insights request ID to track the status of the Insights analysis (in console.redhat.com processing pipeline) for the corresponding Insights data archive.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "insightsRequestID is immutable once set",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                },
+                "relatedObjects": {
+                    "description": "relatedObjects is a list of resources which are useful when debugging or inspecting the data gathering Pod",
+                    "items": {
+                        "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the API Group of the Resource. Enter empty string for the core group. This value should consist of only lowercase alphanumeric characters, hyphens and periods. Example: \"\", \"apps\", \"build.openshift.io\", etc.",
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the referent.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace of the referent.",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the type that is being referenced. It is normally the plural form of the resource kind in lowercase. This value should consist of only lowercase alphanumeric characters and hyphens. Example: \"deployments\", \"deploymentconfigs\", \"pods\", etc.",
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "group",
+                            "name",
+                            "resource"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "startTime": {
+                    "description": "startTime is the time when Insights data gathering started.",
+                    "format": "date-time",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "startTime is immutable once set",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                }
+            },
+            "type": "object",
+            "x-kubernetes-validations": [
+                {
+                    "message": "cannot remove insightsRequestID attribute from status",
+                    "rule": "(!has(oldSelf.insightsRequestID) || has(self.insightsRequestID))"
+                },
+                {
+                    "message": "cannot remove startTime attribute from status",
+                    "rule": "(!has(oldSelf.startTime) || has(self.startTime))"
+                },
+                {
+                    "message": "cannot remove finishTime attribute from status",
+                    "rule": "(!has(oldSelf.finishTime) || has(self.finishTime))"
+                },
+                {
+                    "message": "cannot remove dataGatherState attribute from status",
+                    "rule": "(!has(oldSelf.dataGatherState) || has(self.dataGatherState))"
+                }
+            ],
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/deploymentconfig_apps.openshift.io_v1.json
+++ b/openshift/v4.14-strict/deploymentconfig_apps.openshift.io_v1.json
@@ -1,0 +1,8151 @@
+{
+    "description": "Deployment Configs define the template for a pod and manages deploying new images or configuration changes. A single deployment configuration is usually analogous to a single micro-service. Can support many different deployment patterns, including full restart, customizable rolling updates, and  fully custom behaviors, as well as pre- and post- deployment hooks. Each individual deployment is represented as a replication controller. \n A deployment is \"triggered\" when its configuration is changed or a tag in an Image Stream is changed. Triggers can be disabled to allow manual control over a deployment. The \"strategy\" determines how the deployment is carried out and may be changed at any time. The `latestVersion` field is updated when a new deployment is triggered by any means. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer). Deprecated: Use deployments or other means for declarative updates for pods instead.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec represents a desired deployment state and how to deploy to it.",
+            "properties": {
+                "minReadySeconds": {
+                    "description": "MinReadySeconds is the minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "paused": {
+                    "description": "Paused indicates that the deployment config is paused resulting in no new deployments on template changes or changes in the template caused by other triggers.",
+                    "type": "boolean"
+                },
+                "replicas": {
+                    "description": "Replicas is the number of desired replicas.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "revisionHistoryLimit": {
+                    "description": "RevisionHistoryLimit is the number of old ReplicationControllers to retain to allow for rollbacks. This field is a pointer to allow for differentiation between an explicit zero and not specified. Defaults to 10. (This only applies to DeploymentConfigs created via the new group API resource, not the legacy resource.)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "selector": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Selector is a label query over pods that should match the Replicas count.",
+                    "type": "object"
+                },
+                "strategy": {
+                    "description": "Strategy describes how a deployment is executed.",
+                    "properties": {
+                        "activeDeadlineSeconds": {
+                            "description": "ActiveDeadlineSeconds is the duration in seconds that the deployer pods for this deployment config may be active on a node before the system actively tries to terminate them.",
+                            "format": "int64",
+                            "type": "integer",
+                            "minimum": -9223372036854776000,
+                            "maximum": 9223372036854776000
+                        },
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Annotations is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
+                            "type": "object"
+                        },
+                        "customParams": {
+                            "description": "CustomParams are the input to the Custom deployment strategy, and may also be specified for the Recreate and Rolling strategies to customize the execution process that runs the deployment.",
+                            "properties": {
+                                "command": {
+                                    "description": "Command is optional and overrides CMD in the container Image.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "environment": {
+                                    "description": "Environment holds the environment which will be given to the container for Image.",
+                                    "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                "type": "string"
+                                            },
+                                            "valueFrom": {
+                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                "properties": {
+                                                    "configMapKeyRef": {
+                                                        "description": "Selects a key of a ConfigMap.",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key to select.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "fieldRef": {
+                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "Path of the field to select in the specified API version.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "fieldPath"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "resourceFieldRef": {
+                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                        "properties": {
+                                                            "containerName": {
+                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                                "description": "Required: resource to select",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "resource"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "secretKeyRef": {
+                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                        "properties": {
+                                                            "key": {
+                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            },
+                                                            "optional": {
+                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                "type": "boolean"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "key"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "image": {
+                                    "description": "Image specifies a container image which can carry out a deployment.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Labels is a set of key, value pairs added to custom deployer and lifecycle pre/post hook pods.",
+                            "type": "object"
+                        },
+                        "recreateParams": {
+                            "description": "RecreateParams are the input to the Recreate deployment strategy.",
+                            "properties": {
+                                "mid": {
+                                    "description": "Mid is a lifecycle hook which is executed while the deployment is scaled down to zero before the first new pod is created. All LifecycleHookFailurePolicy values are supported.",
+                                    "properties": {
+                                        "execNewPod": {
+                                            "description": "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Command is the action command and its arguments.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "containerName": {
+                                                    "description": "ContainerName is the name of a container in the deployment pod template whose container image will be used for the hook pod's container.",
+                                                    "type": "string"
+                                                },
+                                                "env": {
+                                                    "description": "Env is a set of environment variables to supply to the hook pod's container.",
+                                                    "items": {
+                                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                                "type": "string"
+                                                            },
+                                                            "valueFrom": {
+                                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                                "properties": {
+                                                                    "configMapKeyRef": {
+                                                                        "description": "Selects a key of a ConfigMap.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key to select.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "fieldRef": {
+                                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "secretKeyRef": {
+                                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "volumes": {
+                                                    "description": "Volumes is a list of named volumes from the pod template which should be copied to the hook pod. Volumes names not found in pod spec are ignored. An empty list means no volumes will be copied.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "command",
+                                                "containerName"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "failurePolicy": {
+                                            "description": "FailurePolicy specifies what action to take if the hook fails.",
+                                            "type": "string"
+                                        },
+                                        "tagImages": {
+                                            "description": "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+                                            "items": {
+                                                "description": "TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single container this value will be defaulted to the name of that container.",
+                                                        "type": "string"
+                                                    },
+                                                    "to": {
+                                                        "description": "To is the target ImageStreamTag to set the container's image onto.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                                "type": "string"
+                                                            },
+                                                            "resourceVersion": {
+                                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "containerName",
+                                                    "to"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "failurePolicy"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "post": {
+                                    "description": "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. All LifecycleHookFailurePolicy values are supported.",
+                                    "properties": {
+                                        "execNewPod": {
+                                            "description": "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Command is the action command and its arguments.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "containerName": {
+                                                    "description": "ContainerName is the name of a container in the deployment pod template whose container image will be used for the hook pod's container.",
+                                                    "type": "string"
+                                                },
+                                                "env": {
+                                                    "description": "Env is a set of environment variables to supply to the hook pod's container.",
+                                                    "items": {
+                                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                                "type": "string"
+                                                            },
+                                                            "valueFrom": {
+                                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                                "properties": {
+                                                                    "configMapKeyRef": {
+                                                                        "description": "Selects a key of a ConfigMap.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key to select.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "fieldRef": {
+                                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "secretKeyRef": {
+                                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "volumes": {
+                                                    "description": "Volumes is a list of named volumes from the pod template which should be copied to the hook pod. Volumes names not found in pod spec are ignored. An empty list means no volumes will be copied.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "command",
+                                                "containerName"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "failurePolicy": {
+                                            "description": "FailurePolicy specifies what action to take if the hook fails.",
+                                            "type": "string"
+                                        },
+                                        "tagImages": {
+                                            "description": "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+                                            "items": {
+                                                "description": "TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single container this value will be defaulted to the name of that container.",
+                                                        "type": "string"
+                                                    },
+                                                    "to": {
+                                                        "description": "To is the target ImageStreamTag to set the container's image onto.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                                "type": "string"
+                                                            },
+                                                            "resourceVersion": {
+                                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "containerName",
+                                                    "to"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "failurePolicy"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "pre": {
+                                    "description": "Pre is a lifecycle hook which is executed before the strategy manipulates the deployment. All LifecycleHookFailurePolicy values are supported.",
+                                    "properties": {
+                                        "execNewPod": {
+                                            "description": "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Command is the action command and its arguments.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "containerName": {
+                                                    "description": "ContainerName is the name of a container in the deployment pod template whose container image will be used for the hook pod's container.",
+                                                    "type": "string"
+                                                },
+                                                "env": {
+                                                    "description": "Env is a set of environment variables to supply to the hook pod's container.",
+                                                    "items": {
+                                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                                "type": "string"
+                                                            },
+                                                            "valueFrom": {
+                                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                                "properties": {
+                                                                    "configMapKeyRef": {
+                                                                        "description": "Selects a key of a ConfigMap.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key to select.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "fieldRef": {
+                                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "secretKeyRef": {
+                                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "volumes": {
+                                                    "description": "Volumes is a list of named volumes from the pod template which should be copied to the hook pod. Volumes names not found in pod spec are ignored. An empty list means no volumes will be copied.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "command",
+                                                "containerName"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "failurePolicy": {
+                                            "description": "FailurePolicy specifies what action to take if the hook fails.",
+                                            "type": "string"
+                                        },
+                                        "tagImages": {
+                                            "description": "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+                                            "items": {
+                                                "description": "TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single container this value will be defaulted to the name of that container.",
+                                                        "type": "string"
+                                                    },
+                                                    "to": {
+                                                        "description": "To is the target ImageStreamTag to set the container's image onto.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                                "type": "string"
+                                                            },
+                                                            "resourceVersion": {
+                                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "containerName",
+                                                    "to"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "failurePolicy"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "timeoutSeconds": {
+                                    "description": "TimeoutSeconds is the time to wait for updates before giving up. If the value is nil, a default will be used.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "resources": {
+                            "description": "Resources contains resource requirements to execute the deployment and any hooks.",
+                            "properties": {
+                                "claims": {
+                                    "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                    "items": {
+                                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "limits": {
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                },
+                                "requests": {
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "rollingParams": {
+                            "description": "RollingParams are the input to the Rolling deployment strategy.",
+                            "properties": {
+                                "intervalSeconds": {
+                                    "description": "IntervalSeconds is the time to wait between polling deployment status after update. If the value is nil, a default will be used.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "maxSurge": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "MaxSurge is the maximum number of pods that can be scheduled above the original number of pods. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. \n This cannot be 0 if MaxUnavailable is 0. By default, 25% is used. \n Example: when this is set to 30%, the new RC can be scaled up by 30% immediately when the rolling update starts. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of original pods.",
+                                    "x-kubernetes-int-or-string": true
+                                },
+                                "maxUnavailable": {
+                                    "anyOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "description": "MaxUnavailable is the maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%). Absolute number is calculated from percentage by rounding down. \n This cannot be 0 if MaxSurge is 0. By default, 25% is used. \n Example: when this is set to 30%, the old RC can be scaled down by 30% immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that at least 70% of original number of pods are available at all times during the update.",
+                                    "x-kubernetes-int-or-string": true
+                                },
+                                "post": {
+                                    "description": "Post is a lifecycle hook which is executed after the strategy has finished all deployment logic. All LifecycleHookFailurePolicy values are supported.",
+                                    "properties": {
+                                        "execNewPod": {
+                                            "description": "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Command is the action command and its arguments.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "containerName": {
+                                                    "description": "ContainerName is the name of a container in the deployment pod template whose container image will be used for the hook pod's container.",
+                                                    "type": "string"
+                                                },
+                                                "env": {
+                                                    "description": "Env is a set of environment variables to supply to the hook pod's container.",
+                                                    "items": {
+                                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                                "type": "string"
+                                                            },
+                                                            "valueFrom": {
+                                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                                "properties": {
+                                                                    "configMapKeyRef": {
+                                                                        "description": "Selects a key of a ConfigMap.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key to select.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "fieldRef": {
+                                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "secretKeyRef": {
+                                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "volumes": {
+                                                    "description": "Volumes is a list of named volumes from the pod template which should be copied to the hook pod. Volumes names not found in pod spec are ignored. An empty list means no volumes will be copied.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "command",
+                                                "containerName"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "failurePolicy": {
+                                            "description": "FailurePolicy specifies what action to take if the hook fails.",
+                                            "type": "string"
+                                        },
+                                        "tagImages": {
+                                            "description": "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+                                            "items": {
+                                                "description": "TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single container this value will be defaulted to the name of that container.",
+                                                        "type": "string"
+                                                    },
+                                                    "to": {
+                                                        "description": "To is the target ImageStreamTag to set the container's image onto.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                                "type": "string"
+                                                            },
+                                                            "resourceVersion": {
+                                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "containerName",
+                                                    "to"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "failurePolicy"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "pre": {
+                                    "description": "Pre is a lifecycle hook which is executed before the deployment process begins. All LifecycleHookFailurePolicy values are supported.",
+                                    "properties": {
+                                        "execNewPod": {
+                                            "description": "ExecNewPod specifies the options for a lifecycle hook backed by a pod.",
+                                            "properties": {
+                                                "command": {
+                                                    "description": "Command is the action command and its arguments.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "containerName": {
+                                                    "description": "ContainerName is the name of a container in the deployment pod template whose container image will be used for the hook pod's container.",
+                                                    "type": "string"
+                                                },
+                                                "env": {
+                                                    "description": "Env is a set of environment variables to supply to the hook pod's container.",
+                                                    "items": {
+                                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                                "type": "string"
+                                                            },
+                                                            "value": {
+                                                                "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                                "type": "string"
+                                                            },
+                                                            "valueFrom": {
+                                                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                                "properties": {
+                                                                    "configMapKeyRef": {
+                                                                        "description": "Selects a key of a ConfigMap.",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key to select.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "fieldRef": {
+                                                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                        "properties": {
+                                                                            "apiVersion": {
+                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "fieldPath": {
+                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "fieldPath"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resourceFieldRef": {
+                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                        "properties": {
+                                                                            "containerName": {
+                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "divisor": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "integer"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                "x-kubernetes-int-or-string": true
+                                                                            },
+                                                                            "resource": {
+                                                                                "description": "Required: resource to select",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "resource"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "secretKeyRef": {
+                                                                        "description": "Selects a key of a secret in the pod's namespace",
+                                                                        "properties": {
+                                                                            "key": {
+                                                                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "optional": {
+                                                                                "description": "Specify whether the Secret or its key must be defined",
+                                                                                "type": "boolean"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "key"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "volumes": {
+                                                    "description": "Volumes is a list of named volumes from the pod template which should be copied to the hook pod. Volumes names not found in pod spec are ignored. An empty list means no volumes will be copied.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "command",
+                                                "containerName"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "failurePolicy": {
+                                            "description": "FailurePolicy specifies what action to take if the hook fails.",
+                                            "type": "string"
+                                        },
+                                        "tagImages": {
+                                            "description": "TagImages instructs the deployer to tag the current image referenced under a container onto an image stream tag.",
+                                            "items": {
+                                                "description": "TagImageHook is a request to tag the image in a particular container onto an ImageStreamTag.",
+                                                "properties": {
+                                                    "containerName": {
+                                                        "description": "ContainerName is the name of a container in the deployment config whose image value will be used as the source of the tag. If there is only a single container this value will be defaulted to the name of that container.",
+                                                        "type": "string"
+                                                    },
+                                                    "to": {
+                                                        "description": "To is the target ImageStreamTag to set the container's image onto.",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "API version of the referent.",
+                                                                "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                                "type": "string"
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                            },
+                                                            "namespace": {
+                                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                                "type": "string"
+                                                            },
+                                                            "resourceVersion": {
+                                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                                "type": "string"
+                                                            },
+                                                            "uid": {
+                                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "containerName",
+                                                    "to"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "failurePolicy"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "timeoutSeconds": {
+                                    "description": "TimeoutSeconds is the time to wait for updates before giving up. If the value is nil, a default will be used.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "updatePeriodSeconds": {
+                                    "description": "UpdatePeriodSeconds is the time to wait between individual pod updates. If the value is nil, a default will be used.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "Type is the name of a deployment strategy.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "template": {
+                    "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected.",
+                    "properties": {
+                        "metadata": {
+                            "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "type": "object"
+                        },
+                        "spec": {
+                            "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                            "properties": {
+                                "activeDeadlineSeconds": {
+                                    "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "affinity": {
+                                    "description": "If specified, the pod's scheduling constraints",
+                                    "properties": {
+                                        "nodeAffinity": {
+                                            "description": "Describes node affinity scheduling rules for the pod.",
+                                            "properties": {
+                                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                                        "properties": {
+                                                            "preference": {
+                                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "A list of node selector requirements by node's labels.",
+                                                                        "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "The label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchFields": {
+                                                                        "description": "A list of node selector requirements by node's fields.",
+                                                                        "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "The label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "weight": {
+                                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "preference",
+                                                            "weight"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                                    "properties": {
+                                                        "nodeSelectorTerms": {
+                                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                                            "items": {
+                                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "A list of node selector requirements by node's labels.",
+                                                                        "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "The label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchFields": {
+                                                                        "description": "A list of node selector requirements by node's fields.",
+                                                                        "items": {
+                                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "The label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "nodeSelectorTerms"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "podAffinity": {
+                                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                            "properties": {
+                                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                        "properties": {
+                                                            "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                    "labelSelector": {
+                                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                                        "properties": {
+                                                                            "matchExpressions": {
+                                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                                "items": {
+                                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "description": "key is the label key that the selector applies to.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "values": {
+                                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "key",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                                "additionalProperties": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "namespaceSelector": {
+                                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                        "properties": {
+                                                                            "matchExpressions": {
+                                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                                "items": {
+                                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "description": "key is the label key that the selector applies to.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "values": {
+                                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "key",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                                "additionalProperties": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "namespaces": {
+                                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "topologyKey": {
+                                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "topologyKey"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "podAffinityTerm",
+                                                            "weight"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                                        "properties": {
+                                                            "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "topologyKey"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "podAntiAffinity": {
+                                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                            "properties": {
+                                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                                    "items": {
+                                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                                        "properties": {
+                                                            "podAffinityTerm": {
+                                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                                "properties": {
+                                                                    "labelSelector": {
+                                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                                        "properties": {
+                                                                            "matchExpressions": {
+                                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                                "items": {
+                                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "description": "key is the label key that the selector applies to.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "values": {
+                                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "key",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                                "additionalProperties": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "namespaceSelector": {
+                                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                        "properties": {
+                                                                            "matchExpressions": {
+                                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                                "items": {
+                                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "description": "key is the label key that the selector applies to.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "values": {
+                                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "key",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                                "additionalProperties": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "namespaces": {
+                                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "topologyKey": {
+                                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "topologyKey"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "weight": {
+                                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "podAffinityTerm",
+                                                            "weight"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                                    "items": {
+                                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                                        "properties": {
+                                                            "labelSelector": {
+                                                                "description": "A label query over a set of resources, in this case pods.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "namespaceSelector": {
+                                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                                "properties": {
+                                                                    "matchExpressions": {
+                                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                        "items": {
+                                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "description": "key is the label key that the selector applies to.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "operator": {
+                                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "values": {
+                                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                    "items": {
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "type": "array"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "operator"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "matchLabels": {
+                                                                        "additionalProperties": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                        "type": "object"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "namespaces": {
+                                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "topologyKey": {
+                                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "topologyKey"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "automountServiceAccountToken": {
+                                    "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                                    "type": "boolean"
+                                },
+                                "containers": {
+                                    "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                                    "items": {
+                                        "description": "A single application container that you want to run within a pod.",
+                                        "properties": {
+                                            "args": {
+                                                "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "env": {
+                                                "description": "List of environment variables to set in the container. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvVar represents an environment variable present in a Container.",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                            "type": "string"
+                                                        },
+                                                        "valueFrom": {
+                                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                            "properties": {
+                                                                "configMapKeyRef": {
+                                                                    "description": "Selects a key of a ConfigMap.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key to select.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "fieldRef": {
+                                                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                    "properties": {
+                                                                        "apiVersion": {
+                                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "fieldPath": {
+                                                                            "description": "Path of the field to select in the specified API version.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldPath"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "resourceFieldRef": {
+                                                                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                    "properties": {
+                                                                        "containerName": {
+                                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "divisor": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ],
+                                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                            "x-kubernetes-int-or-string": true
+                                                                        },
+                                                                        "resource": {
+                                                                            "description": "Required: resource to select",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "resource"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "secretKeyRef": {
+                                                                    "description": "Selects a key of a secret in the pod's namespace",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "envFrom": {
+                                                "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                                    "properties": {
+                                                        "configMapRef": {
+                                                            "description": "The ConfigMap to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the ConfigMap must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "prefix": {
+                                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "secretRef": {
+                                                            "description": "The Secret to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the Secret must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "image": {
+                                                "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                                "type": "string"
+                                            },
+                                            "imagePullPolicy": {
+                                                "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                                "type": "string"
+                                            },
+                                            "lifecycle": {
+                                                "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                                                "properties": {
+                                                    "postStart": {
+                                                        "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "preStop": {
+                                                        "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "livenessProbe": {
+                                                "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "ports": {
+                                                "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                                                "items": {
+                                                    "description": "ContainerPort represents a network port in a single container.",
+                                                    "properties": {
+                                                        "containerPort": {
+                                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "hostIP": {
+                                                            "description": "What host IP to bind the external port to.",
+                                                            "type": "string"
+                                                        },
+                                                        "hostPort": {
+                                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "name": {
+                                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                                            "type": "string"
+                                                        },
+                                                        "protocol": {
+                                                            "default": "TCP",
+                                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "containerPort"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "readinessProbe": {
+                                                "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "resizePolicy": {
+                                                "description": "Resources resize policy for the container.",
+                                                "items": {
+                                                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                                    "properties": {
+                                                        "resourceName": {
+                                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                                            "type": "string"
+                                                        },
+                                                        "restartPolicy": {
+                                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resourceName",
+                                                        "restartPolicy"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "resources": {
+                                                "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                "properties": {
+                                                    "claims": {
+                                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                                        "items": {
+                                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "limits": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    },
+                                                    "requests": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "securityContext": {
+                                                "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                                "properties": {
+                                                    "allowPrivilegeEscalation": {
+                                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "capabilities": {
+                                                        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "add": {
+                                                                "description": "Added capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "drop": {
+                                                                "description": "Removed capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "privileged": {
+                                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "procMount": {
+                                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnlyRootFilesystem": {
+                                                        "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsGroup": {
+                                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "runAsNonRoot": {
+                                                        "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsUser": {
+                                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "seLinuxOptions": {
+                                                        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "level": {
+                                                                "description": "Level is SELinux level label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "role": {
+                                                                "description": "Role is a SELinux role label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "Type is a SELinux type label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "user": {
+                                                                "description": "User is a SELinux user label that applies to the container.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "seccompProfile": {
+                                                        "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "localhostProfile": {
+                                                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "windowsOptions": {
+                                                        "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                                        "properties": {
+                                                            "gmsaCredentialSpec": {
+                                                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                                "type": "string"
+                                                            },
+                                                            "gmsaCredentialSpecName": {
+                                                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                                "type": "string"
+                                                            },
+                                                            "hostProcess": {
+                                                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "runAsUserName": {
+                                                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "startupProbe": {
+                                                "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "stdin": {
+                                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "stdinOnce": {
+                                                "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                                "type": "boolean"
+                                            },
+                                            "terminationMessagePath": {
+                                                "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "terminationMessagePolicy": {
+                                                "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "tty": {
+                                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "volumeDevices": {
+                                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                                "items": {
+                                                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                                    "properties": {
+                                                        "devicePath": {
+                                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "devicePath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "volumeMounts": {
+                                                "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                                "items": {
+                                                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                                    "properties": {
+                                                        "mountPath": {
+                                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                                            "type": "string"
+                                                        },
+                                                        "mountPropagation": {
+                                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "This must match the Name of a Volume.",
+                                                            "type": "string"
+                                                        },
+                                                        "readOnly": {
+                                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "subPath": {
+                                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                                            "type": "string"
+                                                        },
+                                                        "subPathExpr": {
+                                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "mountPath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "workingDir": {
+                                                "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "dnsConfig": {
+                                    "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
+                                    "properties": {
+                                        "nameservers": {
+                                            "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "options": {
+                                            "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                                            "items": {
+                                                "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Required.",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "searches": {
+                                            "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "dnsPolicy": {
+                                    "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+                                    "type": "string"
+                                },
+                                "enableServiceLinks": {
+                                    "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                                    "type": "boolean"
+                                },
+                                "ephemeralContainers": {
+                                    "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                                    "items": {
+                                        "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
+                                        "properties": {
+                                            "args": {
+                                                "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "env": {
+                                                "description": "List of environment variables to set in the container. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvVar represents an environment variable present in a Container.",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                            "type": "string"
+                                                        },
+                                                        "valueFrom": {
+                                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                            "properties": {
+                                                                "configMapKeyRef": {
+                                                                    "description": "Selects a key of a ConfigMap.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key to select.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "fieldRef": {
+                                                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                    "properties": {
+                                                                        "apiVersion": {
+                                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "fieldPath": {
+                                                                            "description": "Path of the field to select in the specified API version.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldPath"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "resourceFieldRef": {
+                                                                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                    "properties": {
+                                                                        "containerName": {
+                                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "divisor": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ],
+                                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                            "x-kubernetes-int-or-string": true
+                                                                        },
+                                                                        "resource": {
+                                                                            "description": "Required: resource to select",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "resource"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "secretKeyRef": {
+                                                                    "description": "Selects a key of a secret in the pod's namespace",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "envFrom": {
+                                                "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                                    "properties": {
+                                                        "configMapRef": {
+                                                            "description": "The ConfigMap to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the ConfigMap must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "prefix": {
+                                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "secretRef": {
+                                                            "description": "The Secret to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the Secret must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "image": {
+                                                "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                                                "type": "string"
+                                            },
+                                            "imagePullPolicy": {
+                                                "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                                "type": "string"
+                                            },
+                                            "lifecycle": {
+                                                "description": "Lifecycle is not allowed for ephemeral containers.",
+                                                "properties": {
+                                                    "postStart": {
+                                                        "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "preStop": {
+                                                        "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "livenessProbe": {
+                                                "description": "Probes are not allowed for ephemeral containers.",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                                                "type": "string"
+                                            },
+                                            "ports": {
+                                                "description": "Ports are not allowed for ephemeral containers.",
+                                                "items": {
+                                                    "description": "ContainerPort represents a network port in a single container.",
+                                                    "properties": {
+                                                        "containerPort": {
+                                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "hostIP": {
+                                                            "description": "What host IP to bind the external port to.",
+                                                            "type": "string"
+                                                        },
+                                                        "hostPort": {
+                                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "name": {
+                                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                                            "type": "string"
+                                                        },
+                                                        "protocol": {
+                                                            "default": "TCP",
+                                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "containerPort"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "readinessProbe": {
+                                                "description": "Probes are not allowed for ephemeral containers.",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "resizePolicy": {
+                                                "description": "Resources resize policy for the container.",
+                                                "items": {
+                                                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                                    "properties": {
+                                                        "resourceName": {
+                                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                                            "type": "string"
+                                                        },
+                                                        "restartPolicy": {
+                                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resourceName",
+                                                        "restartPolicy"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "resources": {
+                                                "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                                                "properties": {
+                                                    "claims": {
+                                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                                        "items": {
+                                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "limits": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    },
+                                                    "requests": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "securityContext": {
+                                                "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.",
+                                                "properties": {
+                                                    "allowPrivilegeEscalation": {
+                                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "capabilities": {
+                                                        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "add": {
+                                                                "description": "Added capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "drop": {
+                                                                "description": "Removed capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "privileged": {
+                                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "procMount": {
+                                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnlyRootFilesystem": {
+                                                        "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsGroup": {
+                                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "runAsNonRoot": {
+                                                        "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsUser": {
+                                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "seLinuxOptions": {
+                                                        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "level": {
+                                                                "description": "Level is SELinux level label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "role": {
+                                                                "description": "Role is a SELinux role label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "Type is a SELinux type label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "user": {
+                                                                "description": "User is a SELinux user label that applies to the container.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "seccompProfile": {
+                                                        "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "localhostProfile": {
+                                                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "windowsOptions": {
+                                                        "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                                        "properties": {
+                                                            "gmsaCredentialSpec": {
+                                                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                                "type": "string"
+                                                            },
+                                                            "gmsaCredentialSpecName": {
+                                                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                                "type": "string"
+                                                            },
+                                                            "hostProcess": {
+                                                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "runAsUserName": {
+                                                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "startupProbe": {
+                                                "description": "Probes are not allowed for ephemeral containers.",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "stdin": {
+                                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "stdinOnce": {
+                                                "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                                "type": "boolean"
+                                            },
+                                            "targetContainerName": {
+                                                "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. \n The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+                                                "type": "string"
+                                            },
+                                            "terminationMessagePath": {
+                                                "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "terminationMessagePolicy": {
+                                                "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "tty": {
+                                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "volumeDevices": {
+                                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                                "items": {
+                                                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                                    "properties": {
+                                                        "devicePath": {
+                                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "devicePath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "volumeMounts": {
+                                                "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+                                                "items": {
+                                                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                                    "properties": {
+                                                        "mountPath": {
+                                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                                            "type": "string"
+                                                        },
+                                                        "mountPropagation": {
+                                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "This must match the Name of a Volume.",
+                                                            "type": "string"
+                                                        },
+                                                        "readOnly": {
+                                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "subPath": {
+                                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                                            "type": "string"
+                                                        },
+                                                        "subPathExpr": {
+                                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "mountPath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "workingDir": {
+                                                "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "hostAliases": {
+                                    "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+                                    "items": {
+                                        "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                                        "properties": {
+                                            "hostnames": {
+                                                "description": "Hostnames for the above IP address.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "ip": {
+                                                "description": "IP address of the host file entry.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "hostIPC": {
+                                    "description": "Use the host's ipc namespace. Optional: Default to false.",
+                                    "type": "boolean"
+                                },
+                                "hostNetwork": {
+                                    "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+                                    "type": "boolean"
+                                },
+                                "hostPID": {
+                                    "description": "Use the host's pid namespace. Optional: Default to false.",
+                                    "type": "boolean"
+                                },
+                                "hostUsers": {
+                                    "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                                    "type": "boolean"
+                                },
+                                "hostname": {
+                                    "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                                    "type": "string"
+                                },
+                                "imagePullSecrets": {
+                                    "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                                    "items": {
+                                        "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "initContainers": {
+                                    "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                                    "items": {
+                                        "description": "A single application container that you want to run within a pod.",
+                                        "properties": {
+                                            "args": {
+                                                "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "command": {
+                                                "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "env": {
+                                                "description": "List of environment variables to set in the container. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvVar represents an environment variable present in a Container.",
+                                                    "properties": {
+                                                        "name": {
+                                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "value": {
+                                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                                            "type": "string"
+                                                        },
+                                                        "valueFrom": {
+                                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                                            "properties": {
+                                                                "configMapKeyRef": {
+                                                                    "description": "Selects a key of a ConfigMap.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key to select.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "fieldRef": {
+                                                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                                    "properties": {
+                                                                        "apiVersion": {
+                                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "fieldPath": {
+                                                                            "description": "Path of the field to select in the specified API version.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldPath"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "resourceFieldRef": {
+                                                                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                                    "properties": {
+                                                                        "containerName": {
+                                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "divisor": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ],
+                                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                            "x-kubernetes-int-or-string": true
+                                                                        },
+                                                                        "resource": {
+                                                                            "description": "Required: resource to select",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "resource"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "secretKeyRef": {
+                                                                    "description": "Selects a key of a secret in the pod's namespace",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "Specify whether the Secret or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "envFrom": {
+                                                "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                                "items": {
+                                                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                                    "properties": {
+                                                        "configMapRef": {
+                                                            "description": "The ConfigMap to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the ConfigMap must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "prefix": {
+                                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                                            "type": "string"
+                                                        },
+                                                        "secretRef": {
+                                                            "description": "The Secret to select from",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                    "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                    "description": "Specify whether the Secret must be defined",
+                                                                    "type": "boolean"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "image": {
+                                                "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                                "type": "string"
+                                            },
+                                            "imagePullPolicy": {
+                                                "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                                "type": "string"
+                                            },
+                                            "lifecycle": {
+                                                "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                                                "properties": {
+                                                    "postStart": {
+                                                        "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "preStop": {
+                                                        "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                                        "properties": {
+                                                            "exec": {
+                                                                "description": "Exec specifies the action to take.",
+                                                                "properties": {
+                                                                    "command": {
+                                                                        "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "httpGet": {
+                                                                "description": "HTTPGet specifies the http request to perform.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "httpHeaders": {
+                                                                        "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                        "items": {
+                                                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                            "properties": {
+                                                                                "name": {
+                                                                                    "description": "The header field name",
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "value": {
+                                                                                    "description": "The header field value",
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "name",
+                                                                                "value"
+                                                                            ],
+                                                                            "type": "object",
+                                                                            "additionalProperties": false
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "path": {
+                                                                        "description": "Path to access on the HTTP server.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    },
+                                                                    "scheme": {
+                                                                        "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "tcpSocket": {
+                                                                "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                                                "properties": {
+                                                                    "host": {
+                                                                        "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "port": {
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "integer"
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
+                                                                        ],
+                                                                        "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                        "x-kubernetes-int-or-string": true
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "port"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "livenessProbe": {
+                                                "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "ports": {
+                                                "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                                                "items": {
+                                                    "description": "ContainerPort represents a network port in a single container.",
+                                                    "properties": {
+                                                        "containerPort": {
+                                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "hostIP": {
+                                                            "description": "What host IP to bind the external port to.",
+                                                            "type": "string"
+                                                        },
+                                                        "hostPort": {
+                                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                                            "format": "int32",
+                                                            "type": "integer",
+                                                            "minimum": -2147483648,
+                                                            "maximum": 2147483647
+                                                        },
+                                                        "name": {
+                                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                                            "type": "string"
+                                                        },
+                                                        "protocol": {
+                                                            "default": "TCP",
+                                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "containerPort"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "readinessProbe": {
+                                                "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "resizePolicy": {
+                                                "description": "Resources resize policy for the container.",
+                                                "items": {
+                                                    "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                                    "properties": {
+                                                        "resourceName": {
+                                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                                            "type": "string"
+                                                        },
+                                                        "restartPolicy": {
+                                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "resourceName",
+                                                        "restartPolicy"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "resources": {
+                                                "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                "properties": {
+                                                    "claims": {
+                                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                                        "items": {
+                                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                            "properties": {
+                                                                "name": {
+                                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "name"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "limits": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    },
+                                                    "requests": {
+                                                        "additionalProperties": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "integer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                            "x-kubernetes-int-or-string": true
+                                                        },
+                                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "securityContext": {
+                                                "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                                "properties": {
+                                                    "allowPrivilegeEscalation": {
+                                                        "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "capabilities": {
+                                                        "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "add": {
+                                                                "description": "Added capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "drop": {
+                                                                "description": "Removed capabilities",
+                                                                "items": {
+                                                                    "description": "Capability represent POSIX capabilities type",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "privileged": {
+                                                        "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "procMount": {
+                                                        "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnlyRootFilesystem": {
+                                                        "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsGroup": {
+                                                        "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "runAsNonRoot": {
+                                                        "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "runAsUser": {
+                                                        "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "seLinuxOptions": {
+                                                        "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "level": {
+                                                                "description": "Level is SELinux level label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "role": {
+                                                                "description": "Role is a SELinux role label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "Type is a SELinux type label that applies to the container.",
+                                                                "type": "string"
+                                                            },
+                                                            "user": {
+                                                                "description": "User is a SELinux user label that applies to the container.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "seccompProfile": {
+                                                        "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                                        "properties": {
+                                                            "localhostProfile": {
+                                                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "windowsOptions": {
+                                                        "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                                        "properties": {
+                                                            "gmsaCredentialSpec": {
+                                                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                                "type": "string"
+                                                            },
+                                                            "gmsaCredentialSpecName": {
+                                                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                                "type": "string"
+                                                            },
+                                                            "hostProcess": {
+                                                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                                "type": "boolean"
+                                                            },
+                                                            "runAsUserName": {
+                                                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "startupProbe": {
+                                                "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                "properties": {
+                                                    "exec": {
+                                                        "description": "Exec specifies the action to take.",
+                                                        "properties": {
+                                                            "command": {
+                                                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "failureThreshold": {
+                                                        "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "grpc": {
+                                                        "description": "GRPC specifies an action involving a GRPC port.",
+                                                        "properties": {
+                                                            "port": {
+                                                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                                                "format": "int32",
+                                                                "type": "integer",
+                                                                "minimum": -2147483648,
+                                                                "maximum": 2147483647
+                                                            },
+                                                            "service": {
+                                                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port",
+                                                            "service"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "httpGet": {
+                                                        "description": "HTTPGet specifies the http request to perform.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                                "type": "string"
+                                                            },
+                                                            "httpHeaders": {
+                                                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                                "items": {
+                                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                                    "properties": {
+                                                                        "name": {
+                                                                            "description": "The header field name",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                            "description": "The header field value",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "name",
+                                                                        "value"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "path": {
+                                                                "description": "Path to access on the HTTP server.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "scheme": {
+                                                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "initialDelaySeconds": {
+                                                        "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "periodSeconds": {
+                                                        "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "successThreshold": {
+                                                        "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "tcpSocket": {
+                                                        "description": "TCPSocket specifies an action involving a TCP port.",
+                                                        "properties": {
+                                                            "host": {
+                                                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                                "type": "string"
+                                                            },
+                                                            "port": {
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "integer"
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
+                                                                ],
+                                                                "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                                "x-kubernetes-int-or-string": true
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "port"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "terminationGracePeriodSeconds": {
+                                                        "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "timeoutSeconds": {
+                                                        "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "stdin": {
+                                                "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "stdinOnce": {
+                                                "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                                "type": "boolean"
+                                            },
+                                            "terminationMessagePath": {
+                                                "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "terminationMessagePolicy": {
+                                                "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                                "type": "string"
+                                            },
+                                            "tty": {
+                                                "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                                "type": "boolean"
+                                            },
+                                            "volumeDevices": {
+                                                "description": "volumeDevices is the list of block devices to be used by the container.",
+                                                "items": {
+                                                    "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                                    "properties": {
+                                                        "devicePath": {
+                                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "devicePath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "volumeMounts": {
+                                                "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                                "items": {
+                                                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                                    "properties": {
+                                                        "mountPath": {
+                                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                                            "type": "string"
+                                                        },
+                                                        "mountPropagation": {
+                                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "This must match the Name of a Volume.",
+                                                            "type": "string"
+                                                        },
+                                                        "readOnly": {
+                                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                                            "type": "boolean"
+                                                        },
+                                                        "subPath": {
+                                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                                            "type": "string"
+                                                        },
+                                                        "subPathExpr": {
+                                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "mountPath",
+                                                        "name"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "workingDir": {
+                                                "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "nodeName": {
+                                    "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+                                    "type": "string"
+                                },
+                                "nodeSelector": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                    "type": "object"
+                                },
+                                "os": {
+                                    "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
+                                    "properties": {
+                                        "name": {
+                                            "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "overhead": {
+                                    "additionalProperties": {
+                                        "anyOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                    },
+                                    "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+                                    "type": "object"
+                                },
+                                "preemptionPolicy": {
+                                    "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+                                    "type": "string"
+                                },
+                                "priority": {
+                                    "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "minimum": -2147483648,
+                                    "maximum": 2147483647
+                                },
+                                "priorityClassName": {
+                                    "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                                    "type": "string"
+                                },
+                                "readinessGates": {
+                                    "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                                    "items": {
+                                        "description": "PodReadinessGate contains the reference to a pod condition",
+                                        "properties": {
+                                            "conditionType": {
+                                                "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "conditionType"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "resourceClaims": {
+                                    "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable.",
+                                    "items": {
+                                        "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                                                "type": "string"
+                                            },
+                                            "source": {
+                                                "description": "Source describes where to find the ResourceClaim.",
+                                                "properties": {
+                                                    "resourceClaimName": {
+                                                        "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.",
+                                                        "type": "string"
+                                                    },
+                                                    "resourceClaimTemplateName": {
+                                                        "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod. \n The template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The name of the ResourceClaim will be <pod name>-<resource name>, where <resource name> is the PodResourceClaim.Name. Pod validation will reject the pod if the concatenated name is not valid for a ResourceClaim (e.g. too long). \n An existing ResourceClaim with that name that is not owned by the pod will not be used for the pod to avoid using an unrelated resource by mistake. Scheduling and pod startup are then blocked until the unrelated ResourceClaim is removed. \n This field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "restartPolicy": {
+                                    "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                                    "type": "string"
+                                },
+                                "runtimeClassName": {
+                                    "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+                                    "type": "string"
+                                },
+                                "schedulerName": {
+                                    "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                                    "type": "string"
+                                },
+                                "schedulingGates": {
+                                    "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod. \n SchedulingGates can only be set at pod creation time, and be removed only afterwards. \n This is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                                    "items": {
+                                        "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "securityContext": {
+                                    "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
+                                    "properties": {
+                                        "fsGroup": {
+                                            "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "fsGroupChangePolicy": {
+                                            "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                                            "type": "string"
+                                        },
+                                        "runAsGroup": {
+                                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "runAsNonRoot": {
+                                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                            "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "seLinuxOptions": {
+                                            "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                            "properties": {
+                                                "level": {
+                                                    "description": "Level is SELinux level label that applies to the container.",
+                                                    "type": "string"
+                                                },
+                                                "role": {
+                                                    "description": "Role is a SELinux role label that applies to the container.",
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "description": "Type is a SELinux type label that applies to the container.",
+                                                    "type": "string"
+                                                },
+                                                "user": {
+                                                    "description": "User is a SELinux user label that applies to the container.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "seccompProfile": {
+                                            "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                                            "properties": {
+                                                "localhostProfile": {
+                                                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "supplementalGroups": {
+                                            "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.",
+                                            "items": {
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "minimum": -9223372036854776000,
+                                                "maximum": 9223372036854776000
+                                            },
+                                            "type": "array"
+                                        },
+                                        "sysctls": {
+                                            "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                                            "items": {
+                                                "description": "Sysctl defines a kernel parameter to be set",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name of a property to set",
+                                                        "type": "string"
+                                                    },
+                                                    "value": {
+                                                        "description": "Value of a property to set",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "value"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "windowsOptions": {
+                                            "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                            "properties": {
+                                                "gmsaCredentialSpec": {
+                                                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                                    "type": "string"
+                                                },
+                                                "gmsaCredentialSpecName": {
+                                                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                                    "type": "string"
+                                                },
+                                                "hostProcess": {
+                                                    "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                                    "type": "boolean"
+                                                },
+                                                "runAsUserName": {
+                                                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "serviceAccount": {
+                                    "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                                    "type": "string"
+                                },
+                                "serviceAccountName": {
+                                    "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                                    "type": "string"
+                                },
+                                "setHostnameAsFQDN": {
+                                    "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+                                    "type": "boolean"
+                                },
+                                "shareProcessNamespace": {
+                                    "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+                                    "type": "boolean"
+                                },
+                                "subdomain": {
+                                    "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+                                    "type": "string"
+                                },
+                                "terminationGracePeriodSeconds": {
+                                    "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+                                    "format": "int64",
+                                    "type": "integer",
+                                    "minimum": -9223372036854776000,
+                                    "maximum": 9223372036854776000
+                                },
+                                "tolerations": {
+                                    "description": "If specified, the pod's tolerations.",
+                                    "items": {
+                                        "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                        "properties": {
+                                            "effect": {
+                                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                "type": "string"
+                                            },
+                                            "key": {
+                                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                                "type": "string"
+                                            },
+                                            "tolerationSeconds": {
+                                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "minimum": -9223372036854776000,
+                                                "maximum": 9223372036854776000
+                                            },
+                                            "value": {
+                                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "topologySpreadConstraints": {
+                                    "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+                                    "items": {
+                                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "matchLabelKeys": {
+                                                "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "maxSkew": {
+                                                "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            },
+                                            "minDomains": {
+                                                "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            },
+                                            "nodeAffinityPolicy": {
+                                                "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                                "type": "string"
+                                            },
+                                            "nodeTaintsPolicy": {
+                                                "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                                "type": "string"
+                                            },
+                                            "topologyKey": {
+                                                "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                                                "type": "string"
+                                            },
+                                            "whenUnsatisfiable": {
+                                                "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "maxSkew",
+                                            "topologyKey",
+                                            "whenUnsatisfiable"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "volumes": {
+                                    "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                    "items": {
+                                        "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                                        "properties": {
+                                            "awsElasticBlockStore": {
+                                                "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                                        "type": "string"
+                                                    },
+                                                    "partition": {
+                                                        "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                                        "type": "boolean"
+                                                    },
+                                                    "volumeID": {
+                                                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "volumeID"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "azureDisk": {
+                                                "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                                                "properties": {
+                                                    "cachingMode": {
+                                                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                                                        "type": "string"
+                                                    },
+                                                    "diskName": {
+                                                        "description": "diskName is the Name of the data disk in the blob storage",
+                                                        "type": "string"
+                                                    },
+                                                    "diskURI": {
+                                                        "description": "diskURI is the URI of data disk in the blob storage",
+                                                        "type": "string"
+                                                    },
+                                                    "fsType": {
+                                                        "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                                        "type": "string"
+                                                    },
+                                                    "kind": {
+                                                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "diskName",
+                                                    "diskURI"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "azureFile": {
+                                                "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                                                "properties": {
+                                                    "readOnly": {
+                                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretName": {
+                                                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                                                        "type": "string"
+                                                    },
+                                                    "shareName": {
+                                                        "description": "shareName is the azure share Name",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "secretName",
+                                                    "shareName"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "cephfs": {
+                                                "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                                                "properties": {
+                                                    "monitors": {
+                                                        "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "path": {
+                                                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretFile": {
+                                                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "user": {
+                                                        "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "monitors"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "cinder": {
+                                                "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "volumeID": {
+                                                        "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "volumeID"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "configMap": {
+                                                "description": "configMap represents a configMap that should populate this volume",
+                                                "properties": {
+                                                    "defaultMode": {
+                                                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "items": {
+                                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                        "items": {
+                                                            "description": "Maps a string key to a path within a volume.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the key to project.",
+                                                                    "type": "string"
+                                                                },
+                                                                "mode": {
+                                                                    "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                    "format": "int32",
+                                                                    "type": "integer",
+                                                                    "minimum": -2147483648,
+                                                                    "maximum": 2147483647
+                                                                },
+                                                                "path": {
+                                                                    "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "path"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                        "type": "string"
+                                                    },
+                                                    "optional": {
+                                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "csi": {
+                                                "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                                                "properties": {
+                                                    "driver": {
+                                                        "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                                        "type": "string"
+                                                    },
+                                                    "fsType": {
+                                                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                                        "type": "string"
+                                                    },
+                                                    "nodePublishSecretRef": {
+                                                        "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                                        "type": "boolean"
+                                                    },
+                                                    "volumeAttributes": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "driver"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "downwardAPI": {
+                                                "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                                                "properties": {
+                                                    "defaultMode": {
+                                                        "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "items": {
+                                                        "description": "Items is a list of downward API volume file",
+                                                        "items": {
+                                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                            "properties": {
+                                                                "fieldRef": {
+                                                                    "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                                    "properties": {
+                                                                        "apiVersion": {
+                                                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "fieldPath": {
+                                                                            "description": "Path of the field to select in the specified API version.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "fieldPath"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "mode": {
+                                                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                    "format": "int32",
+                                                                    "type": "integer",
+                                                                    "minimum": -2147483648,
+                                                                    "maximum": 2147483647
+                                                                },
+                                                                "path": {
+                                                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                                    "type": "string"
+                                                                },
+                                                                "resourceFieldRef": {
+                                                                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                                    "properties": {
+                                                                        "containerName": {
+                                                                            "description": "Container name: required for volumes, optional for env vars",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "divisor": {
+                                                                            "anyOf": [
+                                                                                {
+                                                                                    "type": "integer"
+                                                                                },
+                                                                                {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            ],
+                                                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                            "x-kubernetes-int-or-string": true
+                                                                        },
+                                                                        "resource": {
+                                                                            "description": "Required: resource to select",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "resource"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "path"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "emptyDir": {
+                                                "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                                "properties": {
+                                                    "medium": {
+                                                        "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                                        "type": "string"
+                                                    },
+                                                    "sizeLimit": {
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "integer"
+                                                            },
+                                                            {
+                                                                "type": "string"
+                                                            }
+                                                        ],
+                                                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                        "x-kubernetes-int-or-string": true
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "ephemeral": {
+                                                "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                                                "properties": {
+                                                    "volumeClaimTemplate": {
+                                                        "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                                                        "properties": {
+                                                            "metadata": {
+                                                                "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                                                                "type": "object"
+                                                            },
+                                                            "spec": {
+                                                                "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                                                                "properties": {
+                                                                    "accessModes": {
+                                                                        "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": "array"
+                                                                    },
+                                                                    "dataSource": {
+                                                                        "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                                                        "properties": {
+                                                                            "apiGroup": {
+                                                                                "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "kind": {
+                                                                                "description": "Kind is the type of resource being referenced",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name is the name of resource being referenced",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "apiGroup",
+                                                                            "kind",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "dataSourceRef": {
+                                                                        "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                                        "properties": {
+                                                                            "apiGroup": {
+                                                                                "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "kind": {
+                                                                                "description": "Kind is the type of resource being referenced",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "name": {
+                                                                                "description": "Name is the name of resource being referenced",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "namespace": {
+                                                                                "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "apiGroup",
+                                                                            "kind",
+                                                                            "name"
+                                                                        ],
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "resources": {
+                                                                        "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                                                        "properties": {
+                                                                            "claims": {
+                                                                                "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                                                                "items": {
+                                                                                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                                                    "properties": {
+                                                                                        "name": {
+                                                                                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "name"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "limits": {
+                                                                                "additionalProperties": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    ],
+                                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                    "x-kubernetes-int-or-string": true
+                                                                                },
+                                                                                "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                                "type": "object"
+                                                                            },
+                                                                            "requests": {
+                                                                                "additionalProperties": {
+                                                                                    "anyOf": [
+                                                                                        {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string"
+                                                                                        }
+                                                                                    ],
+                                                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                    "x-kubernetes-int-or-string": true
+                                                                                },
+                                                                                "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "selector": {
+                                                                        "description": "selector is a label query over volumes to consider for binding.",
+                                                                        "properties": {
+                                                                            "matchExpressions": {
+                                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                                "items": {
+                                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                                    "properties": {
+                                                                                        "key": {
+                                                                                            "description": "key is the label key that the selector applies to.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "operator": {
+                                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                                            "type": "string"
+                                                                                        },
+                                                                                        "values": {
+                                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                                            "items": {
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "type": "array"
+                                                                                        }
+                                                                                    },
+                                                                                    "required": [
+                                                                                        "key",
+                                                                                        "operator"
+                                                                                    ],
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false
+                                                                                },
+                                                                                "type": "array"
+                                                                            },
+                                                                            "matchLabels": {
+                                                                                "additionalProperties": {
+                                                                                    "type": "string"
+                                                                                },
+                                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                                "type": "object"
+                                                                            }
+                                                                        },
+                                                                        "type": "object",
+                                                                        "additionalProperties": false
+                                                                    },
+                                                                    "storageClassName": {
+                                                                        "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "volumeMode": {
+                                                                        "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "volumeName": {
+                                                                        "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "spec"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "fc": {
+                                                "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                                        "type": "string"
+                                                    },
+                                                    "lun": {
+                                                        "description": "lun is Optional: FC target lun number",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "targetWWNs": {
+                                                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "wwids": {
+                                                        "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "flexVolume": {
+                                                "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                                                "properties": {
+                                                    "driver": {
+                                                        "description": "driver is the name of the driver to use for this volume.",
+                                                        "type": "string"
+                                                    },
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                                        "type": "string"
+                                                    },
+                                                    "options": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "options is Optional: this field holds extra command options if any.",
+                                                        "type": "object"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    }
+                                                },
+                                                "required": [
+                                                    "driver"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "flocker": {
+                                                "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                                                "properties": {
+                                                    "datasetName": {
+                                                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                                        "type": "string"
+                                                    },
+                                                    "datasetUUID": {
+                                                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "gcePersistentDisk": {
+                                                "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                                        "type": "string"
+                                                    },
+                                                    "partition": {
+                                                        "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "pdName": {
+                                                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "pdName"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "gitRepo": {
+                                                "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                                                "properties": {
+                                                    "directory": {
+                                                        "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                                        "type": "string"
+                                                    },
+                                                    "repository": {
+                                                        "description": "repository is the URL",
+                                                        "type": "string"
+                                                    },
+                                                    "revision": {
+                                                        "description": "revision is the commit hash for the specified revision.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "repository"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "glusterfs": {
+                                                "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                                                "properties": {
+                                                    "endpoints": {
+                                                        "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                                        "type": "string"
+                                                    },
+                                                    "path": {
+                                                        "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "endpoints",
+                                                    "path"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "hostPath": {
+                                                "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                                                "properties": {
+                                                    "path": {
+                                                        "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                                        "type": "string"
+                                                    },
+                                                    "type": {
+                                                        "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "path"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "iscsi": {
+                                                "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                                                "properties": {
+                                                    "chapAuthDiscovery": {
+                                                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                                                        "type": "boolean"
+                                                    },
+                                                    "chapAuthSession": {
+                                                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                                                        "type": "boolean"
+                                                    },
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                                        "type": "string"
+                                                    },
+                                                    "initiatorName": {
+                                                        "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                                        "type": "string"
+                                                    },
+                                                    "iqn": {
+                                                        "description": "iqn is the target iSCSI Qualified Name.",
+                                                        "type": "string"
+                                                    },
+                                                    "iscsiInterface": {
+                                                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                                        "type": "string"
+                                                    },
+                                                    "lun": {
+                                                        "description": "lun represents iSCSI Target Lun number.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "portals": {
+                                                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "targetPortal": {
+                                                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "iqn",
+                                                    "lun",
+                                                    "targetPortal"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "nfs": {
+                                                "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                                "properties": {
+                                                    "path": {
+                                                        "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                                        "type": "boolean"
+                                                    },
+                                                    "server": {
+                                                        "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "path",
+                                                    "server"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "persistentVolumeClaim": {
+                                                "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                                "properties": {
+                                                    "claimName": {
+                                                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "claimName"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "photonPersistentDisk": {
+                                                "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                                        "type": "string"
+                                                    },
+                                                    "pdID": {
+                                                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "pdID"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "portworxVolume": {
+                                                "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "volumeID": {
+                                                        "description": "volumeID uniquely identifies a Portworx volume",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "volumeID"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "projected": {
+                                                "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                                                "properties": {
+                                                    "defaultMode": {
+                                                        "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "sources": {
+                                                        "description": "sources is the list of volume projections",
+                                                        "items": {
+                                                            "description": "Projection that may be projected along with other supported volume types",
+                                                            "properties": {
+                                                                "configMap": {
+                                                                    "description": "configMap information about the configMap data to project",
+                                                                    "properties": {
+                                                                        "items": {
+                                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                            "items": {
+                                                                                "description": "Maps a string key to a path within a volume.",
+                                                                                "properties": {
+                                                                                    "key": {
+                                                                                        "description": "key is the key to project.",
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "mode": {
+                                                                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                                        "format": "int32",
+                                                                                        "type": "integer",
+                                                                                        "minimum": -2147483648,
+                                                                                        "maximum": 2147483647
+                                                                                    },
+                                                                                    "path": {
+                                                                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "key",
+                                                                                    "path"
+                                                                                ],
+                                                                                "type": "object",
+                                                                                "additionalProperties": false
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "downwardAPI": {
+                                                                    "description": "downwardAPI information about the downwardAPI data to project",
+                                                                    "properties": {
+                                                                        "items": {
+                                                                            "description": "Items is a list of DownwardAPIVolume file",
+                                                                            "items": {
+                                                                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                                                "properties": {
+                                                                                    "fieldRef": {
+                                                                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                                                        "properties": {
+                                                                                            "apiVersion": {
+                                                                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "fieldPath": {
+                                                                                                "description": "Path of the field to select in the specified API version.",
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "fieldPath"
+                                                                                        ],
+                                                                                        "type": "object",
+                                                                                        "additionalProperties": false
+                                                                                    },
+                                                                                    "mode": {
+                                                                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                                        "format": "int32",
+                                                                                        "type": "integer",
+                                                                                        "minimum": -2147483648,
+                                                                                        "maximum": 2147483647
+                                                                                    },
+                                                                                    "path": {
+                                                                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "resourceFieldRef": {
+                                                                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                                                        "properties": {
+                                                                                            "containerName": {
+                                                                                                "description": "Container name: required for volumes, optional for env vars",
+                                                                                                "type": "string"
+                                                                                            },
+                                                                                            "divisor": {
+                                                                                                "anyOf": [
+                                                                                                    {
+                                                                                                        "type": "integer"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "type": "string"
+                                                                                                    }
+                                                                                                ],
+                                                                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                                                                "x-kubernetes-int-or-string": true
+                                                                                            },
+                                                                                            "resource": {
+                                                                                                "description": "Required: resource to select",
+                                                                                                "type": "string"
+                                                                                            }
+                                                                                        },
+                                                                                        "required": [
+                                                                                            "resource"
+                                                                                        ],
+                                                                                        "type": "object",
+                                                                                        "additionalProperties": false
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "path"
+                                                                                ],
+                                                                                "type": "object",
+                                                                                "additionalProperties": false
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "secret": {
+                                                                    "description": "secret information about the secret data to project",
+                                                                    "properties": {
+                                                                        "items": {
+                                                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                                            "items": {
+                                                                                "description": "Maps a string key to a path within a volume.",
+                                                                                "properties": {
+                                                                                    "key": {
+                                                                                        "description": "key is the key to project.",
+                                                                                        "type": "string"
+                                                                                    },
+                                                                                    "mode": {
+                                                                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                                        "format": "int32",
+                                                                                        "type": "integer",
+                                                                                        "minimum": -2147483648,
+                                                                                        "maximum": 2147483647
+                                                                                    },
+                                                                                    "path": {
+                                                                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                },
+                                                                                "required": [
+                                                                                    "key",
+                                                                                    "path"
+                                                                                ],
+                                                                                "type": "object",
+                                                                                "additionalProperties": false
+                                                                            },
+                                                                            "type": "array"
+                                                                        },
+                                                                        "name": {
+                                                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "optional": {
+                                                                            "description": "optional field specify whether the Secret or its key must be defined",
+                                                                            "type": "boolean"
+                                                                        }
+                                                                    },
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "serviceAccountToken": {
+                                                                    "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                                                    "properties": {
+                                                                        "audience": {
+                                                                            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "expirationSeconds": {
+                                                                            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                                                            "format": "int64",
+                                                                            "type": "integer",
+                                                                            "minimum": -9223372036854776000,
+                                                                            "maximum": 9223372036854776000
+                                                                        },
+                                                                        "path": {
+                                                                            "description": "path is the path relative to the mount point of the file to project the token into.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "path"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "sources"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "quobyte": {
+                                                "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                                                "properties": {
+                                                    "group": {
+                                                        "description": "group to map volume access to Default is no group",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "registry": {
+                                                        "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                                        "type": "string"
+                                                    },
+                                                    "tenant": {
+                                                        "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                                        "type": "string"
+                                                    },
+                                                    "user": {
+                                                        "description": "user to map volume access to Defaults to serivceaccount user",
+                                                        "type": "string"
+                                                    },
+                                                    "volume": {
+                                                        "description": "volume is a string that references an already created Quobyte volume by name.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "registry",
+                                                    "volume"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "rbd": {
+                                                "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                                        "type": "string"
+                                                    },
+                                                    "image": {
+                                                        "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    },
+                                                    "keyring": {
+                                                        "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    },
+                                                    "monitors": {
+                                                        "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "pool": {
+                                                        "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "user": {
+                                                        "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "image",
+                                                    "monitors"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "scaleIO": {
+                                                "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                                        "type": "string"
+                                                    },
+                                                    "gateway": {
+                                                        "description": "gateway is the host address of the ScaleIO API Gateway.",
+                                                        "type": "string"
+                                                    },
+                                                    "protectionDomain": {
+                                                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "sslEnabled": {
+                                                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                                                        "type": "boolean"
+                                                    },
+                                                    "storageMode": {
+                                                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                                        "type": "string"
+                                                    },
+                                                    "storagePool": {
+                                                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                                                        "type": "string"
+                                                    },
+                                                    "system": {
+                                                        "description": "system is the name of the storage system as configured in ScaleIO.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeName": {
+                                                        "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "gateway",
+                                                    "secretRef",
+                                                    "system"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "secret": {
+                                                "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                "properties": {
+                                                    "defaultMode": {
+                                                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "items": {
+                                                        "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                        "items": {
+                                                            "description": "Maps a string key to a path within a volume.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the key to project.",
+                                                                    "type": "string"
+                                                                },
+                                                                "mode": {
+                                                                    "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                                    "format": "int32",
+                                                                    "type": "integer",
+                                                                    "minimum": -2147483648,
+                                                                    "maximum": 2147483647
+                                                                },
+                                                                "path": {
+                                                                    "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "path"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "optional": {
+                                                        "description": "optional field specify whether the Secret or its keys must be defined",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretName": {
+                                                        "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "storageos": {
+                                                "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                                        "type": "string"
+                                                    },
+                                                    "readOnly": {
+                                                        "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "secretRef": {
+                                                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "volumeName": {
+                                                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumeNamespace": {
+                                                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "vsphereVolume": {
+                                                "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                                                "properties": {
+                                                    "fsType": {
+                                                        "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                                        "type": "string"
+                                                    },
+                                                    "storagePolicyID": {
+                                                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                                        "type": "string"
+                                                    },
+                                                    "storagePolicyName": {
+                                                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                                                        "type": "string"
+                                                    },
+                                                    "volumePath": {
+                                                        "description": "volumePath is the path that identifies vSphere volume vmdk",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "volumePath"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "containers"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "test": {
+                    "description": "Test ensures that this deployment config will have zero replicas except while a deployment is running. This allows the deployment config to be used as a continuous deployment test - triggering on images, running the deployment, and then succeeding or failing. Post strategy hooks and After actions can be used to integrate successful deployment with an action.",
+                    "type": "boolean"
+                },
+                "triggers": {
+                    "description": "Triggers determine how updates to a DeploymentConfig result in new deployments. If no triggers are defined, a new deployment can only occur as a result of an explicit client update to the DeploymentConfig with a new LatestVersion. If null, defaults to having a config change trigger.",
+                    "items": {
+                        "description": "DeploymentTriggerPolicy describes a policy for a single trigger that results in a new deployment.",
+                        "properties": {
+                            "imageChangeParams": {
+                                "description": "ImageChangeParams represents the parameters for the ImageChange trigger.",
+                                "properties": {
+                                    "automatic": {
+                                        "description": "Automatic means that the detection of a new tag value should result in an image update inside the pod template.",
+                                        "type": "boolean"
+                                    },
+                                    "containerNames": {
+                                        "description": "ContainerNames is used to restrict tag updates to the specified set of container names in a pod. If multiple triggers point to the same containers, the resulting behavior is undefined. Future API versions will make this a validation error. If ContainerNames does not point to a valid container, the trigger will be ignored. Future API versions will make this a validation error.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "from": {
+                                        "description": "From is a reference to an image stream tag to watch for changes. From.Name is the only required subfield - if From.Namespace is blank, the namespace of the current deployment trigger will be used.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "fieldPath": {
+                                                "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                            },
+                                            "namespace": {
+                                                "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                "type": "string"
+                                            },
+                                            "resourceVersion": {
+                                                "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "lastTriggeredImage": {
+                                        "description": "LastTriggeredImage is the last image to be triggered.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "from"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": {
+                                "description": "Type of the trigger",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status represents the current deployment state.",
+            "properties": {
+                "availableReplicas": {
+                    "description": "AvailableReplicas is the total number of available pods targeted by this deployment config.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "conditions": {
+                    "description": "Conditions represents the latest available observations of a deployment config's current state.",
+                    "items": {
+                        "description": "DeploymentCondition describes the state of a deployment config at a certain point.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "The last time the condition transitioned from one status to another.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastUpdateTime": {
+                                "description": "The last time this condition was updated.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "A human readable message indicating details about the transition.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "The reason for the condition's last transition.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of deployment condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "details": {
+                    "description": "Details are the reasons for the update to this deployment config. This could be based on a change made by the user or caused by an automatic trigger",
+                    "properties": {
+                        "causes": {
+                            "description": "Causes are extended data associated with all the causes for creating a new deployment",
+                            "items": {
+                                "description": "DeploymentCause captures information about a particular cause of a deployment.",
+                                "properties": {
+                                    "imageTrigger": {
+                                        "description": "ImageTrigger contains the image trigger details, if this trigger was fired based on an image change",
+                                        "properties": {
+                                            "from": {
+                                                "description": "From is a reference to the changed object which triggered a deployment. The field may have the kinds DockerImage, ImageStreamTag, or ImageStreamImage.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "API version of the referent.",
+                                                        "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                        "type": "string"
+                                                    },
+                                                    "kind": {
+                                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "namespace": {
+                                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                        "type": "string"
+                                                    },
+                                                    "resourceVersion": {
+                                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                        "type": "string"
+                                                    },
+                                                    "uid": {
+                                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "from"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": {
+                                        "description": "Type of the trigger that resulted in the creation of a new deployment",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "message": {
+                            "description": "Message is the user specified change message, if this deployment was triggered manually by the user",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "causes"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "latestVersion": {
+                    "description": "LatestVersion is used to determine whether the current deployment associated with a deployment config is out of sync.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "observedGeneration": {
+                    "description": "ObservedGeneration is the most recent generation observed by the deployment config controller.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "Total number of ready pods targeted by this deployment.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "replicas": {
+                    "description": "Replicas is the total number of pods targeted by this deployment config.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unavailableReplicas": {
+                    "description": "UnavailableReplicas is the total number of unavailable pods targeted by this deployment config.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "updatedReplicas": {
+                    "description": "UpdatedReplicas is the total number of non-terminated pods targeted by this deployment config that have the desired template spec.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                }
+            },
+            "required": [
+                "availableReplicas",
+                "latestVersion",
+                "observedGeneration",
+                "replicas",
+                "unavailableReplicas",
+                "updatedReplicas"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/dns_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/dns_config.openshift.io_v1.json
@@ -1,0 +1,130 @@
+{
+    "description": "DNS holds cluster-wide information about DNS. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "baseDomain": {
+                    "description": "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base. \n For example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`. \n Once set, this field cannot be changed.",
+                    "type": "string"
+                },
+                "platform": {
+                    "description": "platform holds configuration specific to the underlying infrastructure provider for DNS. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.",
+                    "properties": {
+                        "aws": {
+                            "description": "aws contains DNS configuration specific to the Amazon Web Services cloud provider.",
+                            "properties": {
+                                "privateZoneIAMRole": {
+                                    "description": "privateZoneIAMRole contains the ARN of an IAM role that should be assumed when performing operations on the cluster's private hosted zone specified in the cluster DNS config. When left empty, no role should be assumed.",
+                                    "pattern": "^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\\/.*$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the underlying infrastructure provider for the cluster. Allowed values: \"\", \"AWS\". \n Individual components may not support all platforms, and must handle unrecognized platforms with best-effort defaults.",
+                            "enum": [
+                                "",
+                                "AWS",
+                                "Azure",
+                                "BareMetal",
+                                "GCP",
+                                "Libvirt",
+                                "OpenStack",
+                                "None",
+                                "VSphere",
+                                "oVirt",
+                                "IBMCloud",
+                                "KubeVirt",
+                                "EquinixMetal",
+                                "PowerVS",
+                                "AlibabaCloud",
+                                "Nutanix",
+                                "External"
+                            ],
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                                {
+                                    "message": "allowed values are '' and 'AWS'",
+                                    "rule": "self in ['','AWS']"
+                                }
+                            ]
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "aws configuration is required when platform is AWS, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'AWS' ?  has(self.aws) : !has(self.aws)"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "privateZone": {
+                    "description": "privateZone is the location where all the DNS records that are only available internally to the cluster exist. \n If this field is nil, no private records should be created. \n Once set, this field cannot be changed.",
+                    "properties": {
+                        "id": {
+                            "description": "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get",
+                            "type": "string"
+                        },
+                        "tags": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "publicZone": {
+                    "description": "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. \n If this field is nil, no public records should be created. \n Once set, this field cannot be changed.",
+                    "properties": {
+                        "id": {
+                            "description": "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get",
+                            "type": "string"
+                        },
+                        "tags": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/dns_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/dns_operator.openshift.io_v1.json
@@ -1,0 +1,375 @@
+{
+    "description": "DNS manages the CoreDNS component to provide a name resolution service for pods and services in the cluster. \n This supports the DNS-based service discovery specification: https://github.com/kubernetes/dns/blob/master/docs/specification.md \n More details: https://kubernetes.io/docs/tasks/administer-cluster/coredns \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the DNS.",
+            "properties": {
+                "cache": {
+                    "description": "cache describes the caching configuration that applies to all server blocks listed in the Corefile. This field allows a cluster admin to optionally configure: * positiveTTL which is a duration for which positive responses should be cached. * negativeTTL which is a duration for which negative responses should be cached. If this is not configured, OpenShift will configure positive and negative caching with a default value that is subject to change. At the time of writing, the default positiveTTL is 900 seconds and the default negativeTTL is 30 seconds or as noted in the respective Corefile for your version of OpenShift.",
+                    "properties": {
+                        "negativeTTL": {
+                            "description": "negativeTTL is optional and specifies the amount of time that a negative response should be cached. \n If configured, it must be a value of 1s (1 second) or greater up to a theoretical maximum of several years. This field expects an unsigned duration string of decimal numbers, each with optional fraction and a unit suffix, e.g. \"100s\", \"1m30s\", \"12h30m10s\". Values that are fractions of a second are rounded down to the nearest second. If the configured value is less than 1s, the default value will be used. If not configured, the value will be 0s and OpenShift will use a default value of 30 seconds unless noted otherwise in the respective Corefile for your version of OpenShift. The default value of 30 seconds is subject to change.",
+                            "pattern": "^(0|([0-9]+(\\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$",
+                            "type": "string"
+                        },
+                        "positiveTTL": {
+                            "description": "positiveTTL is optional and specifies the amount of time that a positive response should be cached. \n If configured, it must be a value of 1s (1 second) or greater up to a theoretical maximum of several years. This field expects an unsigned duration string of decimal numbers, each with optional fraction and a unit suffix, e.g. \"100s\", \"1m30s\", \"12h30m10s\". Values that are fractions of a second are rounded down to the nearest second. If the configured value is less than 1s, the default value will be used. If not configured, the value will be 0s and OpenShift will use a default value of 900 seconds unless noted otherwise in the respective Corefile for your version of OpenShift. The default value of 900 seconds is subject to change.",
+                            "pattern": "^(0|([0-9]+(\\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel describes the desired logging verbosity for CoreDNS. Any one of the following values may be specified: * Normal logs errors from upstream resolvers. * Debug logs errors, NXDOMAIN responses, and NODATA responses. * Trace logs errors and all responses. Setting logLevel: Trace will produce extremely verbose logs. Valid values are: \"Normal\", \"Debug\", \"Trace\". Defaults to \"Normal\".",
+                    "enum": [
+                        "Normal",
+                        "Debug",
+                        "Trace"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether the DNS operator should manage cluster DNS",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "nodePlacement": {
+                    "description": "nodePlacement provides explicit control over the scheduling of DNS pods. \n Generally, it is useful to run a DNS pod on every node so that DNS queries are always handled by a local DNS pod instead of going over the network to a DNS pod on another node.  However, security policies may require restricting the placement of DNS pods to specific nodes. For example, if a security policy prohibits pods on arbitrary nodes from communicating with the API, a node selector can be specified to restrict DNS pods to nodes that are permitted to communicate with the API.  Conversely, if running DNS pods on nodes with a particular taint is desired, a toleration can be specified for that taint. \n If unset, defaults are used. See nodePlacement for more details.",
+                    "properties": {
+                        "nodeSelector": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "nodeSelector is the node selector applied to DNS pods. \n If empty, the default is used, which is currently the following: \n kubernetes.io/os: linux \n This default is subject to change. \n If set, the specified selector is used and replaces the default.",
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "description": "tolerations is a list of tolerations applied to DNS pods. \n If empty, the DNS operator sets a toleration for the \"node-role.kubernetes.io/master\" taint.  This default is subject to change.  Specifying tolerations without including a toleration for the \"node-role.kubernetes.io/master\" taint may be risky as it could lead to an outage if all worker nodes become unavailable. \n Note that the daemon controller adds some tolerations as well.  See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+                            "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                    "effect": {
+                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                        "type": "string"
+                                    },
+                                    "key": {
+                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                        "type": "string"
+                                    },
+                                    "tolerationSeconds": {
+                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                        "format": "int64",
+                                        "type": "integer",
+                                        "minimum": -9223372036854776000,
+                                        "maximum": 9223372036854776000
+                                    },
+                                    "value": {
+                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel controls the logging level of the DNS Operator. Valid values are: \"Normal\", \"Debug\", \"Trace\". Defaults to \"Normal\". setting operatorLogLevel: Trace will produce extremely verbose logs.",
+                    "enum": [
+                        "Normal",
+                        "Debug",
+                        "Trace"
+                    ],
+                    "type": "string"
+                },
+                "servers": {
+                    "description": "servers is a list of DNS resolvers that provide name query delegation for one or more subdomains outside the scope of the cluster domain. If servers consists of more than one Server, longest suffix match will be used to determine the Server. \n For example, if there are two Servers, one for \"foo.com\" and another for \"a.foo.com\", and the name query is for \"www.a.foo.com\", it will be routed to the Server with Zone \"a.foo.com\". \n If this field is nil, no servers are created.",
+                    "items": {
+                        "description": "Server defines the schema for a server that runs per instance of CoreDNS.",
+                        "properties": {
+                            "forwardPlugin": {
+                                "description": "forwardPlugin defines a schema for configuring CoreDNS to proxy DNS messages to upstream resolvers.",
+                                "properties": {
+                                    "policy": {
+                                        "default": "Random",
+                                        "description": "policy is used to determine the order in which upstream servers are selected for querying. Any one of the following values may be specified: \n * \"Random\" picks a random upstream server for each query. * \"RoundRobin\" picks upstream servers in a round-robin order, moving to the next server for each new query. * \"Sequential\" tries querying upstream servers in a sequential order until one responds, starting with the first server for each new query. \n The default value is \"Random\"",
+                                        "enum": [
+                                            "Random",
+                                            "RoundRobin",
+                                            "Sequential"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "protocolStrategy": {
+                                        "description": "protocolStrategy specifies the protocol to use for upstream DNS requests. Valid values for protocolStrategy are \"TCP\" and omitted. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is to use the protocol of the original client request. \"TCP\" specifies that the platform should use TCP for all upstream DNS requests, even if the client request uses UDP. \"TCP\" is useful for UDP-specific issues such as those created by non-compliant upstream resolvers, but may consume more bandwidth or increase DNS response time. Note that protocolStrategy only affects the protocol of DNS requests that CoreDNS makes to upstream resolvers. It does not affect the protocol of DNS requests between clients and CoreDNS.",
+                                        "enum": [
+                                            "TCP",
+                                            ""
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "transportConfig": {
+                                        "description": "transportConfig is used to configure the transport type, server name, and optional custom CA or CA bundle to use when forwarding DNS requests to an upstream resolver. \n The default value is \"\" (empty) which results in a standard cleartext connection being used when forwarding DNS requests to an upstream resolver.",
+                                        "properties": {
+                                            "tls": {
+                                                "description": "tls contains the additional configuration options to use when Transport is set to \"TLS\".",
+                                                "properties": {
+                                                    "caBundle": {
+                                                        "description": "caBundle references a ConfigMap that must contain either a single CA Certificate or a CA Bundle. This allows cluster administrators to provide their own CA or CA bundle for validating the certificate of upstream resolvers. \n 1. The configmap must contain a `ca-bundle.crt` key. 2. The value must be a PEM encoded CA certificate or CA bundle. 3. The administrator must create this configmap in the openshift-config namespace. 4. The upstream server certificate must contain a Subject Alternative Name (SAN) that matches ServerName.",
+                                                        "properties": {
+                                                            "name": {
+                                                                "description": "name is the metadata.name of the referenced config map",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "serverName": {
+                                                        "description": "serverName is the upstream server to connect to when forwarding DNS queries. This is required when Transport is set to \"TLS\". ServerName will be validated against the DNS naming conventions in RFC 1123 and should match the TLS certificate installed in the upstream resolver(s).",
+                                                        "maxLength": 253,
+                                                        "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "serverName"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "transport": {
+                                                "description": "transport allows cluster administrators to opt-in to using a DNS-over-TLS connection between cluster DNS and an upstream resolver(s). Configuring TLS as the transport at this level without configuring a CABundle will result in the system certificates being used to verify the serving certificate of the upstream resolver(s). \n Possible values: \"\" (empty) - This means no explicit choice has been made and the platform chooses the default which is subject to change over time. The current default is \"Cleartext\". \"Cleartext\" - Cluster admin specified cleartext option. This results in the same functionality as an empty value but may be useful when a cluster admin wants to be more explicit about the transport, or wants to switch from \"TLS\" to \"Cleartext\" explicitly. \"TLS\" - This indicates that DNS queries should be sent over a TLS connection. If Transport is set to TLS, you MUST also set ServerName. If a port is not included with the upstream IP, port 853 will be tried by default per RFC 7858 section 3.1; https://datatracker.ietf.org/doc/html/rfc7858#section-3.1.",
+                                                "enum": [
+                                                    "TLS",
+                                                    "Cleartext",
+                                                    ""
+                                                ],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "upstreams": {
+                                        "description": "upstreams is a list of resolvers to forward name queries for subdomains of Zones. Each instance of CoreDNS performs health checking of Upstreams. When a healthy upstream returns an error during the exchange, another resolver is tried from Upstreams. The Upstreams are selected in the order specified in Policy. Each upstream is represented by an IP address or IP:port if the upstream listens on a port other than 53. \n A maximum of 15 upstreams is allowed per ForwardPlugin.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "maxItems": 15,
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "name": {
+                                "description": "name is required and specifies a unique name for the server. Name must comply with the Service Name Syntax of rfc6335.",
+                                "type": "string"
+                            },
+                            "zones": {
+                                "description": "zones is required and specifies the subdomains that Server is authoritative for. Zones must conform to the rfc1123 definition of a subdomain. Specifying the cluster domain (i.e., \"cluster.local\") is invalid.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "upstreamResolvers": {
+                    "description": "upstreamResolvers defines a schema for configuring CoreDNS to proxy DNS messages to upstream resolvers for the case of the default (\".\") server \n If this field is not specified, the upstream used will default to /etc/resolv.conf, with policy \"sequential\"",
+                    "properties": {
+                        "policy": {
+                            "default": "Sequential",
+                            "description": "Policy is used to determine the order in which upstream servers are selected for querying. Any one of the following values may be specified: \n * \"Random\" picks a random upstream server for each query. * \"RoundRobin\" picks upstream servers in a round-robin order, moving to the next server for each new query. * \"Sequential\" tries querying upstream servers in a sequential order until one responds, starting with the first server for each new query. \n The default value is \"Sequential\"",
+                            "enum": [
+                                "Random",
+                                "RoundRobin",
+                                "Sequential"
+                            ],
+                            "type": "string"
+                        },
+                        "protocolStrategy": {
+                            "description": "protocolStrategy specifies the protocol to use for upstream DNS requests. Valid values for protocolStrategy are \"TCP\" and omitted. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is to use the protocol of the original client request. \"TCP\" specifies that the platform should use TCP for all upstream DNS requests, even if the client request uses UDP. \"TCP\" is useful for UDP-specific issues such as those created by non-compliant upstream resolvers, but may consume more bandwidth or increase DNS response time. Note that protocolStrategy only affects the protocol of DNS requests that CoreDNS makes to upstream resolvers. It does not affect the protocol of DNS requests between clients and CoreDNS.",
+                            "enum": [
+                                "TCP",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "transportConfig": {
+                            "description": "transportConfig is used to configure the transport type, server name, and optional custom CA or CA bundle to use when forwarding DNS requests to an upstream resolver. \n The default value is \"\" (empty) which results in a standard cleartext connection being used when forwarding DNS requests to an upstream resolver.",
+                            "properties": {
+                                "tls": {
+                                    "description": "tls contains the additional configuration options to use when Transport is set to \"TLS\".",
+                                    "properties": {
+                                        "caBundle": {
+                                            "description": "caBundle references a ConfigMap that must contain either a single CA Certificate or a CA Bundle. This allows cluster administrators to provide their own CA or CA bundle for validating the certificate of upstream resolvers. \n 1. The configmap must contain a `ca-bundle.crt` key. 2. The value must be a PEM encoded CA certificate or CA bundle. 3. The administrator must create this configmap in the openshift-config namespace. 4. The upstream server certificate must contain a Subject Alternative Name (SAN) that matches ServerName.",
+                                            "properties": {
+                                                "name": {
+                                                    "description": "name is the metadata.name of the referenced config map",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "name"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "serverName": {
+                                            "description": "serverName is the upstream server to connect to when forwarding DNS queries. This is required when Transport is set to \"TLS\". ServerName will be validated against the DNS naming conventions in RFC 1123 and should match the TLS certificate installed in the upstream resolver(s).",
+                                            "maxLength": 253,
+                                            "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "serverName"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "transport": {
+                                    "description": "transport allows cluster administrators to opt-in to using a DNS-over-TLS connection between cluster DNS and an upstream resolver(s). Configuring TLS as the transport at this level without configuring a CABundle will result in the system certificates being used to verify the serving certificate of the upstream resolver(s). \n Possible values: \"\" (empty) - This means no explicit choice has been made and the platform chooses the default which is subject to change over time. The current default is \"Cleartext\". \"Cleartext\" - Cluster admin specified cleartext option. This results in the same functionality as an empty value but may be useful when a cluster admin wants to be more explicit about the transport, or wants to switch from \"TLS\" to \"Cleartext\" explicitly. \"TLS\" - This indicates that DNS queries should be sent over a TLS connection. If Transport is set to TLS, you MUST also set ServerName. If a port is not included with the upstream IP, port 853 will be tried by default per RFC 7858 section 3.1; https://datatracker.ietf.org/doc/html/rfc7858#section-3.1.",
+                                    "enum": [
+                                        "TLS",
+                                        "Cleartext",
+                                        ""
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "upstreams": {
+                            "default": [
+                                {
+                                    "type": "SystemResolvConf"
+                                }
+                            ],
+                            "description": "Upstreams is a list of resolvers to forward name queries for the \".\" domain. Each instance of CoreDNS performs health checking of Upstreams. When a healthy upstream returns an error during the exchange, another resolver is tried from Upstreams. The Upstreams are selected in the order specified in Policy. \n A maximum of 15 upstreams is allowed per ForwardPlugin. If no Upstreams are specified, /etc/resolv.conf is used by default",
+                            "items": {
+                                "description": "Upstream can either be of type SystemResolvConf, or of type Network. \n * For an Upstream of type SystemResolvConf, no further fields are necessary: The upstream will be configured to use /etc/resolv.conf. * For an Upstream of type Network, a NetworkResolver field needs to be defined with an IP address or IP:port if the upstream listens on a port other than 53.",
+                                "properties": {
+                                    "address": {
+                                        "description": "Address must be defined when Type is set to Network. It will be ignored otherwise. It must be a valid ipv4 or ipv6 address.",
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "default": 53,
+                                        "description": "Port may be defined when Type is set to Network. It will be ignored otherwise. Port must be between 65535",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    },
+                                    "type": {
+                                        "description": "Type defines whether this upstream contains an IP/IP:port resolver or the local /etc/resolv.conf. Type accepts 2 possible values: SystemResolvConf or Network. \n * When SystemResolvConf is used, the Upstream structure does not require any further fields to be defined: /etc/resolv.conf will be used * When Network is used, the Upstream structure must contain at least an Address",
+                                        "enum": [
+                                            "SystemResolvConf",
+                                            "Network",
+                                            ""
+                                        ],
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "maxItems": 15,
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the DNS.",
+            "properties": {
+                "clusterDomain": {
+                    "description": "clusterDomain is the local cluster DNS domain suffix for DNS services. This will be a subdomain as defined in RFC 1034, section 3.5: https://tools.ietf.org/html/rfc1034#section-3.5 Example: \"cluster.local\" \n More info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service",
+                    "type": "string"
+                },
+                "clusterIP": {
+                    "description": "clusterIP is the service IP through which this DNS is made available. \n In the case of the default DNS, this will be a well known IP that is used as the default nameserver for pods that are using the default ClusterFirst DNS policy. \n In general, this IP can be specified in a pod's spec.dnsConfig.nameservers list or used explicitly when performing name resolution from within the cluster. Example: dig foo.com @<service IP> \n More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
+                    "type": "string"
+                },
+                "conditions": {
+                    "description": "conditions provide information about the state of the DNS on the cluster. \n These are the supported DNS conditions: \n * Available - True if the following conditions are met: * DNS controller daemonset is available. - False if any of those conditions are unsatisfied.",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "clusterDomain",
+                "clusterIP"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/dnsrecord_ingress.operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/dnsrecord_ingress.operator.openshift.io_v1.json
@@ -1,0 +1,146 @@
+{
+    "description": "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. \n Cluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators. \n If DNSManagementPolicy is \"Unmanaged\", the operator will not be responsible for managing the DNS records on the cloud provider. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the dnsRecord.",
+            "properties": {
+                "dnsManagementPolicy": {
+                    "default": "Managed",
+                    "description": "dnsManagementPolicy denotes the current policy applied on the DNS record. Records that have policy set as \"Unmanaged\" are ignored by the ingress operator.  This means that the DNS record on the cloud provider is not managed by the operator, and the \"Published\" status condition will be updated to \"Unknown\" status, since it is externally managed. Any existing record on the cloud provider can be deleted at the discretion of the cluster admin. \n This field defaults to Managed. Valid values are \"Managed\" and \"Unmanaged\".",
+                    "enum": [
+                        "Managed",
+                        "Unmanaged"
+                    ],
+                    "type": "string"
+                },
+                "dnsName": {
+                    "description": "dnsName is the hostname of the DNS record",
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "recordTTL": {
+                    "description": "recordTTL is the record TTL in seconds. If zero, the default is 30. RecordTTL will not be used in AWS regions Alias targets, but will be used in CNAME targets, per AWS API contract.",
+                    "format": "int64",
+                    "minimum": 0,
+                    "type": "integer",
+                    "maximum": 9223372036854776000
+                },
+                "recordType": {
+                    "description": "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
+                    "enum": [
+                        "CNAME",
+                        "A"
+                    ],
+                    "type": "string"
+                },
+                "targets": {
+                    "description": "targets are record targets.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "required": [
+                "dnsManagementPolicy",
+                "dnsName",
+                "recordTTL",
+                "recordType",
+                "targets"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the dnsRecord.",
+            "properties": {
+                "observedGeneration": {
+                    "description": "observedGeneration is the most recently observed generation of the DNSRecord.  When the DNSRecord is updated, the controller updates the corresponding record in each managed zone.  If an update for a particular zone fails, that failure is recorded in the status condition for the zone so that the controller can determine that it needs to retry the update for that specific zone.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "zones": {
+                    "description": "zones are the status of the record in each zone.",
+                    "items": {
+                        "description": "DNSZoneStatus is the status of a record within a specific zone.",
+                        "properties": {
+                            "conditions": {
+                                "description": "conditions are any conditions associated with the record in the zone. \n If publishing the record succeeds, the \"Published\" condition will be set with status \"True\" and upon failure it will be set to \"False\" along with the reason and message describing the cause of the failure.",
+                                "items": {
+                                    "description": "DNSZoneCondition is just the standard condition fields.",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "minLength": 1,
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "dnsZone": {
+                                "description": "dnsZone is the zone where the record is published.",
+                                "properties": {
+                                    "id": {
+                                        "description": "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get",
+                                        "type": "string"
+                                    },
+                                    "tags": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/egressnetworkpolicy_network.openshift.io_v1.json
+++ b/openshift/v4.14-strict/egressnetworkpolicy_network.openshift.io_v1.json
@@ -1,0 +1,69 @@
+{
+    "description": "EgressNetworkPolicy describes the current egress network policy for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network plugin, traffic from a pod to an IP address outside the cluster will be checked against each EgressNetworkPolicyRule in the pod's namespace's EgressNetworkPolicy, in order. If no rule matches (or no EgressNetworkPolicy is present) then the traffic will be allowed by default. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the current egress network policy",
+            "properties": {
+                "egress": {
+                    "description": "egress contains the list of egress policy rules",
+                    "items": {
+                        "description": "EgressNetworkPolicyRule contains a single egress network policy rule",
+                        "properties": {
+                            "to": {
+                                "description": "to is the target that traffic is allowed/denied to",
+                                "properties": {
+                                    "cidrSelector": {
+                                        "description": "CIDRSelector is the CIDR range to allow/deny traffic to. If this is set, dnsName must be unset Ideally we would have liked to use the cidr openapi format for this property. But openshift-sdn only supports v4 while specifying the cidr format allows both v4 and v6 cidrs We are therefore using a regex pattern to validate instead.",
+                                        "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+                                        "type": "string"
+                                    },
+                                    "dnsName": {
+                                        "description": "DNSName is the domain name to allow/deny traffic to. If this is set, cidrSelector must be unset",
+                                        "pattern": "^([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]+\\.?$",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": {
+                                "description": "type marks this as an \"Allow\" or \"Deny\" rule",
+                                "pattern": "^Allow|Deny$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "to",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "egress"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/egressrouter_network.operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/egressrouter_network.operator.openshift.io_v1.json
@@ -1,0 +1,218 @@
+{
+    "description": "EgressRouter is a feature allowing the user to define an egress router that acts as a bridge between pods and external systems. The egress router runs a service that redirects egress traffic originating from a pod or a group of pods to a remote external system or multiple destinations as per configuration. \n It is consumed by the cluster-network-operator. More specifically, given an EgressRouter CR with <name>, the CNO will create and manage: - A service called <name> - An egress pod called <name> - A NAD called <name> \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer). \n EgressRouter is a single egressrouter pod configuration object.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Specification of the desired egress router.",
+            "properties": {
+                "addresses": {
+                    "description": "List of IP addresses to configure on the pod's secondary interface.",
+                    "items": {
+                        "description": "EgressRouterAddress contains a pair of IP CIDR and gateway to be configured on the router's interface",
+                        "properties": {
+                            "gateway": {
+                                "description": "IP address of the next-hop gateway, if it cannot be automatically determined. Can be IPv4 or IPv6.",
+                                "type": "string"
+                            },
+                            "ip": {
+                                "description": "IP is the address to configure on the router's interface. Can be IPv4 or IPv6.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "ip"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "mode": {
+                    "default": "Redirect",
+                    "description": "Mode depicts the mode that is used for the egress router. The default mode is \"Redirect\" and is the only supported mode currently.",
+                    "enum": [
+                        "Redirect"
+                    ],
+                    "type": "string"
+                },
+                "networkInterface": {
+                    "default": {
+                        "macvlan": {
+                            "mode": "Bridge"
+                        }
+                    },
+                    "description": "Specification of interface to create/use. The default is macvlan. Currently only macvlan is supported.",
+                    "properties": {
+                        "macvlan": {
+                            "default": {
+                                "mode": "Bridge"
+                            },
+                            "description": "Arguments specific to the interfaceType macvlan",
+                            "properties": {
+                                "master": {
+                                    "description": "Name of the master interface. Need not be specified if it can be inferred from the IP address.",
+                                    "type": "string"
+                                },
+                                "mode": {
+                                    "default": "Bridge",
+                                    "description": "Mode depicts the mode that is used for the macvlan interface; one of Bridge|Private|VEPA|Passthru. The default mode is \"Bridge\".",
+                                    "enum": [
+                                        "Bridge",
+                                        "Private",
+                                        "VEPA",
+                                        "Passthru"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "mode"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "redirect": {
+                    "description": "Redirect represents the configuration parameters specific to redirect mode.",
+                    "properties": {
+                        "fallbackIP": {
+                            "description": "FallbackIP specifies the remote destination's IP address. Can be IPv4 or IPv6. If no redirect rules are specified, all traffic from the router are redirected to this IP. If redirect rules are specified, then any connections on any other port (undefined in the rules) on the router will be redirected to this IP. If redirect rules are specified and no fallback IP is provided, connections on other ports will simply be rejected.",
+                            "type": "string"
+                        },
+                        "redirectRules": {
+                            "description": "List of L4RedirectRules that define the DNAT redirection from the pod to the destination in redirect mode.",
+                            "items": {
+                                "description": "L4RedirectRule defines a DNAT redirection from a given port to a destination IP and port.",
+                                "properties": {
+                                    "destinationIP": {
+                                        "description": "IP specifies the remote destination's IP address. Can be IPv4 or IPv6.",
+                                        "type": "string"
+                                    },
+                                    "port": {
+                                        "description": "Port is the port number to which clients should send traffic to be redirected.",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    },
+                                    "protocol": {
+                                        "description": "Protocol can be TCP, SCTP or UDP.",
+                                        "enum": [
+                                            "TCP",
+                                            "UDP",
+                                            "SCTP"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "targetPort": {
+                                        "description": "TargetPort allows specifying the port number on the remote destination to which the traffic gets redirected to. If unspecified, the value from \"Port\" is used.",
+                                        "format": "int32",
+                                        "maximum": 65535,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "destinationIP",
+                                    "port",
+                                    "protocol"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "addresses",
+                "mode",
+                "networkInterface"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Observed status of EgressRouter.",
+            "properties": {
+                "conditions": {
+                    "description": "Observed status of the egress router",
+                    "items": {
+                        "description": "EgressRouterStatusCondition represents the state of the egress router's managed and monitored components.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "LastTransitionTime is the time of the last update to the current status property.",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "message": {
+                                "description": "Message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason is the CamelCase reason for the condition's current status.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "enum": [
+                                    "True",
+                                    "False",
+                                    "Unknown"
+                                ],
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type specifies the aspect reported by this condition; one of Available, Progressing, Degraded",
+                                "enum": [
+                                    "Available",
+                                    "Progressing",
+                                    "Degraded"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "conditions"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/etcd_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/etcd_operator.openshift.io_v1.json
@@ -1,0 +1,260 @@
+{
+    "description": "Etcd provides information to configure an operator to manage etcd. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "failedRevisionLimit": {
+                    "description": "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "forceRedeploymentReason": {
+                    "description": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "succeededRevisionLimit": {
+                    "description": "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "controlPlaneHardwareSpeed": {
+                    "description": "ControlPlaneHardwareSpeed declares valid hardware speed tolerance levels",
+                    "enum": [
+                        "",
+                        "Standard",
+                        "Slower"
+                    ],
+                    "type": "string"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "latestAvailableRevision": {
+                    "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "latestAvailableRevisionReason": {
+                    "description": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
+                    "type": "string"
+                },
+                "nodeStatuses": {
+                    "description": "nodeStatuses track the deployment values and errors across individual nodes",
+                    "items": {
+                        "description": "NodeStatus provides information about the current state of a particular node managed by this operator.",
+                        "properties": {
+                            "currentRevision": {
+                                "description": "currentRevision is the generation of the most recently successful deployment",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedCount": {
+                                "description": "lastFailedCount is how often the installer pod of the last failed revision failed.",
+                                "type": "integer"
+                            },
+                            "lastFailedReason": {
+                                "description": "lastFailedReason is a machine readable failure reason string.",
+                                "type": "string"
+                            },
+                            "lastFailedRevision": {
+                                "description": "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedRevisionErrors": {
+                                "description": "lastFailedRevisionErrors is a list of human readable errors during the failed deployment referenced in lastFailedRevision.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "lastFailedTime": {
+                                "description": "lastFailedTime is the time the last failed revision failed the last time.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastFallbackCount": {
+                                "description": "lastFallbackCount is how often a fallback to a previous revision happened.",
+                                "type": "integer"
+                            },
+                            "nodeName": {
+                                "description": "nodeName is the name of the node",
+                                "type": "string"
+                            },
+                            "targetRevision": {
+                                "description": "targetRevision is the generation of the deployment we're trying to apply",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/etcdbackup_operator.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/etcdbackup_operator.openshift.io_v1alpha1.json
@@ -1,0 +1,116 @@
+{
+    "description": "# EtcdBackup provides configuration options and status for a one-time backup attempt of the etcd cluster \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "pvcName": {
+                    "description": "PVCName specifies the name of the PersistentVolumeClaim (PVC) which binds a PersistentVolume where the etcd backup file would be saved The PVC itself must always be created in the \"openshift-etcd\" namespace If the PVC is left unspecified \"\" then the platform will choose a reasonable default location to save the backup. In the future this would be backups saved across the control-plane master nodes.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "pvcName is immutable once set",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "backupJob": {
+                    "description": "backupJob is the reference to the Job that executes the backup. Optional",
+                    "properties": {
+                        "name": {
+                            "description": "name is the name of the Job. Required",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "namespace is the namespace of the Job. this is always expected to be \"openshift-etcd\" since the user provided PVC is also required to be in \"openshift-etcd\" Required",
+                            "pattern": "^openshift-etcd$",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "namespace"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "conditions": {
+                    "description": "conditions provide details on the status of the etcd backup job.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/featuregate_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/featuregate_config.openshift.io_v1.json
@@ -1,0 +1,175 @@
+{
+    "description": "Feature holds cluster-wide information about feature gates.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "customNoUpgrade": {
+                    "description": "customNoUpgrade allows the enabling or disabling of any feature. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES. Because of its nature, this setting cannot be validated.  If you have any typos or accidentally apply invalid combinations your cluster may fail in an unrecoverable way.  featureSet must equal \"CustomNoUpgrade\" must be set to use this field.",
+                    "properties": {
+                        "disabled": {
+                            "description": "disabled is a list of all feature gates that you want to force off",
+                            "items": {
+                                "description": "FeatureGateName is a string to enforce patterns on the name of a FeatureGate",
+                                "pattern": "^([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]+\\.?$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "enabled": {
+                            "description": "enabled is a list of all feature gates that you want to force on",
+                            "items": {
+                                "description": "FeatureGateName is a string to enforce patterns on the name of a FeatureGate",
+                                "pattern": "^([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]+\\.?$",
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "additionalProperties": false
+                },
+                "featureSet": {
+                    "description": "featureSet changes the list of features in the cluster.  The default is empty.  Be very careful adjusting this setting. Turning on or off features may cause irreversible changes in your cluster which cannot be undone.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions represent the observations of the current state. Known .status.conditions.type are: \"DeterminationDegraded\"",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "featureGates": {
+                    "description": "featureGates contains a list of enabled and disabled featureGates that are keyed by payloadVersion. Operators other than the CVO and cluster-config-operator, must read the .status.featureGates, locate the version they are managing, find the enabled/disabled featuregates and make the operand and operator match. The enabled/disabled values for a particular version may change during the life of the cluster as various .spec.featureSet values are selected. Operators may choose to restart their processes to pick up these changes, but remembering past enable/disable lists is beyond the scope of this API and is the responsibility of individual operators. Only featureGates with .version in the ClusterVersion.status will be present in this list.",
+                    "items": {
+                        "properties": {
+                            "disabled": {
+                                "description": "disabled is a list of all feature gates that are disabled in the cluster for the named version.",
+                                "items": {
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the name of the FeatureGate.",
+                                            "pattern": "^([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]+\\.?$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "enabled": {
+                                "description": "enabled is a list of all feature gates that are enabled in the cluster for the named version.",
+                                "items": {
+                                    "properties": {
+                                        "name": {
+                                            "description": "name is the name of the FeatureGate.",
+                                            "pattern": "^([A-Za-z0-9-]+\\.)*[A-Za-z0-9-]+\\.?$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "name"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "version": {
+                                "description": "version matches the version provided by the ClusterVersion and in the ClusterOperator.Status.Versions field.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "version"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "version"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/gcpmachineproviderspec_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/gcpmachineproviderspec_machine.openshift.io_v1beta1.json
@@ -1,0 +1,313 @@
+{
+    "description": "GCPMachineProviderSpec is the type that will be embedded in a Machine.Spec.ProviderSpec field for an GCP virtual machine. It is used by the GCP machine actuator to create a single Machine. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "canIPForward": {
+            "description": "CanIPForward Allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes.",
+            "type": "boolean"
+        },
+        "confidentialCompute": {
+            "description": "confidentialCompute Defines whether the instance should have confidential compute enabled. If enabled OnHostMaintenance is required to be set to \"Terminate\". If omitted, the platform chooses a default, which is subject to change over time, currently that default is false.",
+            "enum": [
+                "Enabled",
+                "Disabled"
+            ],
+            "type": "string"
+        },
+        "credentialsSecret": {
+            "description": "CredentialsSecret is a reference to the secret with GCP credentials.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "deletionProtection": {
+            "description": "DeletionProtection whether the resource should be protected against deletion.",
+            "type": "boolean"
+        },
+        "disks": {
+            "description": "Disks is a list of disks to be attached to the VM.",
+            "items": {
+                "description": "GCPDisk describes disks for GCP.",
+                "properties": {
+                    "autoDelete": {
+                        "description": "AutoDelete indicates if the disk will be auto-deleted when the instance is deleted (default false).",
+                        "type": "boolean"
+                    },
+                    "boot": {
+                        "description": "Boot indicates if this is a boot disk (default false).",
+                        "type": "boolean"
+                    },
+                    "encryptionKey": {
+                        "description": "EncryptionKey is the customer-supplied encryption key of the disk.",
+                        "properties": {
+                            "kmsKey": {
+                                "description": "KMSKeyName is the reference KMS key, in the format",
+                                "properties": {
+                                    "keyRing": {
+                                        "description": "KeyRing is the name of the KMS Key Ring which the KMS Key belongs to.",
+                                        "type": "string"
+                                    },
+                                    "location": {
+                                        "description": "Location is the GCP location in which the Key Ring exists.",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name is the name of the customer managed encryption key to be used for the disk encryption.",
+                                        "type": "string"
+                                    },
+                                    "projectID": {
+                                        "description": "ProjectID is the ID of the Project in which the KMS Key Ring exists. Defaults to the VM ProjectID if not set.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "kmsKeyServiceAccount": {
+                                "description": "KMSKeyServiceAccount is the service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used. See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account for details on the default service account.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "image": {
+                        "description": "Image is the source image to create this disk.",
+                        "type": "string"
+                    },
+                    "labels": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Labels list of labels to apply to the disk.",
+                        "type": "object"
+                    },
+                    "sizeGb": {
+                        "description": "SizeGB is the size of the disk (in GB).",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "type": {
+                        "description": "Type is the type of the disk (eg: pd-standard).",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "gcpMetadata": {
+            "description": "Metadata key/value pairs to apply to the VM.",
+            "items": {
+                "description": "GCPMetadata describes metadata for GCP.",
+                "properties": {
+                    "key": {
+                        "description": "Key is the metadata key.",
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "Value is the metadata value.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "gpus": {
+            "description": "GPUs is a list of GPUs to be attached to the VM.",
+            "items": {
+                "description": "GCPGPUConfig describes type and count of GPUs attached to the instance on GCP.",
+                "properties": {
+                    "count": {
+                        "description": "Count is the number of GPUs to be attached to an instance.",
+                        "format": "int32",
+                        "type": "integer",
+                        "minimum": -2147483648,
+                        "maximum": 2147483647
+                    },
+                    "type": {
+                        "description": "Type is the type of GPU to be attached to an instance. Supported GPU types are: nvidia-tesla-k80, nvidia-tesla-p100, nvidia-tesla-v100, nvidia-tesla-p4, nvidia-tesla-t4",
+                        "pattern": "^nvidia-tesla-(k80|p100|v100|p4|t4)$",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "labels": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Labels list of labels to apply to the VM.",
+            "type": "object"
+        },
+        "machineType": {
+            "description": "MachineType is the machine type to use for the VM.",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "networkInterfaces": {
+            "description": "NetworkInterfaces is a list of network interfaces to be attached to the VM.",
+            "items": {
+                "description": "GCPNetworkInterface describes network interfaces for GCP",
+                "properties": {
+                    "network": {
+                        "description": "Network is the network name.",
+                        "type": "string"
+                    },
+                    "projectID": {
+                        "description": "ProjectID is the project in which the GCP machine provider will create the VM.",
+                        "type": "string"
+                    },
+                    "publicIP": {
+                        "description": "PublicIP indicates if true a public IP will be used",
+                        "type": "boolean"
+                    },
+                    "subnetwork": {
+                        "description": "Subnetwork is the subnetwork name.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "onHostMaintenance": {
+            "description": "OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot. This is required to be set to \"Terminate\" if you want to provision machine with attached GPUs. Otherwise, allowed values are \"Migrate\" and \"Terminate\". If omitted, the platform chooses a default, which is subject to change over time, currently that default is \"Migrate\".",
+            "enum": [
+                "Migrate",
+                "Terminate"
+            ],
+            "type": "string"
+        },
+        "preemptible": {
+            "description": "Preemptible indicates if created instance is preemptible.",
+            "type": "boolean"
+        },
+        "projectID": {
+            "description": "ProjectID is the project in which the GCP machine provider will create the VM.",
+            "type": "string"
+        },
+        "region": {
+            "description": "Region is the region in which the GCP machine provider will create the VM.",
+            "type": "string"
+        },
+        "restartPolicy": {
+            "description": "RestartPolicy determines the behavior when an instance crashes or the underlying infrastructure provider stops the instance as part of a maintenance event (default \"Always\"). Cannot be \"Always\" with preemptible instances. Otherwise, allowed values are \"Always\" and \"Never\". If omitted, the platform chooses a default, which is subject to change over time, currently that default is \"Always\". RestartPolicy represents AutomaticRestart in GCP compute api",
+            "enum": [
+                "Always",
+                "Never"
+            ],
+            "type": "string"
+        },
+        "serviceAccounts": {
+            "description": "ServiceAccounts is a list of GCP service accounts to be used by the VM.",
+            "items": {
+                "description": "GCPServiceAccount describes service accounts for GCP.",
+                "properties": {
+                    "email": {
+                        "description": "Email is the service account email.",
+                        "type": "string"
+                    },
+                    "scopes": {
+                        "description": "Scopes list of scopes to be assigned to the service account.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "shieldedInstanceConfig": {
+            "description": "ShieldedInstanceConfig is the Shielded VM configuration for the VM",
+            "properties": {
+                "integrityMonitoring": {
+                    "description": "IntegrityMonitoring determines whether the instance should have integrity monitoring that verify the runtime boot integrity. Compares the most recent boot measurements to the integrity policy baseline and return a pair of pass/fail results depending on whether they match or not. If omitted, the platform chooses a default, which is subject to change over time, currently that default is Enabled.",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ],
+                    "type": "string"
+                },
+                "secureBoot": {
+                    "description": "SecureBoot Defines whether the instance should have secure boot enabled. Secure Boot verify the digital signature of all boot components, and halting the boot process if signature verification fails. If omitted, the platform chooses a default, which is subject to change over time, currently that default is Disabled.",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ],
+                    "type": "string"
+                },
+                "virtualizedTrustedPlatformModule": {
+                    "description": "VirtualizedTrustedPlatformModule enable virtualized trusted platform module measurements to create a known good boot integrity policy baseline. The integrity policy baseline is used for comparison with measurements from subsequent VM boots to determine if anything has changed. This is required to be set to \"Enabled\" if IntegrityMonitoring is enabled. If omitted, the platform chooses a default, which is subject to change over time, currently that default is Enabled.",
+                    "enum": [
+                        "Enabled",
+                        "Disabled"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "tags": {
+            "description": "Tags list of tags to apply to the VM.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "targetPools": {
+            "description": "TargetPools are used for network TCP/UDP load balancing. A target pool references member instances, an associated legacy HttpHealthCheck resource, and, optionally, a backup target pool",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "userDataSecret": {
+            "description": "UserDataSecret contains a local reference to a secret that contains the UserData to apply to the instance",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "zone": {
+            "description": "Zone is the zone in which the GCP machine provider will create the VM.",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/gcpmachineproviderstatus_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/gcpmachineproviderstatus_machine.openshift.io_v1beta1.json
@@ -1,0 +1,73 @@
+{
+    "description": "GCPMachineProviderStatus is the type that will be embedded in a Machine.Status.ProviderStatus field. It contains GCP-specific status information. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "conditions": {
+            "description": "Conditions is a set of conditions associated with the Machine to indicate errors or other status",
+            "items": {
+                "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                "properties": {
+                    "lastTransitionTime": {
+                        "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                        "type": "string"
+                    },
+                    "observedGeneration": {
+                        "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "reason": {
+                        "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "status of the condition, one of True, False, Unknown.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "instanceId": {
+            "description": "InstanceID is the ID of the instance in GCP",
+            "type": "string"
+        },
+        "instanceState": {
+            "description": "InstanceState is the provisioning state of the GCP Instance.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/group_user.openshift.io_v1.json
+++ b/openshift/v4.14-strict/group_user.openshift.io_v1.json
@@ -1,0 +1,29 @@
+{
+    "description": "Group represents a referenceable set of Users \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "users": {
+            "description": "Users is the list of users in this group.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "users"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/helmchartrepository_helm.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/helmchartrepository_helm.openshift.io_v1beta1.json
@@ -1,0 +1,139 @@
+{
+    "description": "HelmChartRepository holds cluster-wide configuration for proxied Helm chart repository \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "connectionConfig": {
+                    "description": "Required configuration for connecting to the chart repo",
+                    "properties": {
+                        "ca": {
+                            "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca-bundle.crt\" is used to locate the data. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced config map",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "tlsClientConfig": {
+                            "description": "tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key \"tls.crt\" is used to locate the client certificate. The key \"tls.key\" is used to locate the private key. The namespace for this secret is openshift-config.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "url": {
+                            "description": "Chart repository URL",
+                            "maxLength": 2048,
+                            "pattern": "^https?:\\/\\/",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "description": {
+                    "description": "Optional human readable repository description, it can be used by UI for displaying purposes",
+                    "maxLength": 2048,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "disabled": {
+                    "description": "If set to true, disable the repo usage in the cluster/namespace",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Optional associated human readable repository name, it can be used by UI for displaying purposes",
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Observed status of the repository within the cluster..",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their statuses",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/hostsubnet_network.openshift.io_v1.json
+++ b/openshift/v4.14-strict/hostsubnet_network.openshift.io_v1.json
@@ -1,0 +1,57 @@
+{
+    "description": "HostSubnet describes the container subnet network on a node. The HostSubnet object must have the same name as the Node object it corresponds to. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "egressCIDRs": {
+            "description": "EgressCIDRs is the list of CIDR ranges available for automatically assigning egress IPs to this node from. If this field is set then EgressIPs should be treated as read-only.",
+            "items": {
+                "description": "HostSubnetEgressCIDR represents one egress CIDR from which to assign IP addresses for this node represented by the HostSubnet",
+                "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "egressIPs": {
+            "description": "EgressIPs is the list of automatic egress IP addresses currently hosted by this node. If EgressCIDRs is empty, this can be set by hand; if EgressCIDRs is set then the master will overwrite the value here with its own allocation of egress IPs.",
+            "items": {
+                "description": "HostSubnetEgressIP represents one egress IP address currently hosted on the node represented by HostSubnet",
+                "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "host": {
+            "description": "Host is the name of the node. (This is the same as the object's name, but both fields must be set.)",
+            "pattern": "^[a-z0-9.-]+$",
+            "type": "string"
+        },
+        "hostIP": {
+            "description": "HostIP is the IP address to be used as a VTEP by other nodes in the overlay network",
+            "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "subnet": {
+            "description": "Subnet is the CIDR range of the overlay network assigned to the node for its pods",
+            "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$",
+            "type": "string"
+        }
+    },
+    "required": [
+        "host",
+        "hostIP",
+        "subnet"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/identity_user.openshift.io_v1.json
+++ b/openshift/v4.14-strict/identity_user.openshift.io_v1.json
@@ -1,0 +1,74 @@
+{
+    "description": "Identity records a successful authentication of a user with an identity provider. The information about the source of authentication is stored on the identity, and the identity is then associated with a single user object. Multiple identities can reference a single user. Information retrieved from the authentication provider is stored in the extra field using a schema determined by the provider. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "extra": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Extra holds extra information about this identity",
+            "type": "object"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "providerName": {
+            "description": "ProviderName is the source of identity information",
+            "type": "string"
+        },
+        "providerUserName": {
+            "description": "ProviderUserName uniquely represents this identity in the scope of the provider",
+            "type": "string"
+        },
+        "user": {
+            "description": "User is a reference to the user this identity is associated with Both Name and UID must be set",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "providerName",
+        "providerUserName",
+        "user"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/image_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/image_config.openshift.io_v1.json
@@ -1,0 +1,125 @@
+{
+    "description": "Image governs policies related to imagestream imports and runtime configuration for external registries. It allows cluster admins to configure which registries OpenShift is allowed to import images from, extra CA trust bundles for external registries, and policies to block or allow registry hostnames. When exposing OpenShift's image registry to the public, this also lets cluster admins specify the external hostname. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "additionalTrustedCA": {
+                    "description": "additionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, build image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "allowedRegistriesForImport": {
+                    "description": "allowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.",
+                    "items": {
+                        "description": "RegistryLocation contains a location of the registry specified by the registry domain name. The domain name might include wildcards, like '*' or '??'.",
+                        "properties": {
+                            "domainName": {
+                                "description": "domainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.",
+                                "type": "string"
+                            },
+                            "insecure": {
+                                "description": "insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.",
+                                "type": "boolean"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "externalRegistryHostnames": {
+                    "description": "externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in \"hostname[:port]\" format.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "registrySources": {
+                    "description": "registrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.",
+                    "properties": {
+                        "allowedRegistries": {
+                            "description": "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied. \n Only one of BlockedRegistries or AllowedRegistries may be set.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "blockedRegistries": {
+                            "description": "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted. \n Only one of BlockedRegistries or AllowedRegistries may be set.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "containerRuntimeSearchRegistries": {
+                            "description": "containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified domains in their pull specs. Registries will be searched in the order provided in the list. Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.",
+                            "format": "hostname",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1,
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                        },
+                        "insecureRegistries": {
+                            "description": "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "externalRegistryHostnames": {
+                    "description": "externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in \"hostname[:port]\" format.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "internalRegistryHostname": {
+                    "description": "internalRegistryHostname sets the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/image_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/image_image.openshift.io_v1.json
@@ -1,0 +1,260 @@
+{
+    "description": "Image is an immutable representation of a container image and metadata at a point in time. Images are named by taking a hash of their contents (metadata and content) and any change in format, content, or metadata results in a new name. The images resource is primarily for use by cluster administrators and integrations like the cluster image registry - end users instead access images via the imagestreamtags or imagestreamimages resources. While image metadata is stored in the API, any integration that implements the container image registry API must provide its own storage for the raw manifest data, image config, and layer contents. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "dockerImageConfig": {
+            "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+            "type": "string"
+        },
+        "dockerImageLayers": {
+            "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+            "items": {
+                "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                "properties": {
+                    "mediaType": {
+                        "description": "MediaType of the referenced object.",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the layer as defined by the underlying store.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size of the layer in bytes as defined by the underlying store.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    }
+                },
+                "required": [
+                    "mediaType",
+                    "name",
+                    "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "dockerImageManifest": {
+            "description": "DockerImageManifest is the raw JSON of the manifest",
+            "type": "string"
+        },
+        "dockerImageManifestMediaType": {
+            "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+            "type": "string"
+        },
+        "dockerImageManifests": {
+            "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+            "items": {
+                "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                "properties": {
+                    "architecture": {
+                        "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                        "type": "string"
+                    },
+                    "digest": {
+                        "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                        "type": "string"
+                    },
+                    "manifestSize": {
+                        "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "mediaType": {
+                        "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                        "type": "string"
+                    },
+                    "os": {
+                        "description": "OS specifies the operating system, for example `linux`.",
+                        "type": "string"
+                    },
+                    "variant": {
+                        "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "architecture",
+                    "digest",
+                    "manifestSize",
+                    "mediaType",
+                    "os"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "dockerImageMetadata": {
+            "description": "DockerImageMetadata contains metadata about this image",
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+        },
+        "dockerImageMetadataVersion": {
+            "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+            "type": "string"
+        },
+        "dockerImageReference": {
+            "description": "DockerImageReference is the string that can be used to pull this image.",
+            "type": "string"
+        },
+        "dockerImageSignatures": {
+            "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+            "items": {
+                "format": "byte",
+                "type": "string",
+                "pattern": "^[\\w\\d+\\/=]*$"
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "signatures": {
+            "description": "Signatures holds all signatures of the image.",
+            "items": {
+                "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                "properties": {
+                    "apiVersion": {
+                        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                        "type": "string"
+                    },
+                    "conditions": {
+                        "description": "Conditions represent the latest available observations of a signature's current state.",
+                        "items": {
+                            "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                            "properties": {
+                                "lastProbeTime": {
+                                    "description": "Last time the condition was checked.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                },
+                                "lastTransitionTime": {
+                                    "description": "Last time the condition transit from one status to another.",
+                                    "format": "date-time",
+                                    "type": "string"
+                                },
+                                "message": {
+                                    "description": "Human readable message indicating details about last transition.",
+                                    "type": "string"
+                                },
+                                "reason": {
+                                    "description": "(brief) reason for the condition's last transition.",
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "description": "Status of the condition, one of True, False, Unknown.",
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "description": "Type of signature condition, Complete or Failed.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "status",
+                                "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": "array"
+                    },
+                    "content": {
+                        "description": "Required: An opaque binary string which is an image's signature.",
+                        "format": "byte",
+                        "type": "string",
+                        "pattern": "^[\\w\\d+\\/=]*$"
+                    },
+                    "created": {
+                        "description": "If specified, it is the time of signature's creation.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "imageIdentity": {
+                        "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                        "type": "string"
+                    },
+                    "issuedBy": {
+                        "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                        "properties": {
+                            "commonName": {
+                                "description": "Common name (e.g. openshift-signing-service).",
+                                "type": "string"
+                            },
+                            "organization": {
+                                "description": "Organization name.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "issuedTo": {
+                        "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                        "properties": {
+                            "commonName": {
+                                "description": "Common name (e.g. openshift-signing-service).",
+                                "type": "string"
+                            },
+                            "organization": {
+                                "description": "Organization name.",
+                                "type": "string"
+                            },
+                            "publicKeyID": {
+                                "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "publicKeyID"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "kind": {
+                        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                        "type": "object"
+                    },
+                    "signedClaims": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Contains claims from the signature.",
+                        "type": "object"
+                    },
+                    "type": {
+                        "description": "Required: Describes a type of stored blob.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "content",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagecontentpolicy_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagecontentpolicy_config.openshift.io_v1.json
@@ -1,0 +1,65 @@
+{
+    "description": "ImageContentPolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "repositoryDigestMirrors": {
+                    "description": "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To pull image from mirrors by tags, should set the \"allowMirrorByTags\". \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified.",
+                    "items": {
+                        "description": "RepositoryDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.",
+                        "properties": {
+                            "allowMirrorByTags": {
+                                "description": "allowMirrorByTags if true, the mirrors can be used to pull the images that are referenced by their tags. Default is false, the mirrors only work when pulling the images that are referenced by their digests. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Forcing digest-pulls for mirrors avoids that issue.",
+                                "type": "boolean"
+                            },
+                            "mirrors": {
+                                "description": "mirrors is zero or more repositories that may also contain the same images. If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. No mirror will be configured. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.",
+                                "items": {
+                                    "pattern": "^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9])(:[0-9]+)?(\\/[^\\/:\\n]+)*(\\/[^\\/:\\n]+((:[^\\/:\\n]+)|(@[^\\n]+)))?$",
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                            },
+                            "source": {
+                                "description": "source is the repository that users refer to, e.g. in image pull specifications.",
+                                "pattern": "^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9])(:[0-9]+)?(\\/[^\\/:\\n]+)*(\\/[^\\/:\\n]+((:[^\\/:\\n]+)|(@[^\\n]+)))?$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "source"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "source"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagecontentsourcepolicy_operator.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/imagecontentsourcepolicy_operator.openshift.io_v1alpha1.json
@@ -1,0 +1,54 @@
+{
+    "description": "ImageContentSourcePolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "repositoryDigestMirrors": {
+                    "description": "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. Only image pull specifications that have an image digest will have this behavior applied to them - tags will continue to be pulled from the specified repository in the pull spec. \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified.",
+                    "items": {
+                        "description": "RepositoryDigestMirrors holds cluster-wide information about how to handle mirros in the registries config. Note: the mirrors only work when pulling the images that are referenced by their digests.",
+                        "properties": {
+                            "mirrors": {
+                                "description": "mirrors is one or more repositories that may also contain the same images. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "source": {
+                                "description": "source is the repository that users refer to, e.g. in image pull specifications.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "source"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagedigestmirrorset_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagedigestmirrorset_config.openshift.io_v1.json
@@ -1,0 +1,70 @@
+{
+    "description": "ImageDigestMirrorSet holds cluster-wide information about how to handle registry mirror rules on using digest pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "imageDigestMirrors": {
+                    "description": "imageDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using tag specification, users should configure a list of mirrors using \"ImageTagMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagedigestmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a specific order of mirrors, should configure them into one list of mirrors using the expected order.",
+                    "items": {
+                        "description": "ImageDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.",
+                        "properties": {
+                            "mirrorSourcePolicy": {
+                                "description": "mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.",
+                                "enum": [
+                                    "NeverContactSource",
+                                    "AllowContactingSource"
+                                ],
+                                "type": "string"
+                            },
+                            "mirrors": {
+                                "description": "mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their digests. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by \"mirrorSourcePolicy\" Other cluster configuration, including (but not limited to) other imageDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. \"mirrors\" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table",
+                                "items": {
+                                    "pattern": "^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$",
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                            },
+                            "source": {
+                                "description": "source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. \"source\" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table",
+                                "pattern": "^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "source"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status contains the observed state of the resource.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagepruner_imageregistry.operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagepruner_imageregistry.operator.openshift.io_v1.json
@@ -1,0 +1,909 @@
+{
+    "description": "ImagePruner is the configuration object for an image registry pruner managed by the registry operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "ImagePrunerSpec defines the specs for the running image pruner.",
+            "properties": {
+                "affinity": {
+                    "description": "affinity is a group of node affinity scheduling rules for the image pruner pod.",
+                    "properties": {
+                        "nodeAffinity": {
+                            "description": "Describes node affinity scheduling rules for the pod.",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                        "properties": {
+                                            "preference": {
+                                                "description": "A node selector term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "preference",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                    "properties": {
+                                        "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "items": {
+                                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "A list of node selector requirements by node's labels.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchFields": {
+                                                        "description": "A list of node selector requirements by node's fields.",
+                                                        "items": {
+                                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "The label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": [
+                                        "nodeSelectorTerms"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAffinity": {
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                            "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                    "items": {
+                                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                        "properties": {
+                                            "podAffinityTerm": {
+                                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                                "properties": {
+                                                    "labelSelector": {
+                                                        "description": "A label query over a set of resources, in this case pods.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaceSelector": {
+                                                        "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                        "properties": {
+                                                            "matchExpressions": {
+                                                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                                "items": {
+                                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                                    "properties": {
+                                                                        "key": {
+                                                                            "description": "key is the label key that the selector applies to.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                            "items": {
+                                                                                "type": "string"
+                                                                            },
+                                                                            "type": "array"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "key",
+                                                                        "operator"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "matchLabels": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "namespaces": {
+                                                        "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "topologyKey": {
+                                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "topologyKey"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "weight": {
+                                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            }
+                                        },
+                                        "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                    "items": {
+                                        "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                        "properties": {
+                                            "labelSelector": {
+                                                "description": "A label query over a set of resources, in this case pods.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaceSelector": {
+                                                "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                        "items": {
+                                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "description": "key is the label key that the selector applies to.",
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "operator"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "namespaces": {
+                                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "topologyKey": {
+                                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "topologyKey"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "failedJobsHistoryLimit": {
+                    "description": "failedJobsHistoryLimit specifies how many failed image pruner jobs to retain. Defaults to 3 if not set.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "ignoreInvalidImageReferences": {
+                    "description": "ignoreInvalidImageReferences indicates whether the pruner can ignore errors while parsing image references.",
+                    "type": "boolean"
+                },
+                "keepTagRevisions": {
+                    "description": "keepTagRevisions specifies the number of image revisions for a tag in an image stream that will be preserved. Defaults to 3.",
+                    "type": "integer"
+                },
+                "keepYoungerThan": {
+                    "description": "keepYoungerThan specifies the minimum age in nanoseconds of an image and its referrers for it to be considered a candidate for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration. If both are set, this field is ignored and keepYoungerThanDuration takes precedence.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "keepYoungerThanDuration": {
+                    "description": "keepYoungerThanDuration specifies the minimum age of an image and its referrers for it to be considered a candidate for pruning. Defaults to 60m (60 minutes).",
+                    "format": "duration",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel sets the level of log output for the pruner job. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "nodeSelector defines the node selection constraints for the image pruner pod.",
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "resources defines the resource requests and limits for the image pruner pod.",
+                    "properties": {
+                        "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                            "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "limits": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        },
+                        "requests": {
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "type": "integer"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                            },
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "schedule": {
+                    "description": "schedule specifies when to execute the job using standard cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0 0 * * *`.",
+                    "type": "string"
+                },
+                "successfulJobsHistoryLimit": {
+                    "description": "successfulJobsHistoryLimit specifies how many successful image pruner jobs to retain. Defaults to 3 if not set.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "suspend": {
+                    "description": "suspend specifies whether or not to suspend subsequent executions of this cronjob. Defaults to false.",
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "description": "tolerations defines the node tolerations for the image pruner pod.",
+                    "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                        "properties": {
+                            "effect": {
+                                "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                            },
+                            "key": {
+                                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                "type": "string"
+                            },
+                            "operator": {
+                                "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                "type": "string"
+                            },
+                            "tolerationSeconds": {
+                                "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "value": {
+                                "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "ImagePrunerStatus reports image pruner operational status.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status.",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change that has been applied.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagesignature_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagesignature_image.openshift.io_v1.json
@@ -1,0 +1,127 @@
+{
+    "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "conditions": {
+            "description": "Conditions represent the latest available observations of a signature's current state.",
+            "items": {
+                "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                "properties": {
+                    "lastProbeTime": {
+                        "description": "Last time the condition was checked.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "lastTransitionTime": {
+                        "description": "Last time the condition transit from one status to another.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Human readable message indicating details about last transition.",
+                        "type": "string"
+                    },
+                    "reason": {
+                        "description": "(brief) reason for the condition's last transition.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status of the condition, one of True, False, Unknown.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type of signature condition, Complete or Failed.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "status",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "content": {
+            "description": "Required: An opaque binary string which is an image's signature.",
+            "format": "byte",
+            "type": "string",
+            "pattern": "^[\\w\\d+\\/=]*$"
+        },
+        "created": {
+            "description": "If specified, it is the time of signature's creation.",
+            "format": "date-time",
+            "type": "string"
+        },
+        "imageIdentity": {
+            "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+            "type": "string"
+        },
+        "issuedBy": {
+            "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+            "properties": {
+                "commonName": {
+                    "description": "Common name (e.g. openshift-signing-service).",
+                    "type": "string"
+                },
+                "organization": {
+                    "description": "Organization name.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "issuedTo": {
+            "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+            "properties": {
+                "commonName": {
+                    "description": "Common name (e.g. openshift-signing-service).",
+                    "type": "string"
+                },
+                "organization": {
+                    "description": "Organization name.",
+                    "type": "string"
+                },
+                "publicKeyID": {
+                    "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "publicKeyID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "signedClaims": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Contains claims from the signature.",
+            "type": "object"
+        },
+        "type": {
+            "description": "Required: Describes a type of stored blob.",
+            "type": "string"
+        }
+    },
+    "required": [
+        "content",
+        "type"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestream_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestream_image.openshift.io_v1.json
@@ -1,0 +1,266 @@
+{
+    "description": "An ImageStream stores a mapping of tags to images, metadata overrides that are applied when images are tagged in a stream, and an optional reference to a container image repository on a registry. Users typically update the spec.tags field to point to external images which are imported from container registries using credentials in your namespace with the pull secret type, or to existing image stream tags and images which are immediately accessible for tagging or pulling. The history of images applied to a tag is visible in the status.tags field and any user who can view an image stream is allowed to tag that image into their own image streams. Access to pull images from the integrated registry is granted by having the \"get imagestreams/layers\" permission on a given image stream. Users may remove a tag by deleting the imagestreamtag resource, which causes both spec and status for that tag to be removed. Image stream history is retained until an administrator runs the prune operation, which removes references that are no longer in use. To preserve a historical image, ensure there is a tag in spec pointing to that image by its digest. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec describes the desired state of this stream",
+            "properties": {
+                "dockerImageRepository": {
+                    "description": "dockerImageRepository is optional, if specified this stream is backed by a container repository on this server Deprecated: This field is deprecated as of v3.7 and will be removed in a future release. Specify the source for the tags to be imported in each tag via the spec.tags.from reference instead.",
+                    "type": "string"
+                },
+                "lookupPolicy": {
+                    "description": "lookupPolicy controls how other resources reference images within this namespace.",
+                    "properties": {
+                        "local": {
+                            "description": "local will change the docker short image references (like \"mysql\" or \"php:latest\") on objects in this namespace to the image ID whenever they match this image stream, instead of reaching out to a remote registry. The name will be fully qualified to an image ID if found. The tag's referencePolicy is taken into account on the replaced value. Only works within the current namespace.",
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "local"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tags": {
+                    "description": "tags map arbitrary string values to specific image locators",
+                    "items": {
+                        "description": "TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.",
+                        "properties": {
+                            "annotations": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.",
+                                "type": "object"
+                            },
+                            "from": {
+                                "description": "Optional; if specified, a reference to another image that this tag should point to. Valid values are ImageStreamTag, ImageStreamImage, and DockerImage.  ImageStreamTag references can only reference a tag within this same ImageStream.",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "API version of the referent.",
+                                        "type": "string"
+                                    },
+                                    "fieldPath": {
+                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                        "type": "string"
+                                    },
+                                    "resourceVersion": {
+                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                        "type": "string"
+                                    },
+                                    "uid": {
+                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "generation": {
+                                "description": "Generation is a counter that tracks mutations to the spec tag (user intent). When a tag reference is changed the generation is set to match the current stream generation (which is incremented every time spec is changed). Other processes in the system like the image importer observe that the generation of spec tag is newer than the generation recorded in the status and use that as a trigger to import the newest remote tag. To trigger a new import, clients may set this value to zero which will reset the generation to the latest stream generation. Legacy clients will send this value as nil which will be merged with the current tag generation.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "importPolicy": {
+                                "description": "ImportPolicy is information that controls how images may be imported by the server.",
+                                "properties": {
+                                    "importMode": {
+                                        "description": "ImportMode describes how to import an image manifest.",
+                                        "type": "string"
+                                    },
+                                    "insecure": {
+                                        "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                                        "type": "boolean"
+                                    },
+                                    "scheduled": {
+                                        "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "name": {
+                                "description": "Name of the tag",
+                                "type": "string"
+                            },
+                            "reference": {
+                                "description": "Reference states if the tag will be imported. Default value is false, which means the tag will be imported.",
+                                "type": "boolean"
+                            },
+                            "referencePolicy": {
+                                "description": "ReferencePolicy defines how other components should consume the image.",
+                                "properties": {
+                                    "type": {
+                                        "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status describes the current state of this stream",
+            "properties": {
+                "dockerImageRepository": {
+                    "description": "DockerImageRepository represents the effective location this stream may be accessed at. May be empty until the server determines where the repository is located",
+                    "type": "string"
+                },
+                "publicDockerImageRepository": {
+                    "description": "PublicDockerImageRepository represents the public location from where the image can be pulled outside the cluster. This field may be empty if the administrator has not exposed the integrated registry externally.",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags are a historical record of images associated with each tag. The first entry in the TagEvent array is the currently tagged image.",
+                    "items": {
+                        "description": "NamedTagEventList relates a tag to its image history.",
+                        "properties": {
+                            "conditions": {
+                                "description": "Conditions is an array of conditions that apply to the tag event list.",
+                                "items": {
+                                    "description": "TagEventCondition contains condition information for a tag event.",
+                                    "properties": {
+                                        "generation": {
+                                            "description": "Generation is the spec tag generation that this status corresponds to",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "lastTransitionTime": {
+                                            "description": "LastTransitionTIme is the time the condition transitioned from one status to another.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Message is a human readable description of the details about last transition, complementing reason.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type of tag event condition, currently only ImportSuccess",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "generation",
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "items": {
+                                "description": "Standard object's metadata.",
+                                "items": {
+                                    "description": "TagEvent is used by ImageStreamStatus to keep a historical record of images associated with a tag.",
+                                    "properties": {
+                                        "created": {
+                                            "description": "Created holds the time the TagEvent was created",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "dockerImageReference": {
+                                            "description": "DockerImageReference is the string that can be used to pull this image",
+                                            "type": "string"
+                                        },
+                                        "generation": {
+                                            "description": "Generation is the spec tag generation that resulted in this tag being updated",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "image": {
+                                            "description": "Image is the image",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "created",
+                                        "dockerImageReference",
+                                        "generation",
+                                        "image"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "description": "Tag is the tag for which the history is recorded",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "items",
+                            "tag"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "dockerImageRepository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestreamimage_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestreamimage_image.openshift.io_v1.json
@@ -1,0 +1,282 @@
+{
+    "description": "ImageStreamImage represents an Image that is retrieved by image name from an ImageStream. User interfaces and regular users can use this resource to access the metadata details of a tagged image in the image stream history for viewing, since Image resources are not directly accessible to end users. A not found error will be returned if no such image is referenced by a tag within the ImageStream. Images are created when spec tags are set on an image stream that represent an image in an external registry, when pushing to the integrated registry, or when tagging an existing image from one image stream to another. The name of an image stream image is in the form \"<STREAM>@<DIGEST>\", where the digest is the content addressible identifier for the image (sha256:xxxxx...). You can use ImageStreamImages as the from.kind of an image stream spec tag to reference an image exactly. The only operations supported on the imagestreamimage endpoint are retrieving the image. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "image": {
+            "description": "Image associated with the ImageStream and image name.",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dockerImageConfig": {
+                    "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                    "type": "string"
+                },
+                "dockerImageLayers": {
+                    "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                    "items": {
+                        "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                        "properties": {
+                            "mediaType": {
+                                "description": "MediaType of the referenced object.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Name of the layer as defined by the underlying store.",
+                                "type": "string"
+                            },
+                            "size": {
+                                "description": "Size of the layer in bytes as defined by the underlying store.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "required": [
+                            "mediaType",
+                            "name",
+                            "size"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageManifest": {
+                    "description": "DockerImageManifest is the raw JSON of the manifest",
+                    "type": "string"
+                },
+                "dockerImageManifestMediaType": {
+                    "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                    "type": "string"
+                },
+                "dockerImageManifests": {
+                    "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                    "items": {
+                        "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                        "properties": {
+                            "architecture": {
+                                "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                "type": "string"
+                            },
+                            "digest": {
+                                "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                "type": "string"
+                            },
+                            "manifestSize": {
+                                "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "mediaType": {
+                                "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                "type": "string"
+                            },
+                            "os": {
+                                "description": "OS specifies the operating system, for example `linux`.",
+                                "type": "string"
+                            },
+                            "variant": {
+                                "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "architecture",
+                            "digest",
+                            "manifestSize",
+                            "mediaType",
+                            "os"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageMetadata": {
+                    "description": "DockerImageMetadata contains metadata about this image",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dockerImageMetadataVersion": {
+                    "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                    "type": "string"
+                },
+                "dockerImageReference": {
+                    "description": "DockerImageReference is the string that can be used to pull this image.",
+                    "type": "string"
+                },
+                "dockerImageSignatures": {
+                    "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                    "items": {
+                        "format": "byte",
+                        "type": "string",
+                        "pattern": "^[\\w\\d+\\/=]*$"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object"
+                },
+                "signatures": {
+                    "description": "Signatures holds all signatures of the image.",
+                    "items": {
+                        "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                        "properties": {
+                            "apiVersion": {
+                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                "type": "string"
+                            },
+                            "conditions": {
+                                "description": "Conditions represent the latest available observations of a signature's current state.",
+                                "items": {
+                                    "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                    "properties": {
+                                        "lastProbeTime": {
+                                            "description": "Last time the condition was checked.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "lastTransitionTime": {
+                                            "description": "Last time the condition transit from one status to another.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type of signature condition, Complete or Failed.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "content": {
+                                "description": "Required: An opaque binary string which is an image's signature.",
+                                "format": "byte",
+                                "type": "string",
+                                "pattern": "^[\\w\\d+\\/=]*$"
+                            },
+                            "created": {
+                                "description": "If specified, it is the time of signature's creation.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "imageIdentity": {
+                                "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                "type": "string"
+                            },
+                            "issuedBy": {
+                                "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "issuedTo": {
+                                "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    },
+                                    "publicKeyID": {
+                                        "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "publicKeyID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "kind": {
+                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                "type": "object"
+                            },
+                            "signedClaims": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Contains claims from the signature.",
+                                "type": "object"
+                            },
+                            "type": {
+                                "description": "Required: Describes a type of stored blob.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "image"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestreamimport_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestreamimport_image.openshift.io_v1.json
@@ -1,0 +1,1926 @@
+{
+    "description": "The image stream import resource provides an easy way for a user to find and import container images from other container image registries into the server. Individual images or an entire image repository may be imported, and users may choose to see the results of the import prior to tagging the resulting images into the specified image stream. \n This API is intended for end-user tools that need to see the metadata of the image prior to import (for instance, to generate an application from it). Clients that know the desired image can continue to create spec.tags directly into their image streams. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec is a description of the images that the user wishes to import",
+            "properties": {
+                "images": {
+                    "description": "Images are a list of individual images to import.",
+                    "items": {
+                        "description": "ImageImportSpec describes a request to import a specific image.",
+                        "properties": {
+                            "from": {
+                                "description": "From is the source of an image to import; only kind DockerImage is allowed",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "API version of the referent.",
+                                        "type": "string"
+                                    },
+                                    "fieldPath": {
+                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                        "type": "string"
+                                    },
+                                    "resourceVersion": {
+                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                        "type": "string"
+                                    },
+                                    "uid": {
+                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "importPolicy": {
+                                "description": "ImportPolicy is the policy controlling how the image is imported",
+                                "properties": {
+                                    "importMode": {
+                                        "description": "ImportMode describes how to import an image manifest.",
+                                        "type": "string"
+                                    },
+                                    "insecure": {
+                                        "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                                        "type": "boolean"
+                                    },
+                                    "scheduled": {
+                                        "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "includeManifest": {
+                                "description": "IncludeManifest determines if the manifest for each image is returned in the response",
+                                "type": "boolean"
+                            },
+                            "referencePolicy": {
+                                "description": "ReferencePolicy defines how other components should consume the image",
+                                "properties": {
+                                    "type": {
+                                        "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "to": {
+                                "description": "To is a tag in the current image stream to assign the imported image to, if name is not specified the default tag from from.name will be used",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "from"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "import": {
+                    "description": "Import indicates whether to perform an import - if so, the specified tags are set on the spec and status of the image stream defined by the type meta.",
+                    "type": "boolean"
+                },
+                "repository": {
+                    "description": "Repository is an optional import of an entire container image repository. A maximum limit on the number of tags imported this way is imposed by the server.",
+                    "properties": {
+                        "from": {
+                            "description": "From is the source for the image repository to import; only kind DockerImage and a name of a container image repository is allowed",
+                            "properties": {
+                                "apiVersion": {
+                                    "description": "API version of the referent.",
+                                    "type": "string"
+                                },
+                                "fieldPath": {
+                                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                    "type": "string"
+                                },
+                                "kind": {
+                                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                    "type": "string"
+                                },
+                                "resourceVersion": {
+                                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                    "type": "string"
+                                },
+                                "uid": {
+                                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "importPolicy": {
+                            "description": "ImportPolicy is the policy controlling how the image is imported",
+                            "properties": {
+                                "importMode": {
+                                    "description": "ImportMode describes how to import an image manifest.",
+                                    "type": "string"
+                                },
+                                "insecure": {
+                                    "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                                    "type": "boolean"
+                                },
+                                "scheduled": {
+                                    "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "includeManifest": {
+                            "description": "IncludeManifest determines if the manifest for each image is returned in the response",
+                            "type": "boolean"
+                        },
+                        "referencePolicy": {
+                            "description": "ReferencePolicy defines how other components should consume the image",
+                            "properties": {
+                                "type": {
+                                    "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "required": [
+                        "from"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "import"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status is the result of importing the image",
+            "properties": {
+                "images": {
+                    "description": "Images is set with the result of importing spec.images",
+                    "items": {
+                        "description": "ImageImportStatus describes the result of an image import.",
+                        "properties": {
+                            "image": {
+                                "description": "Image is the metadata of that image, if the image was located",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                        "type": "string"
+                                    },
+                                    "dockerImageConfig": {
+                                        "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                                        "type": "string"
+                                    },
+                                    "dockerImageLayers": {
+                                        "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                                        "items": {
+                                            "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                                            "properties": {
+                                                "mediaType": {
+                                                    "description": "MediaType of the referenced object.",
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "description": "Name of the layer as defined by the underlying store.",
+                                                    "type": "string"
+                                                },
+                                                "size": {
+                                                    "description": "Size of the layer in bytes as defined by the underlying store.",
+                                                    "format": "int64",
+                                                    "type": "integer",
+                                                    "minimum": -9223372036854776000,
+                                                    "maximum": 9223372036854776000
+                                                }
+                                            },
+                                            "required": [
+                                                "mediaType",
+                                                "name",
+                                                "size"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "dockerImageManifest": {
+                                        "description": "DockerImageManifest is the raw JSON of the manifest",
+                                        "type": "string"
+                                    },
+                                    "dockerImageManifestMediaType": {
+                                        "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                                        "type": "string"
+                                    },
+                                    "dockerImageManifests": {
+                                        "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                                        "items": {
+                                            "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                                            "properties": {
+                                                "architecture": {
+                                                    "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                                    "type": "string"
+                                                },
+                                                "digest": {
+                                                    "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                                    "type": "string"
+                                                },
+                                                "manifestSize": {
+                                                    "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                                    "format": "int64",
+                                                    "type": "integer",
+                                                    "minimum": -9223372036854776000,
+                                                    "maximum": 9223372036854776000
+                                                },
+                                                "mediaType": {
+                                                    "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                                    "type": "string"
+                                                },
+                                                "os": {
+                                                    "description": "OS specifies the operating system, for example `linux`.",
+                                                    "type": "string"
+                                                },
+                                                "variant": {
+                                                    "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "architecture",
+                                                "digest",
+                                                "manifestSize",
+                                                "mediaType",
+                                                "os"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "dockerImageMetadata": {
+                                        "description": "DockerImageMetadata contains metadata about this image",
+                                        "type": "object",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                    },
+                                    "dockerImageMetadataVersion": {
+                                        "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                                        "type": "string"
+                                    },
+                                    "dockerImageReference": {
+                                        "description": "DockerImageReference is the string that can be used to pull this image.",
+                                        "type": "string"
+                                    },
+                                    "dockerImageSignatures": {
+                                        "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                                        "items": {
+                                            "format": "byte",
+                                            "type": "string",
+                                            "pattern": "^[\\w\\d+\\/=]*$"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "kind": {
+                                        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                        "type": "object"
+                                    },
+                                    "signatures": {
+                                        "description": "Signatures holds all signatures of the image.",
+                                        "items": {
+                                            "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                            "properties": {
+                                                "apiVersion": {
+                                                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                    "type": "string"
+                                                },
+                                                "conditions": {
+                                                    "description": "Conditions represent the latest available observations of a signature's current state.",
+                                                    "items": {
+                                                        "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                                        "properties": {
+                                                            "lastProbeTime": {
+                                                                "description": "Last time the condition was checked.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "lastTransitionTime": {
+                                                                "description": "Last time the condition transit from one status to another.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "message": {
+                                                                "description": "Human readable message indicating details about last transition.",
+                                                                "type": "string"
+                                                            },
+                                                            "reason": {
+                                                                "description": "(brief) reason for the condition's last transition.",
+                                                                "type": "string"
+                                                            },
+                                                            "status": {
+                                                                "description": "Status of the condition, one of True, False, Unknown.",
+                                                                "type": "string"
+                                                            },
+                                                            "type": {
+                                                                "description": "Type of signature condition, Complete or Failed.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "status",
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "content": {
+                                                    "description": "Required: An opaque binary string which is an image's signature.",
+                                                    "format": "byte",
+                                                    "type": "string",
+                                                    "pattern": "^[\\w\\d+\\/=]*$"
+                                                },
+                                                "created": {
+                                                    "description": "If specified, it is the time of signature's creation.",
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "imageIdentity": {
+                                                    "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                                    "type": "string"
+                                                },
+                                                "issuedBy": {
+                                                    "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                                    "properties": {
+                                                        "commonName": {
+                                                            "description": "Common name (e.g. openshift-signing-service).",
+                                                            "type": "string"
+                                                        },
+                                                        "organization": {
+                                                            "description": "Organization name.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "issuedTo": {
+                                                    "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                                    "properties": {
+                                                        "commonName": {
+                                                            "description": "Common name (e.g. openshift-signing-service).",
+                                                            "type": "string"
+                                                        },
+                                                        "organization": {
+                                                            "description": "Organization name.",
+                                                            "type": "string"
+                                                        },
+                                                        "publicKeyID": {
+                                                            "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "publicKeyID"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "kind": {
+                                                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                    "type": "string"
+                                                },
+                                                "metadata": {
+                                                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                    "type": "object"
+                                                },
+                                                "signedClaims": {
+                                                    "additionalProperties": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": "Contains claims from the signature.",
+                                                    "type": "object"
+                                                },
+                                                "type": {
+                                                    "description": "Required: Describes a type of stored blob.",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "content",
+                                                "type"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "manifests": {
+                                "description": "Manifests holds sub-manifests metadata when importing a manifest list",
+                                "items": {
+                                    "description": "Image is an immutable representation of a container image and metadata at a point in time. Images are named by taking a hash of their contents (metadata and content) and any change in format, content, or metadata results in a new name. The images resource is primarily for use by cluster administrators and integrations like the cluster image registry - end users instead access images via the imagestreamtags or imagestreamimages resources. While image metadata is stored in the API, any integration that implements the container image registry API must provide its own storage for the raw manifest data, image config, and layer contents. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                    "properties": {
+                                        "apiVersion": {
+                                            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                            "type": "string"
+                                        },
+                                        "dockerImageConfig": {
+                                            "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                                            "type": "string"
+                                        },
+                                        "dockerImageLayers": {
+                                            "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                                            "items": {
+                                                "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                                                "properties": {
+                                                    "mediaType": {
+                                                        "description": "MediaType of the referenced object.",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the layer as defined by the underlying store.",
+                                                        "type": "string"
+                                                    },
+                                                    "size": {
+                                                        "description": "Size of the layer in bytes as defined by the underlying store.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    }
+                                                },
+                                                "required": [
+                                                    "mediaType",
+                                                    "name",
+                                                    "size"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "dockerImageManifest": {
+                                            "description": "DockerImageManifest is the raw JSON of the manifest",
+                                            "type": "string"
+                                        },
+                                        "dockerImageManifestMediaType": {
+                                            "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                                            "type": "string"
+                                        },
+                                        "dockerImageManifests": {
+                                            "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                                            "items": {
+                                                "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                                                "properties": {
+                                                    "architecture": {
+                                                        "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                                        "type": "string"
+                                                    },
+                                                    "digest": {
+                                                        "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                                        "type": "string"
+                                                    },
+                                                    "manifestSize": {
+                                                        "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "mediaType": {
+                                                        "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                                        "type": "string"
+                                                    },
+                                                    "os": {
+                                                        "description": "OS specifies the operating system, for example `linux`.",
+                                                        "type": "string"
+                                                    },
+                                                    "variant": {
+                                                        "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "architecture",
+                                                    "digest",
+                                                    "manifestSize",
+                                                    "mediaType",
+                                                    "os"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "dockerImageMetadata": {
+                                            "description": "DockerImageMetadata contains metadata about this image",
+                                            "type": "object",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                        },
+                                        "dockerImageMetadataVersion": {
+                                            "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                                            "type": "string"
+                                        },
+                                        "dockerImageReference": {
+                                            "description": "DockerImageReference is the string that can be used to pull this image.",
+                                            "type": "string"
+                                        },
+                                        "dockerImageSignatures": {
+                                            "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                                            "items": {
+                                                "format": "byte",
+                                                "type": "string",
+                                                "pattern": "^[\\w\\d+\\/=]*$"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "kind": {
+                                            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "metadata": {
+                                            "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                            "type": "object"
+                                        },
+                                        "signatures": {
+                                            "description": "Signatures holds all signatures of the image.",
+                                            "items": {
+                                                "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                        "type": "string"
+                                                    },
+                                                    "conditions": {
+                                                        "description": "Conditions represent the latest available observations of a signature's current state.",
+                                                        "items": {
+                                                            "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                                            "properties": {
+                                                                "lastProbeTime": {
+                                                                    "description": "Last time the condition was checked.",
+                                                                    "format": "date-time",
+                                                                    "type": "string"
+                                                                },
+                                                                "lastTransitionTime": {
+                                                                    "description": "Last time the condition transit from one status to another.",
+                                                                    "format": "date-time",
+                                                                    "type": "string"
+                                                                },
+                                                                "message": {
+                                                                    "description": "Human readable message indicating details about last transition.",
+                                                                    "type": "string"
+                                                                },
+                                                                "reason": {
+                                                                    "description": "(brief) reason for the condition's last transition.",
+                                                                    "type": "string"
+                                                                },
+                                                                "status": {
+                                                                    "description": "Status of the condition, one of True, False, Unknown.",
+                                                                    "type": "string"
+                                                                },
+                                                                "type": {
+                                                                    "description": "Type of signature condition, Complete or Failed.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "status",
+                                                                "type"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "content": {
+                                                        "description": "Required: An opaque binary string which is an image's signature.",
+                                                        "format": "byte",
+                                                        "type": "string",
+                                                        "pattern": "^[\\w\\d+\\/=]*$"
+                                                    },
+                                                    "created": {
+                                                        "description": "If specified, it is the time of signature's creation.",
+                                                        "format": "date-time",
+                                                        "type": "string"
+                                                    },
+                                                    "imageIdentity": {
+                                                        "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                                        "type": "string"
+                                                    },
+                                                    "issuedBy": {
+                                                        "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                                        "properties": {
+                                                            "commonName": {
+                                                                "description": "Common name (e.g. openshift-signing-service).",
+                                                                "type": "string"
+                                                            },
+                                                            "organization": {
+                                                                "description": "Organization name.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "issuedTo": {
+                                                        "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                                        "properties": {
+                                                            "commonName": {
+                                                                "description": "Common name (e.g. openshift-signing-service).",
+                                                                "type": "string"
+                                                            },
+                                                            "organization": {
+                                                                "description": "Organization name.",
+                                                                "type": "string"
+                                                            },
+                                                            "publicKeyID": {
+                                                                "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "publicKeyID"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "kind": {
+                                                        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                        "type": "string"
+                                                    },
+                                                    "metadata": {
+                                                        "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                        "type": "object"
+                                                    },
+                                                    "signedClaims": {
+                                                        "additionalProperties": {
+                                                            "type": "string"
+                                                        },
+                                                        "description": "Contains claims from the signature.",
+                                                        "type": "object"
+                                                    },
+                                                    "type": {
+                                                        "description": "Required: Describes a type of stored blob.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "content",
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "status": {
+                                "description": "Status is the status of the image import, including errors encountered while retrieving the image",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                        "type": "string"
+                                    },
+                                    "code": {
+                                        "description": "Suggested HTTP return code for this status, 0 if not set.",
+                                        "format": "int32",
+                                        "type": "integer",
+                                        "minimum": -2147483648,
+                                        "maximum": 2147483647
+                                    },
+                                    "details": {
+                                        "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+                                        "properties": {
+                                            "causes": {
+                                                "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                                                "items": {
+                                                    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+                                                    "properties": {
+                                                        "field": {
+                                                            "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional. \n Examples: \"name\" - the field \"name\" on the current resource \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+                                                            "type": "string"
+                                                        },
+                                                        "message": {
+                                                            "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+                                                            "type": "string"
+                                                        },
+                                                        "reason": {
+                                                            "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "group": {
+                                                "description": "The group attribute of the resource associated with the status StatusReason.",
+                                                "type": "string"
+                                            },
+                                            "kind": {
+                                                "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                                                "type": "string"
+                                            },
+                                            "retryAfterSeconds": {
+                                                "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            },
+                                            "uid": {
+                                                "description": "UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "kind": {
+                                        "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "message": {
+                                        "description": "A human-readable description of the status of this operation.",
+                                        "type": "string"
+                                    },
+                                    "metadata": {
+                                        "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "properties": {
+                                            "continue": {
+                                                "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+                                                "type": "string"
+                                            },
+                                            "remainingItemCount": {
+                                                "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "minimum": -9223372036854776000,
+                                                "maximum": 9223372036854776000
+                                            },
+                                            "resourceVersion": {
+                                                "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                "type": "string"
+                                            },
+                                            "selfLink": {
+                                                "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "reason": {
+                                        "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                                        "type": "string"
+                                    },
+                                    "status": {
+                                        "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "tag": {
+                                "description": "Tag is the tag this image was located under, if any",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "status"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "import": {
+                    "description": "Import is the image stream that was successfully updated or created when 'to' was set.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "metadata": {
+                            "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "type": "object"
+                        },
+                        "spec": {
+                            "description": "Spec describes the desired state of this stream",
+                            "properties": {
+                                "dockerImageRepository": {
+                                    "description": "dockerImageRepository is optional, if specified this stream is backed by a container repository on this server Deprecated: This field is deprecated as of v3.7 and will be removed in a future release. Specify the source for the tags to be imported in each tag via the spec.tags.from reference instead.",
+                                    "type": "string"
+                                },
+                                "lookupPolicy": {
+                                    "description": "lookupPolicy controls how other resources reference images within this namespace.",
+                                    "properties": {
+                                        "local": {
+                                            "description": "local will change the docker short image references (like \"mysql\" or \"php:latest\") on objects in this namespace to the image ID whenever they match this image stream, instead of reaching out to a remote registry. The name will be fully qualified to an image ID if found. The tag's referencePolicy is taken into account on the replaced value. Only works within the current namespace.",
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "required": [
+                                        "local"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "tags": {
+                                    "description": "tags map arbitrary string values to specific image locators",
+                                    "items": {
+                                        "description": "TagReference specifies optional annotations for images using this tag and an optional reference to an ImageStreamTag, ImageStreamImage, or DockerImage this tag should track.",
+                                        "properties": {
+                                            "annotations": {
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.",
+                                                "type": "object"
+                                            },
+                                            "from": {
+                                                "description": "Optional; if specified, a reference to another image that this tag should point to. Valid values are ImageStreamTag, ImageStreamImage, and DockerImage.  ImageStreamTag references can only reference a tag within this same ImageStream.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "API version of the referent.",
+                                                        "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                                        "type": "string"
+                                                    },
+                                                    "kind": {
+                                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                        "type": "string"
+                                                    },
+                                                    "namespace": {
+                                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                                        "type": "string"
+                                                    },
+                                                    "resourceVersion": {
+                                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                        "type": "string"
+                                                    },
+                                                    "uid": {
+                                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "generation": {
+                                                "description": "Generation is a counter that tracks mutations to the spec tag (user intent). When a tag reference is changed the generation is set to match the current stream generation (which is incremented every time spec is changed). Other processes in the system like the image importer observe that the generation of spec tag is newer than the generation recorded in the status and use that as a trigger to import the newest remote tag. To trigger a new import, clients may set this value to zero which will reset the generation to the latest stream generation. Legacy clients will send this value as nil which will be merged with the current tag generation.",
+                                                "format": "int64",
+                                                "type": "integer",
+                                                "minimum": -9223372036854776000,
+                                                "maximum": 9223372036854776000
+                                            },
+                                            "importPolicy": {
+                                                "description": "ImportPolicy is information that controls how images may be imported by the server.",
+                                                "properties": {
+                                                    "importMode": {
+                                                        "description": "ImportMode describes how to import an image manifest.",
+                                                        "type": "string"
+                                                    },
+                                                    "insecure": {
+                                                        "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "scheduled": {
+                                                        "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "Name of the tag",
+                                                "type": "string"
+                                            },
+                                            "reference": {
+                                                "description": "Reference states if the tag will be imported. Default value is false, which means the tag will be imported.",
+                                                "type": "boolean"
+                                            },
+                                            "referencePolicy": {
+                                                "description": "ReferencePolicy defines how other components should consume the image.",
+                                                "properties": {
+                                                    "type": {
+                                                        "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "status": {
+                            "description": "Status describes the current state of this stream",
+                            "properties": {
+                                "dockerImageRepository": {
+                                    "description": "DockerImageRepository represents the effective location this stream may be accessed at. May be empty until the server determines where the repository is located",
+                                    "type": "string"
+                                },
+                                "publicDockerImageRepository": {
+                                    "description": "PublicDockerImageRepository represents the public location from where the image can be pulled outside the cluster. This field may be empty if the administrator has not exposed the integrated registry externally.",
+                                    "type": "string"
+                                },
+                                "tags": {
+                                    "description": "Tags are a historical record of images associated with each tag. The first entry in the TagEvent array is the currently tagged image.",
+                                    "items": {
+                                        "description": "NamedTagEventList relates a tag to its image history.",
+                                        "properties": {
+                                            "conditions": {
+                                                "description": "Conditions is an array of conditions that apply to the tag event list.",
+                                                "items": {
+                                                    "description": "TagEventCondition contains condition information for a tag event.",
+                                                    "properties": {
+                                                        "generation": {
+                                                            "description": "Generation is the spec tag generation that this status corresponds to",
+                                                            "format": "int64",
+                                                            "type": "integer",
+                                                            "minimum": -9223372036854776000,
+                                                            "maximum": 9223372036854776000
+                                                        },
+                                                        "lastTransitionTime": {
+                                                            "description": "LastTransitionTIme is the time the condition transitioned from one status to another.",
+                                                            "format": "date-time",
+                                                            "type": "string"
+                                                        },
+                                                        "message": {
+                                                            "description": "Message is a human readable description of the details about last transition, complementing reason.",
+                                                            "type": "string"
+                                                        },
+                                                        "reason": {
+                                                            "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                                                            "type": "string"
+                                                        },
+                                                        "status": {
+                                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                                            "type": "string"
+                                                        },
+                                                        "type": {
+                                                            "description": "Type of tag event condition, currently only ImportSuccess",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "generation",
+                                                        "status",
+                                                        "type"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "items": {
+                                                "description": "Standard object's metadata.",
+                                                "items": {
+                                                    "description": "TagEvent is used by ImageStreamStatus to keep a historical record of images associated with a tag.",
+                                                    "properties": {
+                                                        "created": {
+                                                            "description": "Created holds the time the TagEvent was created",
+                                                            "format": "date-time",
+                                                            "type": "string"
+                                                        },
+                                                        "dockerImageReference": {
+                                                            "description": "DockerImageReference is the string that can be used to pull this image",
+                                                            "type": "string"
+                                                        },
+                                                        "generation": {
+                                                            "description": "Generation is the spec tag generation that resulted in this tag being updated",
+                                                            "format": "int64",
+                                                            "type": "integer",
+                                                            "minimum": -9223372036854776000,
+                                                            "maximum": 9223372036854776000
+                                                        },
+                                                        "image": {
+                                                            "description": "Image is the image",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "created",
+                                                        "dockerImageReference",
+                                                        "generation",
+                                                        "image"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "tag": {
+                                                "description": "Tag is the tag for which the history is recorded",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "items",
+                                            "tag"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "required": [
+                                "dockerImageRepository"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "repository": {
+                    "description": "Repository is set if spec.repository was set to the outcome of the import",
+                    "properties": {
+                        "additionalTags": {
+                            "description": "AdditionalTags are tags that exist in the repository but were not imported because a maximum limit of automatic imports was applied.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "images": {
+                            "description": "Images is a list of images successfully retrieved by the import of the repository.",
+                            "items": {
+                                "description": "ImageImportStatus describes the result of an image import.",
+                                "properties": {
+                                    "image": {
+                                        "description": "Image is the metadata of that image, if the image was located",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                "type": "string"
+                                            },
+                                            "dockerImageConfig": {
+                                                "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                                                "type": "string"
+                                            },
+                                            "dockerImageLayers": {
+                                                "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                                                "items": {
+                                                    "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                                                    "properties": {
+                                                        "mediaType": {
+                                                            "description": "MediaType of the referenced object.",
+                                                            "type": "string"
+                                                        },
+                                                        "name": {
+                                                            "description": "Name of the layer as defined by the underlying store.",
+                                                            "type": "string"
+                                                        },
+                                                        "size": {
+                                                            "description": "Size of the layer in bytes as defined by the underlying store.",
+                                                            "format": "int64",
+                                                            "type": "integer",
+                                                            "minimum": -9223372036854776000,
+                                                            "maximum": 9223372036854776000
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "mediaType",
+                                                        "name",
+                                                        "size"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "dockerImageManifest": {
+                                                "description": "DockerImageManifest is the raw JSON of the manifest",
+                                                "type": "string"
+                                            },
+                                            "dockerImageManifestMediaType": {
+                                                "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                                                "type": "string"
+                                            },
+                                            "dockerImageManifests": {
+                                                "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                                                "items": {
+                                                    "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                                                    "properties": {
+                                                        "architecture": {
+                                                            "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                                            "type": "string"
+                                                        },
+                                                        "digest": {
+                                                            "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                                            "type": "string"
+                                                        },
+                                                        "manifestSize": {
+                                                            "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                                            "format": "int64",
+                                                            "type": "integer",
+                                                            "minimum": -9223372036854776000,
+                                                            "maximum": 9223372036854776000
+                                                        },
+                                                        "mediaType": {
+                                                            "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                                            "type": "string"
+                                                        },
+                                                        "os": {
+                                                            "description": "OS specifies the operating system, for example `linux`.",
+                                                            "type": "string"
+                                                        },
+                                                        "variant": {
+                                                            "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "architecture",
+                                                        "digest",
+                                                        "manifestSize",
+                                                        "mediaType",
+                                                        "os"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            },
+                                            "dockerImageMetadata": {
+                                                "description": "DockerImageMetadata contains metadata about this image",
+                                                "type": "object",
+                                                "x-kubernetes-preserve-unknown-fields": true
+                                            },
+                                            "dockerImageMetadataVersion": {
+                                                "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                                                "type": "string"
+                                            },
+                                            "dockerImageReference": {
+                                                "description": "DockerImageReference is the string that can be used to pull this image.",
+                                                "type": "string"
+                                            },
+                                            "dockerImageSignatures": {
+                                                "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                                                "items": {
+                                                    "format": "byte",
+                                                    "type": "string",
+                                                    "pattern": "^[\\w\\d+\\/=]*$"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "kind": {
+                                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                "type": "object"
+                                            },
+                                            "signatures": {
+                                                "description": "Signatures holds all signatures of the image.",
+                                                "items": {
+                                                    "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                                    "properties": {
+                                                        "apiVersion": {
+                                                            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                            "type": "string"
+                                                        },
+                                                        "conditions": {
+                                                            "description": "Conditions represent the latest available observations of a signature's current state.",
+                                                            "items": {
+                                                                "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                                                "properties": {
+                                                                    "lastProbeTime": {
+                                                                        "description": "Last time the condition was checked.",
+                                                                        "format": "date-time",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "lastTransitionTime": {
+                                                                        "description": "Last time the condition transit from one status to another.",
+                                                                        "format": "date-time",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "message": {
+                                                                        "description": "Human readable message indicating details about last transition.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "reason": {
+                                                                        "description": "(brief) reason for the condition's last transition.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "status": {
+                                                                        "description": "Status of the condition, one of True, False, Unknown.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "type": {
+                                                                        "description": "Type of signature condition, Complete or Failed.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "status",
+                                                                    "type"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "type": "array"
+                                                        },
+                                                        "content": {
+                                                            "description": "Required: An opaque binary string which is an image's signature.",
+                                                            "format": "byte",
+                                                            "type": "string",
+                                                            "pattern": "^[\\w\\d+\\/=]*$"
+                                                        },
+                                                        "created": {
+                                                            "description": "If specified, it is the time of signature's creation.",
+                                                            "format": "date-time",
+                                                            "type": "string"
+                                                        },
+                                                        "imageIdentity": {
+                                                            "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                                            "type": "string"
+                                                        },
+                                                        "issuedBy": {
+                                                            "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                                            "properties": {
+                                                                "commonName": {
+                                                                    "description": "Common name (e.g. openshift-signing-service).",
+                                                                    "type": "string"
+                                                                },
+                                                                "organization": {
+                                                                    "description": "Organization name.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "issuedTo": {
+                                                            "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                                            "properties": {
+                                                                "commonName": {
+                                                                    "description": "Common name (e.g. openshift-signing-service).",
+                                                                    "type": "string"
+                                                                },
+                                                                "organization": {
+                                                                    "description": "Organization name.",
+                                                                    "type": "string"
+                                                                },
+                                                                "publicKeyID": {
+                                                                    "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "publicKeyID"
+                                                            ],
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "kind": {
+                                                            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                            "type": "string"
+                                                        },
+                                                        "metadata": {
+                                                            "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                            "type": "object"
+                                                        },
+                                                        "signedClaims": {
+                                                            "additionalProperties": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "Contains claims from the signature.",
+                                                            "type": "object"
+                                                        },
+                                                        "type": {
+                                                            "description": "Required: Describes a type of stored blob.",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "content",
+                                                        "type"
+                                                    ],
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "manifests": {
+                                        "description": "Manifests holds sub-manifests metadata when importing a manifest list",
+                                        "items": {
+                                            "description": "Image is an immutable representation of a container image and metadata at a point in time. Images are named by taking a hash of their contents (metadata and content) and any change in format, content, or metadata results in a new name. The images resource is primarily for use by cluster administrators and integrations like the cluster image registry - end users instead access images via the imagestreamtags or imagestreamimages resources. While image metadata is stored in the API, any integration that implements the container image registry API must provide its own storage for the raw manifest data, image config, and layer contents. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                            "properties": {
+                                                "apiVersion": {
+                                                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageConfig": {
+                                                    "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageLayers": {
+                                                    "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                                                    "items": {
+                                                        "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                                                        "properties": {
+                                                            "mediaType": {
+                                                                "description": "MediaType of the referenced object.",
+                                                                "type": "string"
+                                                            },
+                                                            "name": {
+                                                                "description": "Name of the layer as defined by the underlying store.",
+                                                                "type": "string"
+                                                            },
+                                                            "size": {
+                                                                "description": "Size of the layer in bytes as defined by the underlying store.",
+                                                                "format": "int64",
+                                                                "type": "integer",
+                                                                "minimum": -9223372036854776000,
+                                                                "maximum": 9223372036854776000
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "mediaType",
+                                                            "name",
+                                                            "size"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "dockerImageManifest": {
+                                                    "description": "DockerImageManifest is the raw JSON of the manifest",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageManifestMediaType": {
+                                                    "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageManifests": {
+                                                    "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                                                    "items": {
+                                                        "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                                                        "properties": {
+                                                            "architecture": {
+                                                                "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                                                "type": "string"
+                                                            },
+                                                            "digest": {
+                                                                "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                                                "type": "string"
+                                                            },
+                                                            "manifestSize": {
+                                                                "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                                                "format": "int64",
+                                                                "type": "integer",
+                                                                "minimum": -9223372036854776000,
+                                                                "maximum": 9223372036854776000
+                                                            },
+                                                            "mediaType": {
+                                                                "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                                                "type": "string"
+                                                            },
+                                                            "os": {
+                                                                "description": "OS specifies the operating system, for example `linux`.",
+                                                                "type": "string"
+                                                            },
+                                                            "variant": {
+                                                                "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "architecture",
+                                                            "digest",
+                                                            "manifestSize",
+                                                            "mediaType",
+                                                            "os"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "dockerImageMetadata": {
+                                                    "description": "DockerImageMetadata contains metadata about this image",
+                                                    "type": "object",
+                                                    "x-kubernetes-preserve-unknown-fields": true
+                                                },
+                                                "dockerImageMetadataVersion": {
+                                                    "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageReference": {
+                                                    "description": "DockerImageReference is the string that can be used to pull this image.",
+                                                    "type": "string"
+                                                },
+                                                "dockerImageSignatures": {
+                                                    "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                                                    "items": {
+                                                        "format": "byte",
+                                                        "type": "string",
+                                                        "pattern": "^[\\w\\d+\\/=]*$"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "kind": {
+                                                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                    "type": "string"
+                                                },
+                                                "metadata": {
+                                                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                    "type": "object"
+                                                },
+                                                "signatures": {
+                                                    "description": "Signatures holds all signatures of the image.",
+                                                    "items": {
+                                                        "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                                                        "properties": {
+                                                            "apiVersion": {
+                                                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                                "type": "string"
+                                                            },
+                                                            "conditions": {
+                                                                "description": "Conditions represent the latest available observations of a signature's current state.",
+                                                                "items": {
+                                                                    "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                                                    "properties": {
+                                                                        "lastProbeTime": {
+                                                                            "description": "Last time the condition was checked.",
+                                                                            "format": "date-time",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "lastTransitionTime": {
+                                                                            "description": "Last time the condition transit from one status to another.",
+                                                                            "format": "date-time",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "message": {
+                                                                            "description": "Human readable message indicating details about last transition.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "reason": {
+                                                                            "description": "(brief) reason for the condition's last transition.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "status": {
+                                                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                                                            "type": "string"
+                                                                        },
+                                                                        "type": {
+                                                                            "description": "Type of signature condition, Complete or Failed.",
+                                                                            "type": "string"
+                                                                        }
+                                                                    },
+                                                                    "required": [
+                                                                        "status",
+                                                                        "type"
+                                                                    ],
+                                                                    "type": "object",
+                                                                    "additionalProperties": false
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "content": {
+                                                                "description": "Required: An opaque binary string which is an image's signature.",
+                                                                "format": "byte",
+                                                                "type": "string",
+                                                                "pattern": "^[\\w\\d+\\/=]*$"
+                                                            },
+                                                            "created": {
+                                                                "description": "If specified, it is the time of signature's creation.",
+                                                                "format": "date-time",
+                                                                "type": "string"
+                                                            },
+                                                            "imageIdentity": {
+                                                                "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                                                "type": "string"
+                                                            },
+                                                            "issuedBy": {
+                                                                "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                                                "properties": {
+                                                                    "commonName": {
+                                                                        "description": "Common name (e.g. openshift-signing-service).",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "organization": {
+                                                                        "description": "Organization name.",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "issuedTo": {
+                                                                "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                                                "properties": {
+                                                                    "commonName": {
+                                                                        "description": "Common name (e.g. openshift-signing-service).",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "organization": {
+                                                                        "description": "Organization name.",
+                                                                        "type": "string"
+                                                                    },
+                                                                    "publicKeyID": {
+                                                                        "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                                                        "type": "string"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "publicKeyID"
+                                                                ],
+                                                                "type": "object",
+                                                                "additionalProperties": false
+                                                            },
+                                                            "kind": {
+                                                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                                "type": "string"
+                                                            },
+                                                            "metadata": {
+                                                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                                                "type": "object"
+                                                            },
+                                                            "signedClaims": {
+                                                                "additionalProperties": {
+                                                                    "type": "string"
+                                                                },
+                                                                "description": "Contains claims from the signature.",
+                                                                "type": "object"
+                                                            },
+                                                            "type": {
+                                                                "description": "Required: Describes a type of stored blob.",
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "content",
+                                                            "type"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "status": {
+                                        "description": "Status is the status of the image import, including errors encountered while retrieving the image",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                                "type": "string"
+                                            },
+                                            "code": {
+                                                "description": "Suggested HTTP return code for this status, 0 if not set.",
+                                                "format": "int32",
+                                                "type": "integer",
+                                                "minimum": -2147483648,
+                                                "maximum": 2147483647
+                                            },
+                                            "details": {
+                                                "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+                                                "properties": {
+                                                    "causes": {
+                                                        "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                                                        "items": {
+                                                            "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+                                                            "properties": {
+                                                                "field": {
+                                                                    "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional. \n Examples: \"name\" - the field \"name\" on the current resource \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+                                                                    "type": "string"
+                                                                },
+                                                                "message": {
+                                                                    "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+                                                                    "type": "string"
+                                                                },
+                                                                "reason": {
+                                                                    "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "group": {
+                                                        "description": "The group attribute of the resource associated with the status StatusReason.",
+                                                        "type": "string"
+                                                    },
+                                                    "kind": {
+                                                        "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                                                        "type": "string"
+                                                    },
+                                                    "retryAfterSeconds": {
+                                                        "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                                                        "format": "int32",
+                                                        "type": "integer",
+                                                        "minimum": -2147483648,
+                                                        "maximum": 2147483647
+                                                    },
+                                                    "uid": {
+                                                        "description": "UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "kind": {
+                                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "message": {
+                                                "description": "A human-readable description of the status of this operation.",
+                                                "type": "string"
+                                            },
+                                            "metadata": {
+                                                "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "properties": {
+                                                    "continue": {
+                                                        "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+                                                        "type": "string"
+                                                    },
+                                                    "remainingItemCount": {
+                                                        "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+                                                        "format": "int64",
+                                                        "type": "integer",
+                                                        "minimum": -9223372036854776000,
+                                                        "maximum": 9223372036854776000
+                                                    },
+                                                    "resourceVersion": {
+                                                        "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                                        "type": "string"
+                                                    },
+                                                    "selfLink": {
+                                                        "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "reason": {
+                                                "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                                                "type": "string"
+                                            },
+                                            "status": {
+                                                "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "tag": {
+                                        "description": "Tag is the tag this image was located under, if any",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "status"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "status": {
+                            "description": "Status reflects whether any failure occurred during import",
+                            "properties": {
+                                "apiVersion": {
+                                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                    "type": "string"
+                                },
+                                "code": {
+                                    "description": "Suggested HTTP return code for this status, 0 if not set.",
+                                    "format": "int32",
+                                    "type": "integer",
+                                    "minimum": -2147483648,
+                                    "maximum": 2147483647
+                                },
+                                "details": {
+                                    "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+                                    "properties": {
+                                        "causes": {
+                                            "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+                                            "items": {
+                                                "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+                                                "properties": {
+                                                    "field": {
+                                                        "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional. \n Examples: \"name\" - the field \"name\" on the current resource \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+                                                        "type": "string"
+                                                    },
+                                                    "message": {
+                                                        "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+                                                        "type": "string"
+                                                    },
+                                                    "reason": {
+                                                        "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "group": {
+                                            "description": "The group attribute of the resource associated with the status StatusReason.",
+                                            "type": "string"
+                                        },
+                                        "kind": {
+                                            "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+                                            "type": "string"
+                                        },
+                                        "retryAfterSeconds": {
+                                            "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+                                            "format": "int32",
+                                            "type": "integer",
+                                            "minimum": -2147483648,
+                                            "maximum": 2147483647
+                                        },
+                                        "uid": {
+                                            "description": "UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "kind": {
+                                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                    "type": "string"
+                                },
+                                "message": {
+                                    "description": "A human-readable description of the status of this operation.",
+                                    "type": "string"
+                                },
+                                "metadata": {
+                                    "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                    "properties": {
+                                        "continue": {
+                                            "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+                                            "type": "string"
+                                        },
+                                        "remainingItemCount": {
+                                            "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "resourceVersion": {
+                                            "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                            "type": "string"
+                                        },
+                                        "selfLink": {
+                                            "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "reason": {
+                                    "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+                                    "type": "string"
+                                },
+                                "status": {
+                                    "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec",
+        "status"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestreamlayers_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestreamlayers_image.openshift.io_v1.json
@@ -1,0 +1,82 @@
+{
+    "description": "ImageStreamLayers describes information about the layers referenced by images in this image stream. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "blobs": {
+            "additionalProperties": {
+                "description": "ImageLayerData contains metadata about an image layer.",
+                "properties": {
+                    "mediaType": {
+                        "description": "MediaType of the referenced object.",
+                        "type": "string"
+                    },
+                    "size": {
+                        "description": "Size of the layer in bytes as defined by the underlying store. This field is optional if the necessary information about size is not available.",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    }
+                },
+                "required": [
+                    "mediaType",
+                    "size"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "description": "blobs is a map of blob name to metadata about the blob.",
+            "type": "object"
+        },
+        "images": {
+            "additionalProperties": {
+                "description": "ImageBlobReferences describes the blob references within an image.",
+                "properties": {
+                    "config": {
+                        "description": "config, if set, is the blob that contains the image config. Some images do not have separate config blobs and this field will be set to nil if so.",
+                        "type": "string"
+                    },
+                    "imageMissing": {
+                        "description": "imageMissing is true if the image is referenced by the image stream but the image object has been deleted from the API by an administrator. When this field is set, layers and config fields may be empty and callers that depend on the image metadata should consider the image to be unavailable for download or viewing.",
+                        "type": "boolean"
+                    },
+                    "layers": {
+                        "description": "layers is the list of blobs that compose this image, from base layer to top layer. All layers referenced by this array will be defined in the blobs map. Some images may have zero layers.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "manifests": {
+                        "description": "manifests is the list of other image names that this image points to. For a single architecture image, it is empty. For a multi-arch image, it consists of the digests of single architecture images, such images shouldn't have layers nor config.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "description": "images is a map between an image name and the names of the blobs and config that comprise the image.",
+            "type": "object"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "blobs",
+        "images"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestreammapping_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestreammapping_image.openshift.io_v1.json
@@ -1,0 +1,287 @@
+{
+    "description": "ImageStreamMapping represents a mapping from a single image stream tag to a container image as well as the reference to the container image stream the image came from. This resource is used by privileged integrators to create an image resource and to associate it with an image stream in the status tags field. Creating an ImageStreamMapping will allow any user who can view the image stream to tag or pull that image, so only create mappings where the user has proven they have access to the image contents directly. The only operation supported for this resource is create and the metadata name and namespace should be set to the image stream containing the tag that should be updated. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "image": {
+            "description": "Image is a container image.",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dockerImageConfig": {
+                    "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                    "type": "string"
+                },
+                "dockerImageLayers": {
+                    "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                    "items": {
+                        "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                        "properties": {
+                            "mediaType": {
+                                "description": "MediaType of the referenced object.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Name of the layer as defined by the underlying store.",
+                                "type": "string"
+                            },
+                            "size": {
+                                "description": "Size of the layer in bytes as defined by the underlying store.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "required": [
+                            "mediaType",
+                            "name",
+                            "size"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageManifest": {
+                    "description": "DockerImageManifest is the raw JSON of the manifest",
+                    "type": "string"
+                },
+                "dockerImageManifestMediaType": {
+                    "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                    "type": "string"
+                },
+                "dockerImageManifests": {
+                    "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                    "items": {
+                        "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                        "properties": {
+                            "architecture": {
+                                "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                "type": "string"
+                            },
+                            "digest": {
+                                "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                "type": "string"
+                            },
+                            "manifestSize": {
+                                "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "mediaType": {
+                                "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                "type": "string"
+                            },
+                            "os": {
+                                "description": "OS specifies the operating system, for example `linux`.",
+                                "type": "string"
+                            },
+                            "variant": {
+                                "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "architecture",
+                            "digest",
+                            "manifestSize",
+                            "mediaType",
+                            "os"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageMetadata": {
+                    "description": "DockerImageMetadata contains metadata about this image",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dockerImageMetadataVersion": {
+                    "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                    "type": "string"
+                },
+                "dockerImageReference": {
+                    "description": "DockerImageReference is the string that can be used to pull this image.",
+                    "type": "string"
+                },
+                "dockerImageSignatures": {
+                    "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                    "items": {
+                        "format": "byte",
+                        "type": "string",
+                        "pattern": "^[\\w\\d+\\/=]*$"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object"
+                },
+                "signatures": {
+                    "description": "Signatures holds all signatures of the image.",
+                    "items": {
+                        "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                        "properties": {
+                            "apiVersion": {
+                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                "type": "string"
+                            },
+                            "conditions": {
+                                "description": "Conditions represent the latest available observations of a signature's current state.",
+                                "items": {
+                                    "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                    "properties": {
+                                        "lastProbeTime": {
+                                            "description": "Last time the condition was checked.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "lastTransitionTime": {
+                                            "description": "Last time the condition transit from one status to another.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type of signature condition, Complete or Failed.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "content": {
+                                "description": "Required: An opaque binary string which is an image's signature.",
+                                "format": "byte",
+                                "type": "string",
+                                "pattern": "^[\\w\\d+\\/=]*$"
+                            },
+                            "created": {
+                                "description": "If specified, it is the time of signature's creation.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "imageIdentity": {
+                                "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                "type": "string"
+                            },
+                            "issuedBy": {
+                                "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "issuedTo": {
+                                "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    },
+                                    "publicKeyID": {
+                                        "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "publicKeyID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "kind": {
+                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                "type": "object"
+                            },
+                            "signedClaims": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Contains claims from the signature.",
+                                "type": "object"
+                            },
+                            "type": {
+                                "description": "Required: Describes a type of stored blob.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "tag": {
+            "description": "Tag is a string value this image can be located with inside the stream.",
+            "type": "string"
+        }
+    },
+    "required": [
+        "image",
+        "tag"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagestreamtag_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagestreamtag_image.openshift.io_v1.json
@@ -1,0 +1,450 @@
+{
+    "description": "ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream. Use this resource to interact with the tags and images in an image stream by tag, or to see the image details for a particular tag. The image associated with this resource is the most recently successfully tagged, imported, or pushed image (as described in the image stream status.tags.items list for this tag). If an import is in progress or has failed the previous image will be shown. Deleting an image stream tag clears both the status and spec fields of an image stream. If no image can be retrieved for a given tag, a not found error will be returned. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "conditions": {
+            "description": "conditions is an array of conditions that apply to the image stream tag.",
+            "items": {
+                "description": "TagEventCondition contains condition information for a tag event.",
+                "properties": {
+                    "generation": {
+                        "description": "Generation is the spec tag generation that this status corresponds to",
+                        "format": "int64",
+                        "type": "integer",
+                        "minimum": -9223372036854776000,
+                        "maximum": 9223372036854776000
+                    },
+                    "lastTransitionTime": {
+                        "description": "LastTransitionTIme is the time the condition transitioned from one status to another.",
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "message": {
+                        "description": "Message is a human readable description of the details about last transition, complementing reason.",
+                        "type": "string"
+                    },
+                    "reason": {
+                        "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                        "type": "string"
+                    },
+                    "status": {
+                        "description": "Status of the condition, one of True, False, Unknown.",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type of tag event condition, currently only ImportSuccess",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "generation",
+                    "status",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "generation": {
+            "description": "generation is the current generation of the tagged image - if tag is provided and this value is not equal to the tag generation, a user has requested an import that has not completed, or conditions will be filled out indicating any error.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "image": {
+            "description": "image associated with the ImageStream and tag.",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dockerImageConfig": {
+                    "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                    "type": "string"
+                },
+                "dockerImageLayers": {
+                    "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                    "items": {
+                        "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                        "properties": {
+                            "mediaType": {
+                                "description": "MediaType of the referenced object.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Name of the layer as defined by the underlying store.",
+                                "type": "string"
+                            },
+                            "size": {
+                                "description": "Size of the layer in bytes as defined by the underlying store.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "required": [
+                            "mediaType",
+                            "name",
+                            "size"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageManifest": {
+                    "description": "DockerImageManifest is the raw JSON of the manifest",
+                    "type": "string"
+                },
+                "dockerImageManifestMediaType": {
+                    "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                    "type": "string"
+                },
+                "dockerImageManifests": {
+                    "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                    "items": {
+                        "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                        "properties": {
+                            "architecture": {
+                                "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                "type": "string"
+                            },
+                            "digest": {
+                                "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                "type": "string"
+                            },
+                            "manifestSize": {
+                                "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "mediaType": {
+                                "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                "type": "string"
+                            },
+                            "os": {
+                                "description": "OS specifies the operating system, for example `linux`.",
+                                "type": "string"
+                            },
+                            "variant": {
+                                "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "architecture",
+                            "digest",
+                            "manifestSize",
+                            "mediaType",
+                            "os"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageMetadata": {
+                    "description": "DockerImageMetadata contains metadata about this image",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dockerImageMetadataVersion": {
+                    "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                    "type": "string"
+                },
+                "dockerImageReference": {
+                    "description": "DockerImageReference is the string that can be used to pull this image.",
+                    "type": "string"
+                },
+                "dockerImageSignatures": {
+                    "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                    "items": {
+                        "format": "byte",
+                        "type": "string",
+                        "pattern": "^[\\w\\d+\\/=]*$"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object"
+                },
+                "signatures": {
+                    "description": "Signatures holds all signatures of the image.",
+                    "items": {
+                        "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                        "properties": {
+                            "apiVersion": {
+                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                "type": "string"
+                            },
+                            "conditions": {
+                                "description": "Conditions represent the latest available observations of a signature's current state.",
+                                "items": {
+                                    "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                    "properties": {
+                                        "lastProbeTime": {
+                                            "description": "Last time the condition was checked.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "lastTransitionTime": {
+                                            "description": "Last time the condition transit from one status to another.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type of signature condition, Complete or Failed.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "content": {
+                                "description": "Required: An opaque binary string which is an image's signature.",
+                                "format": "byte",
+                                "type": "string",
+                                "pattern": "^[\\w\\d+\\/=]*$"
+                            },
+                            "created": {
+                                "description": "If specified, it is the time of signature's creation.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "imageIdentity": {
+                                "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                "type": "string"
+                            },
+                            "issuedBy": {
+                                "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "issuedTo": {
+                                "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    },
+                                    "publicKeyID": {
+                                        "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "publicKeyID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "kind": {
+                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                "type": "object"
+                            },
+                            "signedClaims": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Contains claims from the signature.",
+                                "type": "object"
+                            },
+                            "type": {
+                                "description": "Required: Describes a type of stored blob.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "lookupPolicy": {
+            "description": "lookupPolicy indicates whether this tag will handle image references in this namespace.",
+            "properties": {
+                "local": {
+                    "description": "local will change the docker short image references (like \"mysql\" or \"php:latest\") on objects in this namespace to the image ID whenever they match this image stream, instead of reaching out to a remote registry. The name will be fully qualified to an image ID if found. The tag's referencePolicy is taken into account on the replaced value. Only works within the current namespace.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "local"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "tag": {
+            "description": "tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.",
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.",
+                    "type": "object"
+                },
+                "from": {
+                    "description": "Optional; if specified, a reference to another image that this tag should point to. Valid values are ImageStreamTag, ImageStreamImage, and DockerImage.  ImageStreamTag references can only reference a tag within this same ImageStream.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "generation": {
+                    "description": "Generation is a counter that tracks mutations to the spec tag (user intent). When a tag reference is changed the generation is set to match the current stream generation (which is incremented every time spec is changed). Other processes in the system like the image importer observe that the generation of spec tag is newer than the generation recorded in the status and use that as a trigger to import the newest remote tag. To trigger a new import, clients may set this value to zero which will reset the generation to the latest stream generation. Legacy clients will send this value as nil which will be merged with the current tag generation.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "importPolicy": {
+                    "description": "ImportPolicy is information that controls how images may be imported by the server.",
+                    "properties": {
+                        "importMode": {
+                            "description": "ImportMode describes how to import an image manifest.",
+                            "type": "string"
+                        },
+                        "insecure": {
+                            "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                            "type": "boolean"
+                        },
+                        "scheduled": {
+                            "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "name": {
+                    "description": "Name of the tag",
+                    "type": "string"
+                },
+                "reference": {
+                    "description": "Reference states if the tag will be imported. Default value is false, which means the tag will be imported.",
+                    "type": "boolean"
+                },
+                "referencePolicy": {
+                    "description": "ReferencePolicy defines how other components should consume the image.",
+                    "properties": {
+                        "type": {
+                            "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "generation",
+        "image",
+        "lookupPolicy",
+        "tag"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagetag_image.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagetag_image.openshift.io_v1.json
@@ -1,0 +1,480 @@
+{
+    "description": "ImageTag represents a single tag within an image stream and includes the spec, the status history, and the currently referenced image (if any) of the provided tag. This type replaces the ImageStreamTag by providing a full view of the tag. ImageTags are returned for every spec or status tag present on the image stream. If no tag exists in either form a not found error will be returned by the API. A create operation will succeed if no spec tag has already been defined and the spec field is set. Delete will remove both spec and status elements from the image stream. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "image": {
+            "description": "image is the details of the most recent image stream status tag, and it may be null if import has not completed or an administrator has deleted the image object. To verify this is the most recent image, you must verify the generation of the most recent status.items entry matches the spec tag (if a spec tag is set). This field will not be set when listing image tags.",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                    "type": "string"
+                },
+                "dockerImageConfig": {
+                    "description": "DockerImageConfig is a JSON blob that the runtime uses to set up the container. This is a part of manifest schema v2. Will not be set when the image represents a manifest list.",
+                    "type": "string"
+                },
+                "dockerImageLayers": {
+                    "description": "DockerImageLayers represents the layers in the image. May not be set if the image does not define that data or if the image represents a manifest list.",
+                    "items": {
+                        "description": "ImageLayer represents a single layer of the image. Some images may have multiple layers. Some may have none.",
+                        "properties": {
+                            "mediaType": {
+                                "description": "MediaType of the referenced object.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "Name of the layer as defined by the underlying store.",
+                                "type": "string"
+                            },
+                            "size": {
+                                "description": "Size of the layer in bytes as defined by the underlying store.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "required": [
+                            "mediaType",
+                            "name",
+                            "size"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageManifest": {
+                    "description": "DockerImageManifest is the raw JSON of the manifest",
+                    "type": "string"
+                },
+                "dockerImageManifestMediaType": {
+                    "description": "DockerImageManifestMediaType specifies the mediaType of manifest. This is a part of manifest schema v2.",
+                    "type": "string"
+                },
+                "dockerImageManifests": {
+                    "description": "DockerImageManifests holds information about sub-manifests when the image represents a manifest list. When this field is present, no DockerImageLayers should be specified.",
+                    "items": {
+                        "description": "ImageManifest represents sub-manifests of a manifest list. The Digest field points to a regular Image object.",
+                        "properties": {
+                            "architecture": {
+                                "description": "Architecture specifies the supported CPU architecture, for example `amd64` or `ppc64le`.",
+                                "type": "string"
+                            },
+                            "digest": {
+                                "description": "Digest is the unique identifier for the manifest. It refers to an Image object.",
+                                "type": "string"
+                            },
+                            "manifestSize": {
+                                "description": "ManifestSize represents the size of the raw object contents, in bytes.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "mediaType": {
+                                "description": "MediaType defines the type of the manifest, possible values are application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json or application/vnd.docker.distribution.manifest.v1+json.",
+                                "type": "string"
+                            },
+                            "os": {
+                                "description": "OS specifies the operating system, for example `linux`.",
+                                "type": "string"
+                            },
+                            "variant": {
+                                "description": "Variant is an optional field repreenting a variant of the CPU, for example v6 to specify a particular CPU variant of the ARM CPU.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "architecture",
+                            "digest",
+                            "manifestSize",
+                            "mediaType",
+                            "os"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "dockerImageMetadata": {
+                    "description": "DockerImageMetadata contains metadata about this image",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "dockerImageMetadataVersion": {
+                    "description": "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
+                    "type": "string"
+                },
+                "dockerImageReference": {
+                    "description": "DockerImageReference is the string that can be used to pull this image.",
+                    "type": "string"
+                },
+                "dockerImageSignatures": {
+                    "description": "DockerImageSignatures provides the signatures as opaque blobs. This is a part of manifest schema v1.",
+                    "items": {
+                        "format": "byte",
+                        "type": "string",
+                        "pattern": "^[\\w\\d+\\/=]*$"
+                    },
+                    "type": "array"
+                },
+                "kind": {
+                    "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "metadata": {
+                    "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object"
+                },
+                "signatures": {
+                    "description": "Signatures holds all signatures of the image.",
+                    "items": {
+                        "description": "ImageSignature holds a signature of an image. It allows to verify image identity and possibly other claims as long as the signature is trusted. Based on this information it is possible to restrict runnable images to those matching cluster-wide policy. Mandatory fields should be parsed by clients doing image verification. The others are parsed from signature's content by the server. They serve just an informative purpose. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+                        "properties": {
+                            "apiVersion": {
+                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                                "type": "string"
+                            },
+                            "conditions": {
+                                "description": "Conditions represent the latest available observations of a signature's current state.",
+                                "items": {
+                                    "description": "SignatureCondition describes an image signature condition of particular kind at particular probe time.",
+                                    "properties": {
+                                        "lastProbeTime": {
+                                            "description": "Last time the condition was checked.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "lastTransitionTime": {
+                                            "description": "Last time the condition transit from one status to another.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type of signature condition, Complete or Failed.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "content": {
+                                "description": "Required: An opaque binary string which is an image's signature.",
+                                "format": "byte",
+                                "type": "string",
+                                "pattern": "^[\\w\\d+\\/=]*$"
+                            },
+                            "created": {
+                                "description": "If specified, it is the time of signature's creation.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "imageIdentity": {
+                                "description": "A human readable string representing image's identity. It could be a product name and version, or an image pull spec (e.g. \"registry.access.redhat.com/rhel7/rhel:7.2\").",
+                                "type": "string"
+                            },
+                            "issuedBy": {
+                                "description": "If specified, it holds information about an issuer of signing certificate or key (a person or entity who signed the signing certificate or key).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "issuedTo": {
+                                "description": "If specified, it holds information about a subject of signing certificate or key (a person or entity who signed the image).",
+                                "properties": {
+                                    "commonName": {
+                                        "description": "Common name (e.g. openshift-signing-service).",
+                                        "type": "string"
+                                    },
+                                    "organization": {
+                                        "description": "Organization name.",
+                                        "type": "string"
+                                    },
+                                    "publicKeyID": {
+                                        "description": "If present, it is a human readable key id of public key belonging to the subject used to verify image signature. It should contain at least 64 lowest bits of public key's fingerprint (e.g. 0x685ebe62bf278440).",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "publicKeyID"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "kind": {
+                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                "type": "string"
+                            },
+                            "metadata": {
+                                "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                                "type": "object"
+                            },
+                            "signedClaims": {
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Contains claims from the signature.",
+                                "type": "object"
+                            },
+                            "type": {
+                                "description": "Required: Describes a type of stored blob.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "content",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.",
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Optional; if specified, annotations that are applied to images retrieved via ImageStreamTags.",
+                    "type": "object"
+                },
+                "from": {
+                    "description": "Optional; if specified, a reference to another image that this tag should point to. Valid values are ImageStreamTag, ImageStreamImage, and DockerImage.  ImageStreamTag references can only reference a tag within this same ImageStream.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "generation": {
+                    "description": "Generation is a counter that tracks mutations to the spec tag (user intent). When a tag reference is changed the generation is set to match the current stream generation (which is incremented every time spec is changed). Other processes in the system like the image importer observe that the generation of spec tag is newer than the generation recorded in the status and use that as a trigger to import the newest remote tag. To trigger a new import, clients may set this value to zero which will reset the generation to the latest stream generation. Legacy clients will send this value as nil which will be merged with the current tag generation.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "importPolicy": {
+                    "description": "ImportPolicy is information that controls how images may be imported by the server.",
+                    "properties": {
+                        "importMode": {
+                            "description": "ImportMode describes how to import an image manifest.",
+                            "type": "string"
+                        },
+                        "insecure": {
+                            "description": "Insecure is true if the server may bypass certificate verification or connect directly over HTTP during image import.",
+                            "type": "boolean"
+                        },
+                        "scheduled": {
+                            "description": "Scheduled indicates to the server that this tag should be periodically checked to ensure it is up to date, and imported",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "name": {
+                    "description": "Name of the tag",
+                    "type": "string"
+                },
+                "reference": {
+                    "description": "Reference states if the tag will be imported. Default value is false, which means the tag will be imported.",
+                    "type": "boolean"
+                },
+                "referencePolicy": {
+                    "description": "ReferencePolicy defines how other components should consume the image.",
+                    "properties": {
+                        "type": {
+                            "description": "Type determines how the image pull spec should be transformed when the image stream tag is used in deployment config triggers or new builds. The default value is `Source`, indicating the original location of the image should be used (if imported). The user may also specify `Local`, indicating that the pull spec should point to the integrated container image registry and leverage the registry's ability to proxy the pull to an upstream registry. `Local` allows the credentials used to pull this image to be managed from the image stream's namespace, so others on the platform can access a remote image but have no access to the remote secret. It also allows the image layers to be mirrored into the local registry which the images can still be pulled even if the upstream registry is unavailable.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the status tag details associated with this image stream tag, and it may be null if no push or import has been performed.",
+            "properties": {
+                "conditions": {
+                    "description": "Conditions is an array of conditions that apply to the tag event list.",
+                    "items": {
+                        "description": "TagEventCondition contains condition information for a tag event.",
+                        "properties": {
+                            "generation": {
+                                "description": "Generation is the spec tag generation that this status corresponds to",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "lastTransitionTime": {
+                                "description": "LastTransitionTIme is the time the condition transitioned from one status to another.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "Message is a human readable description of the details about last transition, complementing reason.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of tag event condition, currently only ImportSuccess",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "generation",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "items": {
+                    "description": "Standard object's metadata.",
+                    "items": {
+                        "description": "TagEvent is used by ImageStreamStatus to keep a historical record of images associated with a tag.",
+                        "properties": {
+                            "created": {
+                                "description": "Created holds the time the TagEvent was created",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "dockerImageReference": {
+                                "description": "DockerImageReference is the string that can be used to pull this image",
+                                "type": "string"
+                            },
+                            "generation": {
+                                "description": "Generation is the spec tag generation that resulted in this tag being updated",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "image": {
+                                "description": "Image is the image",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "created",
+                            "dockerImageReference",
+                            "generation",
+                            "image"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "tag": {
+                    "description": "Tag is the tag for which the history is recorded",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "items",
+                "tag"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "image",
+        "spec",
+        "status"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/imagetagmirrorset_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/imagetagmirrorset_config.openshift.io_v1.json
@@ -1,0 +1,70 @@
+{
+    "description": "ImageTagMirrorSet holds cluster-wide information about how to handle registry mirror rules on using tag pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "imageTagMirrors": {
+                    "description": "imageTagMirrors allows images referenced by image tags in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageTagMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using digest specification only, users should configure a list of mirrors using \"ImageDigestMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagetagmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a deterministic order of mirrors, should configure them into one list of mirrors using the expected order.",
+                    "items": {
+                        "description": "ImageTagMirrors holds cluster-wide information about how to handle mirrors in the registries config.",
+                        "properties": {
+                            "mirrorSourcePolicy": {
+                                "description": "mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.",
+                                "enum": [
+                                    "NeverContactSource",
+                                    "AllowContactingSource"
+                                ],
+                                "type": "string"
+                            },
+                            "mirrors": {
+                                "description": "mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their tags. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Configuring a list of mirrors using \"ImageDigestMirrorSet\" CRD and forcing digest-pulls for mirrors avoids that issue. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by \"mirrorSourcePolicy\". Other cluster configuration, including (but not limited to) other imageTagMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. \"mirrors\" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table",
+                                "items": {
+                                    "pattern": "^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$",
+                                    "type": "string"
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                            },
+                            "source": {
+                                "description": "source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. \"source\" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table",
+                                "pattern": "^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "source"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status contains the observed state of the resource.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/infrastructure_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/infrastructure_config.openshift.io_v1.json
@@ -1,0 +1,1148 @@
+{
+    "description": "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "cloudConfig": {
+                    "description": "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only.",
+                    "properties": {
+                        "key": {
+                            "description": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "platformSpec": {
+                    "description": "platformSpec holds desired information specific to the underlying infrastructure provider.",
+                    "properties": {
+                        "alibabaCloud": {
+                            "description": "AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.",
+                            "type": "object"
+                        },
+                        "aws": {
+                            "description": "AWS contains settings specific to the Amazon Web Services infrastructure provider.",
+                            "properties": {
+                                "serviceEndpoints": {
+                                    "description": "serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
+                                    "items": {
+                                        "description": "AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.",
+                                                "pattern": "^[a-z0-9-]+$",
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "description": "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.",
+                                                "pattern": "^https://",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "azure": {
+                            "description": "Azure contains settings specific to the Azure infrastructure provider.",
+                            "type": "object"
+                        },
+                        "baremetal": {
+                            "description": "BareMetal contains settings specific to the BareMetal platform.",
+                            "type": "object"
+                        },
+                        "equinixMetal": {
+                            "description": "EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.",
+                            "type": "object"
+                        },
+                        "external": {
+                            "description": "ExternalPlatformType represents generic infrastructure provider. Platform-specific components should be supplemented separately.",
+                            "properties": {
+                                "platformName": {
+                                    "default": "Unknown",
+                                    "description": "PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time. This field is solely for informational and reporting purposes and is not expected to be used for decision-making.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "platform name cannot be changed once set",
+                                            "rule": "oldSelf == 'Unknown' || self == oldSelf"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "gcp": {
+                            "description": "GCP contains settings specific to the Google Cloud Platform infrastructure provider.",
+                            "type": "object"
+                        },
+                        "ibmcloud": {
+                            "description": "IBMCloud contains settings specific to the IBMCloud infrastructure provider.",
+                            "type": "object"
+                        },
+                        "kubevirt": {
+                            "description": "Kubevirt contains settings specific to the kubevirt infrastructure provider.",
+                            "type": "object"
+                        },
+                        "nutanix": {
+                            "description": "Nutanix contains settings specific to the Nutanix infrastructure provider.",
+                            "properties": {
+                                "prismCentral": {
+                                    "description": "prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.",
+                                    "properties": {
+                                        "address": {
+                                            "description": "address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)",
+                                            "maxLength": 256,
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "description": "port is the port number to access the Nutanix Prism Central or Element (cluster)",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "address",
+                                        "port"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "prismElements": {
+                                    "description": "prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.",
+                                    "items": {
+                                        "description": "NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)",
+                                        "properties": {
+                                            "endpoint": {
+                                                "description": "endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.",
+                                                "properties": {
+                                                    "address": {
+                                                        "description": "address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)",
+                                                        "maxLength": 256,
+                                                        "type": "string"
+                                                    },
+                                                    "port": {
+                                                        "description": "port is the port number to access the Nutanix Prism Central or Element (cluster)",
+                                                        "format": "int32",
+                                                        "maximum": 65535,
+                                                        "minimum": 1,
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "address",
+                                                    "port"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).",
+                                                "maxLength": 256,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "endpoint",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "required": [
+                                "prismCentral",
+                                "prismElements"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "openstack": {
+                            "description": "OpenStack contains settings specific to the OpenStack infrastructure provider.",
+                            "type": "object"
+                        },
+                        "ovirt": {
+                            "description": "Ovirt contains settings specific to the oVirt infrastructure provider.",
+                            "type": "object"
+                        },
+                        "powervs": {
+                            "description": "PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.",
+                            "properties": {
+                                "serviceEndpoints": {
+                                    "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.",
+                                    "items": {
+                                        "description": "PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud",
+                                                "pattern": "^[a-z0-9-]+$",
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "description": "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.",
+                                                "format": "uri",
+                                                "pattern": "^https://",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"KubeVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+                            "enum": [
+                                "",
+                                "AWS",
+                                "Azure",
+                                "BareMetal",
+                                "GCP",
+                                "Libvirt",
+                                "OpenStack",
+                                "None",
+                                "VSphere",
+                                "oVirt",
+                                "IBMCloud",
+                                "KubeVirt",
+                                "EquinixMetal",
+                                "PowerVS",
+                                "AlibabaCloud",
+                                "Nutanix",
+                                "External"
+                            ],
+                            "type": "string"
+                        },
+                        "vsphere": {
+                            "description": "VSphere contains settings specific to the VSphere infrastructure provider.",
+                            "properties": {
+                                "failureDomains": {
+                                    "description": "failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.",
+                                    "items": {
+                                        "description": "VSpherePlatformFailureDomainSpec holds the region and zone failure domain and the vCenter topology of that failure domain.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name defines the arbitrary but unique name of a failure domain.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "region": {
+                                                "description": "region defines the name of a region tag that will be attached to a vCenter datacenter. The tag category in vCenter must be named openshift-region.",
+                                                "maxLength": 80,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "server": {
+                                                "description": "server is the fully-qualified domain name or the IP address of the vCenter server. ---",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "topology": {
+                                                "description": "Topology describes a given failure domain using vSphere constructs",
+                                                "properties": {
+                                                    "computeCluster": {
+                                                        "description": "computeCluster the absolute path of the vCenter cluster in which virtual machine will be located. The absolute path is of the form /<datacenter>/host/<cluster>. The maximum length of the path is 2048 characters.",
+                                                        "maxLength": 2048,
+                                                        "pattern": "^/.*?/host/.*?",
+                                                        "type": "string"
+                                                    },
+                                                    "datacenter": {
+                                                        "description": "datacenter is the name of vCenter datacenter in which virtual machines will be located. The maximum length of the datacenter name is 80 characters.",
+                                                        "maxLength": 80,
+                                                        "type": "string"
+                                                    },
+                                                    "datastore": {
+                                                        "description": "datastore is the absolute path of the datastore in which the virtual machine is located. The absolute path is of the form /<datacenter>/datastore/<datastore> The maximum length of the path is 2048 characters.",
+                                                        "maxLength": 2048,
+                                                        "pattern": "^/.*?/datastore/.*?",
+                                                        "type": "string"
+                                                    },
+                                                    "folder": {
+                                                        "description": "folder is the absolute path of the folder where virtual machines are located. The absolute path is of the form /<datacenter>/vm/<folder>. The maximum length of the path is 2048 characters.",
+                                                        "maxLength": 2048,
+                                                        "pattern": "^/.*?/vm/.*?",
+                                                        "type": "string"
+                                                    },
+                                                    "networks": {
+                                                        "description": "networks is the list of port group network names within this failure domain. Currently, we only support a single interface per RHCOS virtual machine. The available networks (port groups) can be listed using `govc ls 'network/*'` The single interface should be the absolute path of the form /<datacenter>/network/<portgroup>.",
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                    },
+                                                    "resourcePool": {
+                                                        "description": "resourcePool is the absolute path of the resource pool where virtual machines will be created. The absolute path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>. The maximum length of the path is 2048 characters.",
+                                                        "maxLength": 2048,
+                                                        "pattern": "^/.*?/host/.*?/Resources.*",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "computeCluster",
+                                                    "datacenter",
+                                                    "datastore",
+                                                    "networks"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "zone": {
+                                                "description": "zone defines the name of a zone tag that will be attached to a vCenter cluster. The tag category in vCenter must be named openshift-zone.",
+                                                "maxLength": 80,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "region",
+                                            "server",
+                                            "topology",
+                                            "zone"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "nodeNetworking": {
+                                    "description": "nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.",
+                                    "properties": {
+                                        "external": {
+                                            "description": "external represents the network configuration of the node that is externally routable.",
+                                            "properties": {
+                                                "excludeNetworkSubnetCidr": {
+                                                    "description": "excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "network": {
+                                                    "description": "network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`",
+                                                    "type": "string"
+                                                },
+                                                "networkSubnetCidr": {
+                                                    "description": "networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "internal": {
+                                            "description": "internal represents the network configuration of the node that is routable only within the cluster.",
+                                            "properties": {
+                                                "excludeNetworkSubnetCidr": {
+                                                    "description": "excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "network": {
+                                                    "description": "network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`",
+                                                    "type": "string"
+                                                },
+                                                "networkSubnetCidr": {
+                                                    "description": "networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "vcenters": {
+                                    "description": "vcenters holds the connection details for services to communicate with vCenter. Currently, only a single vCenter is supported. ---",
+                                    "items": {
+                                        "description": "VSpherePlatformVCenterSpec stores the vCenter connection fields. This is used by the vSphere CCM.",
+                                        "properties": {
+                                            "datacenters": {
+                                                "description": "The vCenter Datacenters in which the RHCOS vm guests are located. This field will be used by the Cloud Controller Manager. Each datacenter listed here should be used within a topology.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1,
+                                                "type": "array"
+                                            },
+                                            "port": {
+                                                "description": "port is the TCP port that will be used to communicate to the vCenter endpoint. When omitted, this means the user has no opinion and it is up to the platform to choose a sensible default, which is subject to change over time.",
+                                                "format": "int32",
+                                                "maximum": 32767,
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            },
+                                            "server": {
+                                                "description": "server is the fully-qualified domain name or the IP address of the vCenter server. ---",
+                                                "maxLength": 255,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "datacenters",
+                                            "server"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "minItems": 0,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "apiServerInternalURI": {
+                    "description": "apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
+                    "type": "string"
+                },
+                "apiServerURL": {
+                    "description": "apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
+                    "type": "string"
+                },
+                "controlPlaneTopology": {
+                    "default": "HighlyAvailable",
+                    "description": "controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a \"normal\" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.",
+                    "enum": [
+                        "HighlyAvailable",
+                        "SingleReplica",
+                        "External"
+                    ],
+                    "type": "string"
+                },
+                "cpuPartitioning": {
+                    "default": "None",
+                    "description": "cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are \"None\" and \"AllNodes\". When omitted, the default value is \"None\". The default value of \"None\" indicates that no nodes will be setup with CPU partitioning. The \"AllNodes\" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.",
+                    "enum": [
+                        "None",
+                        "AllNodes"
+                    ],
+                    "type": "string"
+                },
+                "etcdDiscoveryDomain": {
+                    "description": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.",
+                    "type": "string"
+                },
+                "infrastructureName": {
+                    "description": "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
+                    "type": "string"
+                },
+                "infrastructureTopology": {
+                    "default": "HighlyAvailable",
+                    "description": "infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is 'HighlyAvailable', which represents the behavior operators have in a \"normal\" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.",
+                    "enum": [
+                        "HighlyAvailable",
+                        "SingleReplica"
+                    ],
+                    "type": "string"
+                },
+                "platform": {
+                    "description": "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead.",
+                    "enum": [
+                        "",
+                        "AWS",
+                        "Azure",
+                        "BareMetal",
+                        "GCP",
+                        "Libvirt",
+                        "OpenStack",
+                        "None",
+                        "VSphere",
+                        "oVirt",
+                        "IBMCloud",
+                        "KubeVirt",
+                        "EquinixMetal",
+                        "PowerVS",
+                        "AlibabaCloud",
+                        "Nutanix",
+                        "External"
+                    ],
+                    "type": "string"
+                },
+                "platformStatus": {
+                    "description": "platformStatus holds status information specific to the underlying infrastructure provider.",
+                    "properties": {
+                        "alibabaCloud": {
+                            "description": "AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.",
+                            "properties": {
+                                "region": {
+                                    "description": "region specifies the region for Alibaba Cloud resources created for the cluster.",
+                                    "pattern": "^[0-9A-Za-z-]+$",
+                                    "type": "string"
+                                },
+                                "resourceGroupID": {
+                                    "description": "resourceGroupID is the ID of the resource group for the cluster.",
+                                    "pattern": "^(rg-[0-9A-Za-z]+)?$",
+                                    "type": "string"
+                                },
+                                "resourceTags": {
+                                    "description": "resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.",
+                                    "items": {
+                                        "description": "AlibabaCloudResourceTag is the set of tags to add to apply to resources.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the key of the tag.",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "value is the value of the tag.",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "key"
+                                    ],
+                                    "x-kubernetes-list-type": "map"
+                                }
+                            },
+                            "required": [
+                                "region"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "aws": {
+                            "description": "AWS contains settings specific to the Amazon Web Services infrastructure provider.",
+                            "properties": {
+                                "region": {
+                                    "description": "region holds the default AWS region for new AWS resources created by the cluster.",
+                                    "type": "string"
+                                },
+                                "resourceTags": {
+                                    "description": "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+                                    "items": {
+                                        "description": "AWSResourceTag is a tag to apply to AWS resources created for the cluster.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the key of the tag",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "pattern": "^[0-9A-Za-z_.:/=+-@]+$",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[0-9A-Za-z_.:/=+-@]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 25,
+                                    "type": "array"
+                                },
+                                "serviceEndpoints": {
+                                    "description": "ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
+                                    "items": {
+                                        "description": "AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.",
+                                                "pattern": "^[a-z0-9-]+$",
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "description": "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.",
+                                                "pattern": "^https://",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "azure": {
+                            "description": "Azure contains settings specific to the Azure infrastructure provider.",
+                            "properties": {
+                                "armEndpoint": {
+                                    "description": "armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.",
+                                    "type": "string"
+                                },
+                                "cloudName": {
+                                    "description": "cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.",
+                                    "enum": [
+                                        "",
+                                        "AzurePublicCloud",
+                                        "AzureUSGovernmentCloud",
+                                        "AzureChinaCloud",
+                                        "AzureGermanCloud",
+                                        "AzureStackCloud"
+                                    ],
+                                    "type": "string"
+                                },
+                                "networkResourceGroupName": {
+                                    "description": "networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.",
+                                    "type": "string"
+                                },
+                                "resourceGroupName": {
+                                    "description": "resourceGroupName is the Resource Group for new Azure resources created for the cluster.",
+                                    "type": "string"
+                                },
+                                "resourceTags": {
+                                    "description": "resourceTags is a list of additional tags to apply to Azure resources created for the cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags for information on tagging Azure resources. Due to limitations on Automation, Content Delivery Network, DNS Azure resources, a maximum of 15 tags may be applied. OpenShift reserves 5 tags for internal use, allowing 10 tags for user configuration.",
+                                    "items": {
+                                        "description": "AzureResourceTag is a tag to apply to Azure resources created for the cluster.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the key part of the tag. A tag key can have a maximum of 128 characters and cannot be empty. Key must begin with a letter, end with a letter, number or underscore, and must contain only alphanumeric characters and the following special characters `_ . -`.",
+                                                "maxLength": 128,
+                                                "minLength": 1,
+                                                "pattern": "^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "value is the value part of the tag. A tag value can have a maximum of 256 characters and cannot be empty. Value must contain only alphanumeric characters and the following special characters `_ + , - . / : ; < = > ? @`.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[0-9A-Za-z_.=+-@]+$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "value"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 10,
+                                    "type": "array",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "resourceTags are immutable and may only be configured during installation",
+                                            "rule": "self.all(x, x in oldSelf) && oldSelf.all(x, x in self)"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                                {
+                                    "message": "resourceTags may only be configured during installation",
+                                    "rule": "!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "baremetal": {
+                            "description": "BareMetal contains settings specific to the BareMetal platform.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead.",
+                                    "type": "string"
+                                },
+                                "apiServerInternalIPs": {
+                                    "description": "apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead.",
+                                    "type": "string"
+                                },
+                                "ingressIPs": {
+                                    "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "nodeDNSIP": {
+                                    "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "equinixMetal": {
+                            "description": "EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.",
+                                    "type": "string"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "external": {
+                            "description": "External contains settings specific to the generic External infrastructure provider.",
+                            "properties": {
+                                "cloudControllerManager": {
+                                    "description": "cloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI). When omitted, new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.",
+                                    "properties": {
+                                        "state": {
+                                            "description": "state determines whether or not an external Cloud Controller Manager is expected to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager \n Valid values are \"External\", \"None\" and omitted. When set to \"External\", new nodes will be tainted as uninitialized when created, preventing them from running workloads until they are initialized by the cloud controller manager. When omitted or set to \"None\", new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.",
+                                            "enum": [
+                                                "",
+                                                "External",
+                                                "None"
+                                            ],
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                                {
+                                                    "message": "state is immutable once set",
+                                                    "rule": "self == oldSelf"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "state may not be added or removed once set",
+                                            "rule": "(has(self.state) == has(oldSelf.state)) || (!has(oldSelf.state) && self.state != \"External\")"
+                                        }
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                                {
+                                    "message": "cloudControllerManager may not be added or removed once set",
+                                    "rule": "has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "gcp": {
+                            "description": "GCP contains settings specific to the Google Cloud Platform infrastructure provider.",
+                            "properties": {
+                                "projectID": {
+                                    "description": "resourceGroupName is the Project ID for new GCP resources created for the cluster.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region holds the region for new GCP resources created for the cluster.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ibmcloud": {
+                            "description": "IBMCloud contains settings specific to the IBMCloud infrastructure provider.",
+                            "properties": {
+                                "cisInstanceCRN": {
+                                    "description": "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
+                                    "type": "string"
+                                },
+                                "dnsInstanceCRN": {
+                                    "description": "DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain",
+                                    "type": "string"
+                                },
+                                "location": {
+                                    "description": "Location is where the cluster has been deployed",
+                                    "type": "string"
+                                },
+                                "providerType": {
+                                    "description": "ProviderType indicates the type of cluster that was created",
+                                    "type": "string"
+                                },
+                                "resourceGroupName": {
+                                    "description": "ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "kubevirt": {
+                            "description": "Kubevirt contains settings specific to the kubevirt infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.",
+                                    "type": "string"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "nutanix": {
+                            "description": "Nutanix contains settings specific to the Nutanix infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead.",
+                                    "type": "string"
+                                },
+                                "apiServerInternalIPs": {
+                                    "description": "apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead.",
+                                    "type": "string"
+                                },
+                                "ingressIPs": {
+                                    "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "openstack": {
+                            "description": "OpenStack contains settings specific to the OpenStack infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead.",
+                                    "type": "string"
+                                },
+                                "apiServerInternalIPs": {
+                                    "description": "apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "cloudName": {
+                                    "description": "cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).",
+                                    "type": "string"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead.",
+                                    "type": "string"
+                                },
+                                "ingressIPs": {
+                                    "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "loadBalancer": {
+                                    "default": {
+                                        "type": "OpenShiftManagedDefault"
+                                    },
+                                    "description": "loadBalancer defines how the load balancer used by the cluster is configured.",
+                                    "properties": {
+                                        "type": {
+                                            "default": "OpenShiftManagedDefault",
+                                            "description": "type defines the type of load balancer used by the cluster on OpenStack platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.",
+                                            "enum": [
+                                                "OpenShiftManagedDefault",
+                                                "UserManaged"
+                                            ],
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                                {
+                                                    "message": "type is immutable once set",
+                                                    "rule": "oldSelf == '' || self == oldSelf"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "nodeDNSIP": {
+                                    "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ovirt": {
+                            "description": "Ovirt contains settings specific to the oVirt infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead.",
+                                    "type": "string"
+                                },
+                                "apiServerInternalIPs": {
+                                    "description": "apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead.",
+                                    "type": "string"
+                                },
+                                "ingressIPs": {
+                                    "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "nodeDNSIP": {
+                                    "description": "deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "powervs": {
+                            "description": "PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.",
+                            "properties": {
+                                "cisInstanceCRN": {
+                                    "description": "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
+                                    "type": "string"
+                                },
+                                "dnsInstanceCRN": {
+                                    "description": "DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "region holds the default Power VS region for new Power VS resources created by the cluster.",
+                                    "type": "string"
+                                },
+                                "resourceGroup": {
+                                    "description": "resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won't be able to configure storage, which results in the image registry cluster operator not being in an available state.",
+                                    "maxLength": 40,
+                                    "pattern": "^[a-zA-Z0-9-_ ]+$",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "resourceGroup is immutable once set",
+                                            "rule": "oldSelf == '' || self == oldSelf"
+                                        }
+                                    ]
+                                },
+                                "serviceEndpoints": {
+                                    "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.",
+                                    "items": {
+                                        "description": "PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud",
+                                                "pattern": "^[a-z0-9-]+$",
+                                                "type": "string"
+                                            },
+                                            "url": {
+                                                "description": "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.",
+                                                "format": "uri",
+                                                "pattern": "^https://",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name",
+                                            "url"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "zone": {
+                                    "description": "zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                                {
+                                    "message": "cannot unset resourceGroup once set",
+                                    "rule": "!has(oldSelf.resourceGroup) || has(self.resourceGroup)"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set.",
+                            "enum": [
+                                "",
+                                "AWS",
+                                "Azure",
+                                "BareMetal",
+                                "GCP",
+                                "Libvirt",
+                                "OpenStack",
+                                "None",
+                                "VSphere",
+                                "oVirt",
+                                "IBMCloud",
+                                "KubeVirt",
+                                "EquinixMetal",
+                                "PowerVS",
+                                "AlibabaCloud",
+                                "Nutanix",
+                                "External"
+                            ],
+                            "type": "string"
+                        },
+                        "vsphere": {
+                            "description": "VSphere contains settings specific to the VSphere infrastructure provider.",
+                            "properties": {
+                                "apiServerInternalIP": {
+                                    "description": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead.",
+                                    "type": "string"
+                                },
+                                "apiServerInternalIPs": {
+                                    "description": "apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "ingressIP": {
+                                    "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead.",
+                                    "type": "string"
+                                },
+                                "ingressIPs": {
+                                    "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.",
+                                    "format": "ip",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "maxItems": 2,
+                                    "type": "array"
+                                },
+                                "nodeDNSIP": {
+                                    "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/ingress_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/ingress_config.openshift.io_v1.json
@@ -1,0 +1,410 @@
+{
+    "description": "Ingress holds cluster-wide information about ingress, including the default ingress domain used for routes. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "appsDomain": {
+                    "description": "appsDomain is an optional domain to use instead of the one specified in the domain field when a Route is created without specifying an explicit host. If appsDomain is nonempty, this value is used to generate default host values for Route. Unlike domain, appsDomain may be modified after installation. This assumes a new ingresscontroller has been setup with a wildcard certificate.",
+                    "type": "string"
+                },
+                "componentRoutes": {
+                    "description": "componentRoutes is an optional list of routes that are managed by OpenShift components that a cluster-admin is able to configure the hostname and serving certificate for. The namespace and name of each route in this list should match an existing entry in the status.componentRoutes list. \n To determine the set of configurable Routes, look at namespace and name of entries in the .status.componentRoutes list, where participating operators write the status of configurable routes.",
+                    "items": {
+                        "description": "ComponentRouteSpec allows for configuration of a route's hostname and serving certificate.",
+                        "properties": {
+                            "hostname": {
+                                "description": "hostname is the hostname that should be used by the route.",
+                                "pattern": "^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is the namespace of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized.",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                            },
+                            "servingCertKeyPairSecret": {
+                                "description": "servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.",
+                                "properties": {
+                                    "name": {
+                                        "description": "name is the metadata.name of the referenced secret",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "hostname",
+                            "name",
+                            "namespace"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "namespace",
+                        "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "domain": {
+                    "description": "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\". \n It is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\". \n Once set, changing domain is not currently supported.",
+                    "type": "string"
+                },
+                "loadBalancer": {
+                    "description": "loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure provider of the current cluster and are required for Ingress Controller to work on OpenShift.",
+                    "properties": {
+                        "platform": {
+                            "description": "platform holds configuration specific to the underlying infrastructure provider for the ingress load balancers. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.",
+                            "properties": {
+                                "aws": {
+                                    "description": "aws contains settings specific to the Amazon Web Services infrastructure provider.",
+                                    "properties": {
+                                        "type": {
+                                            "description": "type allows user to set a load balancer type. When this field is set the default ingresscontroller will get created using the specified LBType. If this field is not set then the default ingress controller of LBType Classic will be created. Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb",
+                                            "enum": [
+                                                "NLB",
+                                                "Classic"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": {
+                                    "description": "type is the underlying infrastructure provider for the cluster. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"KubeVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+                                    "enum": [
+                                        "",
+                                        "AWS",
+                                        "Azure",
+                                        "BareMetal",
+                                        "GCP",
+                                        "Libvirt",
+                                        "OpenStack",
+                                        "None",
+                                        "VSphere",
+                                        "oVirt",
+                                        "IBMCloud",
+                                        "KubeVirt",
+                                        "EquinixMetal",
+                                        "PowerVS",
+                                        "AlibabaCloud",
+                                        "Nutanix",
+                                        "External"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "requiredHSTSPolicies": {
+                    "description": "requiredHSTSPolicies specifies HSTS policies that are required to be set on newly created  or updated routes matching the domainPattern/s and namespaceSelector/s that are specified in the policy. Each requiredHSTSPolicy must have at least a domainPattern and a maxAge to validate a route HSTS Policy route annotation, and affect route admission. \n A candidate route is checked for HSTS Policies if it has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\" E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains \n - For each candidate route, if it matches a requiredHSTSPolicy domainPattern and optional namespaceSelector, then the maxAge, preloadPolicy, and includeSubdomainsPolicy must be valid to be admitted.  Otherwise, the route is rejected. - The first match, by domainPattern and optional namespaceSelector, in the ordering of the RequiredHSTSPolicies determines the route's admission status. - If the candidate route doesn't match any requiredHSTSPolicy domainPattern and optional namespaceSelector, then it may use any HSTS Policy annotation. \n The HSTS policy configuration may be changed after routes have already been created. An update to a previously admitted route may then fail if the updated route does not conform to the updated HSTS policy configuration. However, changing the HSTS policy configuration will not cause a route that is already admitted to stop working. \n Note that if there are no RequiredHSTSPolicies, any HSTS Policy annotation on the route is valid.",
+                    "items": {
+                        "properties": {
+                            "domainPatterns": {
+                                "description": "domainPatterns is a list of domains for which the desired HSTS annotations are required. If domainPatterns is specified and a route is created with a spec.host matching one of the domains, the route must specify the HSTS Policy components described in the matching RequiredHSTSPolicy. \n The use of wildcards is allowed like this: *.foo.com matches everything under foo.com. foo.com only matches foo.com, so to cover foo.com and everything under it, you must specify *both*.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            },
+                            "includeSubDomainsPolicy": {
+                                "description": "includeSubDomainsPolicy means the HSTS Policy should apply to any subdomains of the host's domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy was set to RequireIncludeSubDomains: - the host app.bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host foo.com would NOT inherit the HSTS Policy of bar.foo.com - the host def.foo.com would NOT inherit the HSTS Policy of bar.foo.com",
+                                "enum": [
+                                    "RequireIncludeSubDomains",
+                                    "RequireNoIncludeSubDomains",
+                                    "NoOpinion"
+                                ],
+                                "type": "string"
+                            },
+                            "maxAge": {
+                                "description": "maxAge is the delta time range in seconds during which hosts are regarded as HSTS hosts. If set to 0, it negates the effect, and hosts are removed as HSTS hosts. If set to 0 and includeSubdomains is specified, all subdomains of the host are also removed as HSTS hosts. maxAge is a time-to-live value, and if this policy is not refreshed on a client, the HSTS policy will eventually expire on that client.",
+                                "properties": {
+                                    "largestMaxAge": {
+                                        "description": "The largest allowed value (in seconds) of the RequiredHSTSPolicy max-age This value can be left unspecified, in which case no upper limit is enforced.",
+                                        "format": "int32",
+                                        "maximum": 2147483647,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    },
+                                    "smallestMaxAge": {
+                                        "description": "The smallest allowed value (in seconds) of the RequiredHSTSPolicy max-age Setting max-age=0 allows the deletion of an existing HSTS header from a host.  This is a necessary tool for administrators to quickly correct mistakes. This value can be left unspecified, in which case no lower limit is enforced.",
+                                        "format": "int32",
+                                        "maximum": 2147483647,
+                                        "minimum": 0,
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "namespaceSelector": {
+                                "description": "namespaceSelector specifies a label selector such that the policy applies only to those routes that are in namespaces with labels that match the selector, and are in one of the DomainPatterns. Defaults to the empty LabelSelector, which matches everything.",
+                                "properties": {
+                                    "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                },
+                                                "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "matchLabels": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "preloadPolicy": {
+                                "description": "preloadPolicy directs the client to include hosts in its host preload list so that it never needs to do an initial load to get the HSTS header (note that this is not defined in RFC 6797 and is therefore client implementation-dependent).",
+                                "enum": [
+                                    "RequirePreload",
+                                    "RequireNoPreload",
+                                    "NoOpinion"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "domainPatterns"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "componentRoutes": {
+                    "description": "componentRoutes is where participating operators place the current route status for routes whose hostnames and serving certificates can be customized by the cluster-admin.",
+                    "items": {
+                        "description": "ComponentRouteStatus contains information allowing configuration of a route's hostname and serving certificate.",
+                        "properties": {
+                            "conditions": {
+                                "description": "conditions are used to communicate the state of the componentRoutes entry. \n Supported conditions include Available, Degraded and Progressing. \n If available is true, the content served by the route can be accessed by users. This includes cases where a default may continue to serve content while the customized route specified by the cluster-admin is being configured. \n If Degraded is true, that means something has gone wrong trying to handle the componentRoutes entry. The currentHostnames field may or may not be in effect. \n If Progressing is true, that means the component is taking some action related to the componentRoutes entry.",
+                                "items": {
+                                    "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                            "type": "string"
+                                        },
+                                        "observedGeneration": {
+                                            "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                            "format": "int64",
+                                            "type": "integer",
+                                            "minimum": -9223372036854776000,
+                                            "maximum": 9223372036854776000
+                                        },
+                                        "reason": {
+                                            "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "status of the condition, one of True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "lastTransitionTime",
+                                        "message",
+                                        "reason",
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "type"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                            },
+                            "consumingUsers": {
+                                "description": "consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.",
+                                "items": {
+                                    "description": "ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.",
+                                    "maxLength": 512,
+                                    "minLength": 1,
+                                    "pattern": "^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                },
+                                "maxItems": 5,
+                                "type": "array"
+                            },
+                            "currentHostnames": {
+                                "description": "currentHostnames is the list of current names used by the route. Typically, this list should consist of a single hostname, but if multiple hostnames are supported by the route the operator may write multiple entries to this list.",
+                                "items": {
+                                    "description": "Hostname is an alias for hostname string validation. \n The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256. ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$ \n The right operand of the | is a new pattern that mimics the current API route admission validation on hostname, except that it allows hostnames longer than the maximum length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$ \n Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname was saved via validation by the incorrect left operand of the | operator.",
+                                    "pattern": "^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$",
+                                    "type": "string"
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            },
+                            "defaultHostname": {
+                                "description": "defaultHostname is the hostname of this route prior to customization.",
+                                "pattern": "^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is the namespace of the route to customize. It must be a real namespace. Using an actual namespace ensures that no two components will conflict and the same component can be installed multiple times. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized.",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                            },
+                            "relatedObjects": {
+                                "description": "relatedObjects is a list of resources which are useful when debugging or inspecting how spec.componentRoutes is applied.",
+                                "items": {
+                                    "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                                    "properties": {
+                                        "group": {
+                                            "description": "group of the referent.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of the referent.",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "namespace of the referent.",
+                                            "type": "string"
+                                        },
+                                        "resource": {
+                                            "description": "resource of the referent.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "group",
+                                        "name",
+                                        "resource"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "minItems": 1,
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "defaultHostname",
+                            "name",
+                            "namespace",
+                            "relatedObjects"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "namespace",
+                        "name"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "defaultPlacement": {
+                    "description": "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers",
+                    "enum": [
+                        "ControlPlane",
+                        "Workers",
+                        ""
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/ingresscontroller_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/ingresscontroller_operator.openshift.io_v1.json
@@ -1,0 +1,1566 @@
+{
+    "description": "IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources. \n When an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out. \n https://kubernetes.io/docs/concepts/services-networking/ingress-controllers \n Whenever possible, sensible defaults for the platform are used. See each field for more details. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the IngressController.",
+            "properties": {
+                "clientTLS": {
+                    "description": "clientTLS specifies settings for requesting and verifying client certificates, which can be used to enable mutual TLS for edge-terminated and reencrypt routes.",
+                    "properties": {
+                        "allowedSubjectPatterns": {
+                            "description": "allowedSubjectPatterns specifies a list of regular expressions that should be matched against the distinguished name on a valid client certificate to filter requests.  The regular expressions must use PCRE syntax.  If this list is empty, no filtering is performed.  If the list is nonempty, then at least one pattern must match a client certificate's distinguished name or else the ingress controller rejects the certificate and denies the connection.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        },
+                        "clientCA": {
+                            "description": "clientCA specifies a configmap containing the PEM-encoded CA certificate bundle that should be used to verify a client's certificate.  The administrator must create this configmap in the openshift-config namespace.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced config map",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "clientCertificatePolicy": {
+                            "description": "clientCertificatePolicy specifies whether the ingress controller requires clients to provide certificates.  This field accepts the values \"Required\" or \"Optional\". \n Note that the ingress controller only checks client certificates for edge-terminated and reencrypt TLS routes; it cannot check certificates for cleartext HTTP or passthrough TLS routes.",
+                            "enum": [
+                                "",
+                                "Required",
+                                "Optional"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "clientCA",
+                        "clientCertificatePolicy"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "defaultCertificate": {
+                    "description": "defaultCertificate is a reference to a secret containing the default certificate served by the ingress controller. When Routes don't specify their own certificate, defaultCertificate is used. \n The secret must contain the following keys and data: \n tls.crt: certificate file contents tls.key: key file contents \n If unset, a wildcard certificate is automatically generated and used. The certificate is valid for the ingress controller domain (and subdomains) and the generated certificate's CA will be automatically integrated with the cluster's trust store. \n If a wildcard certificate is used and shared by multiple HTTP/2 enabled routes (which implies ALPN) then clients (i.e., notably browsers) are at liberty to reuse open connections. This means a client can reuse a connection to another route and that is likely to fail. This behaviour is generally known as connection coalescing. \n The in-use certificate (whether generated or user-specified) will be automatically integrated with OpenShift's built-in OAuth server.",
+                    "properties": {
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "domain": {
+                    "description": "domain is a DNS name serviced by the ingress controller and is used to configure multiple features: \n * For the LoadBalancerService endpoint publishing strategy, domain is used to configure DNS records. See endpointPublishingStrategy. \n * When using a generated default certificate, the certificate will be valid for domain and its subdomains. See defaultCertificate. \n * The value is published to individual Route statuses so that end-users know where to target external DNS records. \n domain must be unique among all IngressControllers, and cannot be updated. \n If empty, defaults to ingress.config.openshift.io/cluster .spec.domain.",
+                    "type": "string"
+                },
+                "endpointPublishingStrategy": {
+                    "description": "endpointPublishingStrategy is used to publish the ingress controller endpoints to other networks, enable load balancer integrations, etc. \n If unset, the default is based on infrastructure.config.openshift.io/cluster .status.platform: \n AWS:          LoadBalancerService (with External scope) Azure:        LoadBalancerService (with External scope) GCP:          LoadBalancerService (with External scope) IBMCloud:     LoadBalancerService (with External scope) AlibabaCloud: LoadBalancerService (with External scope) Libvirt:      HostNetwork \n Any other platform types (including None) default to HostNetwork. \n endpointPublishingStrategy cannot be updated.",
+                    "properties": {
+                        "hostNetwork": {
+                            "description": "hostNetwork holds parameters for the HostNetwork endpoint publishing strategy. Present only if type is HostNetwork.",
+                            "properties": {
+                                "httpPort": {
+                                    "default": 80,
+                                    "description": "httpPort is the port on the host which should be used to listen for HTTP requests. This field should be set when port 80 is already in use. The value should not coincide with the NodePort range of the cluster. When the value is 0 or is not specified it defaults to 80.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "httpsPort": {
+                                    "default": 443,
+                                    "description": "httpsPort is the port on the host which should be used to listen for HTTPS requests. This field should be set when port 443 is already in use. The value should not coincide with the NodePort range of the cluster. When the value is 0 or is not specified it defaults to 443.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                },
+                                "statsPort": {
+                                    "default": 1936,
+                                    "description": "statsPort is the port on the host where the stats from the router are published. The value should not coincide with the NodePort range of the cluster. If an external load balancer is configured to forward connections to this IngressController, the load balancer should use this port for health checks. The load balancer can send HTTP probes on this port on a given node, with the path /healthz/ready to determine if the ingress controller is ready to receive traffic on the node. For proper operation the load balancer must not forward traffic to a node until the health check reports ready. The load balancer should also stop forwarding requests within a maximum of 45 seconds after /healthz/ready starts reporting not-ready. Probing every 5 to 10 seconds, with a 5-second timeout and with a threshold of two successful or failed requests to become healthy or unhealthy respectively, are well-tested values. When the value is 0 or is not specified it defaults to 1936.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "loadBalancer": {
+                            "description": "loadBalancer holds parameters for the load balancer. Present only if type is LoadBalancerService.",
+                            "properties": {
+                                "allowedSourceRanges": {
+                                    "description": "allowedSourceRanges specifies an allowlist of IP address ranges to which access to the load balancer should be restricted.  Each range must be specified using CIDR notation (e.g. \"10.0.0.0/8\" or \"fd00::/8\"). If no range is specified, \"0.0.0.0/0\" for IPv4 and \"::/0\" for IPv6 are used by default, which allows all source addresses. \n To facilitate migration from earlier versions of OpenShift that did not have the allowedSourceRanges field, you may set the service.beta.kubernetes.io/load-balancer-source-ranges annotation on the \"router-<ingresscontroller name>\" service in the \"openshift-ingress\" namespace, and this annotation will take effect if allowedSourceRanges is empty on OpenShift 4.12.",
+                                    "items": {
+                                        "description": "CIDR is an IP address range in CIDR notation (for example, \"10.0.0.0/8\" or \"fd00::/8\").",
+                                        "pattern": "(^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)",
+                                        "type": "string"
+                                    },
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ]
+                                },
+                                "dnsManagementPolicy": {
+                                    "default": "Managed",
+                                    "description": "dnsManagementPolicy indicates if the lifecycle of the wildcard DNS record associated with the load balancer service will be managed by the ingress operator. It defaults to Managed. Valid values are: Managed and Unmanaged.",
+                                    "enum": [
+                                        "Managed",
+                                        "Unmanaged"
+                                    ],
+                                    "type": "string"
+                                },
+                                "providerParameters": {
+                                    "description": "providerParameters holds desired load balancer information specific to the underlying infrastructure provider. \n If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.",
+                                    "properties": {
+                                        "aws": {
+                                            "description": "aws provides configuration settings that are specific to AWS load balancers. \n If empty, defaults will be applied. See specific aws fields for details about their defaults.",
+                                            "properties": {
+                                                "classicLoadBalancer": {
+                                                    "description": "classicLoadBalancerParameters holds configuration parameters for an AWS classic load balancer. Present only if type is Classic.",
+                                                    "properties": {
+                                                        "connectionIdleTimeout": {
+                                                            "description": "connectionIdleTimeout specifies the maximum time period that a connection may be idle before the load balancer closes the connection.  The value must be parseable as a time duration value; see <https://pkg.go.dev/time#ParseDuration>.  A nil or zero value means no opinion, in which case a default value is used.  The default value for this field is 60s.  This default is subject to change.",
+                                                            "format": "duration",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "networkLoadBalancer": {
+                                                    "description": "networkLoadBalancerParameters holds configuration parameters for an AWS network load balancer. Present only if type is NLB.",
+                                                    "type": "object"
+                                                },
+                                                "type": {
+                                                    "description": "type is the type of AWS load balancer to instantiate for an ingresscontroller. \n Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb",
+                                                    "enum": [
+                                                        "Classic",
+                                                        "NLB"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "gcp": {
+                                            "description": "gcp provides configuration settings that are specific to GCP load balancers. \n If empty, defaults will be applied. See specific gcp fields for details about their defaults.",
+                                            "properties": {
+                                                "clientAccess": {
+                                                    "description": "clientAccess describes how client access is restricted for internal load balancers. \n Valid values are: * \"Global\": Specifying an internal load balancer with Global client access allows clients from any region within the VPC to communicate with the load balancer. \n https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access \n * \"Local\": Specifying an internal load balancer with Local client access means only clients within the same region (and VPC) as the GCP load balancer can communicate with the load balancer. Note that this is the default behavior. \n https://cloud.google.com/load-balancing/docs/internal#client_access",
+                                                    "enum": [
+                                                        "Global",
+                                                        "Local"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "ibm": {
+                                            "description": "ibm provides configuration settings that are specific to IBM Cloud load balancers. \n If empty, defaults will be applied. See specific ibm fields for details about their defaults.",
+                                            "properties": {
+                                                "protocol": {
+                                                    "description": "protocol specifies whether the load balancer uses PROXY protocol to forward connections to the IngressController. See \"service.kubernetes.io/ibm-load-balancer-cloud-provider-enable-features: \"proxy-protocol\"\" at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas\" \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n Valid values for protocol are TCP, PROXY and omitted. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is TCP, without the proxy protocol enabled.",
+                                                    "enum": [
+                                                        "",
+                                                        "TCP",
+                                                        "PROXY"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": {
+                                            "description": "type is the underlying infrastructure provider for the load balancer. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"IBM\", \"Nutanix\", \"OpenStack\", and \"VSphere\".",
+                                            "enum": [
+                                                "AWS",
+                                                "Azure",
+                                                "BareMetal",
+                                                "GCP",
+                                                "Nutanix",
+                                                "OpenStack",
+                                                "VSphere",
+                                                "IBM"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "scope": {
+                                    "description": "scope indicates the scope at which the load balancer is exposed. Possible values are \"External\" and \"Internal\".",
+                                    "enum": [
+                                        "Internal",
+                                        "External"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "dnsManagementPolicy",
+                                "scope"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "nodePort": {
+                            "description": "nodePort holds parameters for the NodePortService endpoint publishing strategy. Present only if type is NodePortService.",
+                            "properties": {
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "private": {
+                            "description": "private holds parameters for the Private endpoint publishing strategy. Present only if type is Private.",
+                            "properties": {
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the publishing strategy to use. Valid values are: \n * LoadBalancerService \n Publishes the ingress controller using a Kubernetes LoadBalancer Service. \n In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer \n If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. \n Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. \n * HostNetwork \n Publishes the ingress controller on node ports where the ingress controller is deployed. \n In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. \n * Private \n Does not publish the ingress controller. \n In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. \n * NodePortService \n Publishes the ingress controller using a Kubernetes NodePort Service. \n In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.",
+                            "enum": [
+                                "LoadBalancerService",
+                                "HostNetwork",
+                                "Private",
+                                "NodePortService"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "httpCompression": {
+                    "description": "httpCompression defines a policy for HTTP traffic compression. By default, there is no HTTP compression.",
+                    "properties": {
+                        "mimeTypes": {
+                            "description": "mimeTypes is a list of MIME types that should have compression applied. This list can be empty, in which case the ingress controller does not apply compression. \n Note: Not all MIME types benefit from compression, but HAProxy will still use resources to try to compress if instructed to.  Generally speaking, text (html, css, js, etc.) formats benefit from compression, but formats that are already compressed (image, audio, video, etc.) benefit little in exchange for the time and cpu spent on compressing again. See https://joehonton.medium.com/the-gzip-penalty-d31bd697f1a2",
+                            "items": {
+                                "description": "CompressionMIMEType defines the format of a single MIME type. E.g. \"text/css; charset=utf-8\", \"text/html\", \"text/*\", \"image/svg+xml\", \"application/octet-stream\", \"X-custom/customsub\", etc. \n The format should follow the Content-Type definition in RFC 1341: Content-Type := type \"/\" subtype *[\";\" parameter] - The type in Content-Type can be one of: application, audio, image, message, multipart, text, video, or a custom type preceded by \"X-\" and followed by a token as defined below. - The token is a string of at least one character, and not containing white space, control characters, or any of the characters in the tspecials set. - The tspecials set contains the characters ()<>@,;:\\\"/[]?.= - The subtype in Content-Type is also a token. - The optional parameter/s following the subtype are defined as: token \"=\" (token / quoted-string) - The quoted-string, as defined in RFC 822, is surrounded by double quotes and can contain white space plus any character EXCEPT \\, \", and CR. It can also contain any single ASCII character as long as it is escaped by \\.",
+                                "pattern": "^(?i)(x-[^][ ()\\\\<>@,;:\"/?.=\\x00-\\x1F\\x7F]+|application|audio|image|message|multipart|text|video)/[^][ ()\\\\<>@,;:\"/?.=\\x00-\\x1F\\x7F]+(; *[^][ ()\\\\<>@,;:\"/?.=\\x00-\\x1F\\x7F]+=([^][ ()\\\\<>@,;:\"/?.=\\x00-\\x1F\\x7F]+|\"(\\\\[\\x00-\\x7F]|[^\\x0D\"\\\\])*\"))*$",
+                                "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "set"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "httpEmptyRequestsPolicy": {
+                    "default": "Respond",
+                    "description": "httpEmptyRequestsPolicy describes how HTTP connections should be handled if the connection times out before a request is received. Allowed values for this field are \"Respond\" and \"Ignore\".  If the field is set to \"Respond\", the ingress controller sends an HTTP 400 or 408 response, logs the connection (if access logging is enabled), and counts the connection in the appropriate metrics.  If the field is set to \"Ignore\", the ingress controller closes the connection without sending a response, logging the connection, or incrementing metrics.  The default value is \"Respond\". \n Typically, these connections come from load balancers' health probes or Web browsers' speculative connections (\"preconnect\") and can be safely ignored.  However, these requests may also be caused by network errors, and so setting this field to \"Ignore\" may impede detection and diagnosis of problems.  In addition, these requests may be caused by port scans, in which case logging empty requests may aid in detecting intrusion attempts.",
+                    "enum": [
+                        "Respond",
+                        "Ignore"
+                    ],
+                    "type": "string"
+                },
+                "httpErrorCodePages": {
+                    "description": "httpErrorCodePages specifies a configmap with custom error pages. The administrator must create this configmap in the openshift-config namespace. This configmap should have keys in the format \"error-page-<error code>.http\", where <error code> is an HTTP error code. For example, \"error-page-503.http\" defines an error page for HTTP 503 responses. Currently only error pages for 503 and 404 responses can be customized. Each value in the configmap should be the full response, including HTTP headers. Eg- https://raw.githubusercontent.com/openshift/router/fadab45747a9b30cc3f0a4b41ad2871f95827a93/images/router/haproxy/conf/error-page-503.http If this field is empty, the ingress controller uses the default error pages.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "httpHeaders": {
+                    "description": "httpHeaders defines policy for HTTP headers. \n If this field is empty, the default values are used.",
+                    "properties": {
+                        "actions": {
+                            "description": "actions specifies options for modifying headers and their values. Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be modified for TLS passthrough connections. Setting the HSTS (`Strict-Transport-Security`) header is not supported via actions. `Strict-Transport-Security` may only be configured using the \"haproxy.router.openshift.io/hsts_header\" route annotation, and only in accordance with the policy specified in Ingress.Spec.RequiredHSTSPolicies. Any actions defined here are applied after any actions related to the following other fields: cache-control, spec.clientTLS, spec.httpHeaders.forwardedHeaderPolicy, spec.httpHeaders.uniqueId, and spec.httpHeaders.headerNameCaseAdjustments. In case of HTTP request headers, the actions specified in spec.httpHeaders.actions on the Route will be executed after the actions specified in the IngressController's spec.httpHeaders.actions field. In case of HTTP response headers, the actions specified in spec.httpHeaders.actions on the IngressController will be executed after the actions specified in the Route's spec.httpHeaders.actions field. Headers set using this API cannot be captured for use in access logs. The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController. Please refer to the documentation for that API field for more details.",
+                            "properties": {
+                                "request": {
+                                    "description": "request is a list of HTTP request headers to modify. Actions defined here will modify the request headers of all requests passing through an ingress controller. These actions are applied to all Routes i.e. for all connections handled by the ingress controller defined within a cluster. IngressController actions for request headers will be executed before Route actions. Currently, actions may define to either `Set` or `Delete` headers values. Actions are applied in sequence as defined in this list. A maximum of 20 request header actions may be configured. Sample fetchers allowed are \"req.hdr\" and \"ssl_c_der\". Converters allowed are \"lower\" and \"base64\". Example header values: \"%[req.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\".",
+                                    "items": {
+                                        "description": "IngressControllerHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set specifies how the HTTP header should be set. This field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value. Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6  and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. The value of this field must be no more than 16384 characters in length. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header. Possible values are Set or Delete. Set allows you to set HTTP request and response headers. Delete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "host header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'host'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are req.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:req\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                },
+                                "response": {
+                                    "description": "response is a list of HTTP response headers to modify. Actions defined here will modify the response headers of all requests passing through an ingress controller. These actions are applied to all Routes i.e. for all connections handled by the ingress controller defined within a cluster. IngressController actions for response headers will be executed after Route actions. Currently, actions may define to either `Set` or `Delete` headers values. Actions are applied in sequence as defined in this list. A maximum of 20 response header actions may be configured. Sample fetchers allowed are \"res.hdr\" and \"ssl_c_der\". Converters allowed are \"lower\" and \"base64\". Example header values: \"%[res.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\".",
+                                    "items": {
+                                        "description": "IngressControllerHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set specifies how the HTTP header should be set. This field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value. Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6  and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. The value of this field must be no more than 16384 characters in length. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header. Possible values are Set or Delete. Set allows you to set HTTP request and response headers. Delete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "host header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'host'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are res.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:res\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "forwardedHeaderPolicy": {
+                            "description": "forwardedHeaderPolicy specifies when and how the IngressController sets the Forwarded, X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, X-Forwarded-Proto, and X-Forwarded-Proto-Version HTTP headers.  The value may be one of the following: \n * \"Append\", which specifies that the IngressController appends the headers, preserving existing headers. \n * \"Replace\", which specifies that the IngressController sets the headers, replacing any existing Forwarded or X-Forwarded-* headers. \n * \"IfNone\", which specifies that the IngressController sets the headers if they are not already set. \n * \"Never\", which specifies that the IngressController never sets the headers, preserving any existing headers. \n By default, the policy is \"Append\".",
+                            "enum": [
+                                "Append",
+                                "Replace",
+                                "IfNone",
+                                "Never"
+                            ],
+                            "type": "string"
+                        },
+                        "headerNameCaseAdjustments": {
+                            "description": "headerNameCaseAdjustments specifies case adjustments that can be applied to HTTP header names.  Each adjustment is specified as an HTTP header name with the desired capitalization.  For example, specifying \"X-Forwarded-For\" indicates that the \"x-forwarded-for\" HTTP header should be adjusted to have the specified capitalization. \n These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1. \n For request headers, these adjustments are applied only for routes that have the haproxy.router.openshift.io/h1-adjust-case=true annotation.  For response headers, these adjustments are applied to all HTTP responses. \n If this field is empty, no request headers are adjusted.",
+                            "items": {
+                                "description": "IngressControllerHTTPHeaderNameCaseAdjustment is the name of an HTTP header (for example, \"X-Forwarded-For\") in the desired capitalization.  The value must be a valid HTTP header name as defined in RFC 2616 section 4.2.",
+                                "maxLength": 1024,
+                                "minLength": 0,
+                                "pattern": "^$|^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                "type": "string"
+                            },
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "uniqueId": {
+                            "description": "uniqueId describes configuration for a custom HTTP header that the ingress controller should inject into incoming HTTP requests. Typically, this header is configured to have a value that is unique to the HTTP request.  The header can be used by applications or included in access logs to facilitate tracing individual HTTP requests. \n If this field is empty, no such header is injected into requests.",
+                            "properties": {
+                                "format": {
+                                    "description": "format specifies the format for the injected HTTP header's value. This field has no effect unless name is specified.  For the HAProxy-based ingress controller implementation, this format uses the same syntax as the HTTP log format.  If the field is empty, the default value is \"%{+X}o\\\\ %ci:%cp_%fi:%fp_%Ts_%rt:%pid\"; see the corresponding HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3",
+                                    "maxLength": 1024,
+                                    "minLength": 0,
+                                    "pattern": "^(%(%|(\\{[-+]?[QXE](,[-+]?[QXE])*\\})?([A-Za-z]+|\\[[.0-9A-Z_a-z]+(\\([^)]+\\))?(,[.0-9A-Z_a-z]+(\\([^)]+\\))?)*\\]))|[^%[:cntrl:]])*$",
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "description": "name specifies the name of the HTTP header (for example, \"unique-id\") that the ingress controller should inject into HTTP requests.  The field's value must be a valid HTTP header name as defined in RFC 2616 section 4.2.  If the field is empty, no header is injected.",
+                                    "maxLength": 1024,
+                                    "minLength": 0,
+                                    "pattern": "^$|^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "logging": {
+                    "description": "logging defines parameters for what should be logged where.  If this field is empty, operational logs are enabled but access logs are disabled.",
+                    "properties": {
+                        "access": {
+                            "description": "access describes how the client requests should be logged. \n If this field is empty, access logging is disabled.",
+                            "properties": {
+                                "destination": {
+                                    "description": "destination is where access logs go.",
+                                    "properties": {
+                                        "container": {
+                                            "description": "container holds parameters for the Container logging destination. Present only if type is Container.",
+                                            "properties": {
+                                                "maxLength": {
+                                                    "default": 1024,
+                                                    "description": "maxLength is the maximum length of the log message. \n Valid values are integers in the range 480 to 8192, inclusive. \n When omitted, the default value is 1024.",
+                                                    "format": "int32",
+                                                    "maximum": 8192,
+                                                    "minimum": 480,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "syslog": {
+                                            "description": "syslog holds parameters for a syslog endpoint.  Present only if type is Syslog.",
+                                            "properties": {
+                                                "address": {
+                                                    "description": "address is the IP address of the syslog endpoint that receives log messages.",
+                                                    "type": "string"
+                                                },
+                                                "facility": {
+                                                    "description": "facility specifies the syslog facility of log messages. \n If this field is empty, the facility is \"local1\".",
+                                                    "enum": [
+                                                        "kern",
+                                                        "user",
+                                                        "mail",
+                                                        "daemon",
+                                                        "auth",
+                                                        "syslog",
+                                                        "lpr",
+                                                        "news",
+                                                        "uucp",
+                                                        "cron",
+                                                        "auth2",
+                                                        "ftp",
+                                                        "ntp",
+                                                        "audit",
+                                                        "alert",
+                                                        "cron2",
+                                                        "local0",
+                                                        "local1",
+                                                        "local2",
+                                                        "local3",
+                                                        "local4",
+                                                        "local5",
+                                                        "local6",
+                                                        "local7"
+                                                    ],
+                                                    "type": "string"
+                                                },
+                                                "maxLength": {
+                                                    "default": 1024,
+                                                    "description": "maxLength is the maximum length of the log message. \n Valid values are integers in the range 480 to 4096, inclusive. \n When omitted, the default value is 1024.",
+                                                    "format": "int32",
+                                                    "maximum": 4096,
+                                                    "minimum": 480,
+                                                    "type": "integer"
+                                                },
+                                                "port": {
+                                                    "description": "port is the UDP port number of the syslog endpoint that receives log messages.",
+                                                    "format": "int32",
+                                                    "maximum": 65535,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "address",
+                                                "port"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": {
+                                            "description": "type is the type of destination for logs.  It must be one of the following: \n * Container \n The ingress operator configures the sidecar container named \"logs\" on the ingress controller pod and configures the ingress controller to write logs to the sidecar.  The logs are then available as container logs.  The expectation is that the administrator configures a custom logging solution that reads logs from this sidecar.  Note that using container logs means that logs may be dropped if the rate of logs exceeds the container runtime's or the custom logging solution's capacity. \n * Syslog \n Logs are sent to a syslog endpoint.  The administrator must specify an endpoint that can receive syslog messages.  The expectation is that the administrator has configured a custom syslog instance.",
+                                            "enum": [
+                                                "Container",
+                                                "Syslog"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "httpCaptureCookies": {
+                                    "description": "httpCaptureCookies specifies HTTP cookies that should be captured in access logs.  If this field is empty, no cookies are captured.",
+                                    "items": {
+                                        "description": "IngressControllerCaptureHTTPCookie describes an HTTP cookie that should be captured.",
+                                        "properties": {
+                                            "matchType": {
+                                                "description": "matchType specifies the type of match to be performed on the cookie name.  Allowed values are \"Exact\" for an exact string match and \"Prefix\" for a string prefix match.  If \"Exact\" is specified, a name must be specified in the name field.  If \"Prefix\" is provided, a prefix must be specified in the namePrefix field.  For example, specifying matchType \"Prefix\" and namePrefix \"foo\" will capture a cookie named \"foo\" or \"foobar\" but not one named \"bar\".  The first matching cookie is captured.",
+                                                "enum": [
+                                                    "Exact",
+                                                    "Prefix"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "maxLength": {
+                                                "description": "maxLength specifies a maximum length of the string that will be logged, which includes the cookie name, cookie value, and one-character delimiter.  If the log entry exceeds this length, the value will be truncated in the log message.  Note that the ingress controller may impose a separate bound on the total length of HTTP headers in a request.",
+                                                "maximum": 1024,
+                                                "minimum": 1,
+                                                "type": "integer"
+                                            },
+                                            "name": {
+                                                "description": "name specifies a cookie name.  Its value must be a valid HTTP cookie name as defined in RFC 6265 section 4.1.",
+                                                "maxLength": 1024,
+                                                "minLength": 0,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$",
+                                                "type": "string"
+                                            },
+                                            "namePrefix": {
+                                                "description": "namePrefix specifies a cookie name prefix.  Its value must be a valid HTTP cookie name as defined in RFC 6265 section 4.1.",
+                                                "maxLength": 1024,
+                                                "minLength": 0,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "matchType",
+                                            "maxLength"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 1,
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ]
+                                },
+                                "httpCaptureHeaders": {
+                                    "description": "httpCaptureHeaders defines HTTP headers that should be captured in access logs.  If this field is empty, no headers are captured. \n Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be captured for TLS passthrough connections.",
+                                    "properties": {
+                                        "request": {
+                                            "description": "request specifies which HTTP request headers to capture. \n If this field is empty, no request headers are captured.",
+                                            "items": {
+                                                "description": "IngressControllerCaptureHTTPHeader describes an HTTP header that should be captured.",
+                                                "properties": {
+                                                    "maxLength": {
+                                                        "description": "maxLength specifies a maximum length for the header value.  If a header value exceeds this length, the value will be truncated in the log message.  Note that the ingress controller may impose a separate bound on the total length of HTTP headers in a request.",
+                                                        "minimum": 1,
+                                                        "type": "integer"
+                                                    },
+                                                    "name": {
+                                                        "description": "name specifies a header name.  Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2.",
+                                                        "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "maxLength",
+                                                    "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": [
+                                                "array",
+                                                "null"
+                                            ]
+                                        },
+                                        "response": {
+                                            "description": "response specifies which HTTP response headers to capture. \n If this field is empty, no response headers are captured.",
+                                            "items": {
+                                                "description": "IngressControllerCaptureHTTPHeader describes an HTTP header that should be captured.",
+                                                "properties": {
+                                                    "maxLength": {
+                                                        "description": "maxLength specifies a maximum length for the header value.  If a header value exceeds this length, the value will be truncated in the log message.  Note that the ingress controller may impose a separate bound on the total length of HTTP headers in a request.",
+                                                        "minimum": 1,
+                                                        "type": "integer"
+                                                    },
+                                                    "name": {
+                                                        "description": "name specifies a header name.  Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2.",
+                                                        "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "maxLength",
+                                                    "name"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": [
+                                                "array",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "httpLogFormat": {
+                                    "description": "httpLogFormat specifies the format of the log message for an HTTP request. \n If this field is empty, log messages use the implementation's default HTTP log format.  For HAProxy's default HTTP log format, see the HAProxy documentation: http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#8.2.3 \n Note that this format only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  It does not affect the log format for TLS passthrough connections.",
+                                    "type": "string"
+                                },
+                                "logEmptyRequests": {
+                                    "default": "Log",
+                                    "description": "logEmptyRequests specifies how connections on which no request is received should be logged.  Typically, these empty requests come from load balancers' health probes or Web browsers' speculative connections (\"preconnect\"), in which case logging these requests may be undesirable.  However, these requests may also be caused by network errors, in which case logging empty requests may be useful for diagnosing the errors.  In addition, these requests may be caused by port scans, in which case logging empty requests may aid in detecting intrusion attempts.  Allowed values for this field are \"Log\" and \"Ignore\".  The default value is \"Log\".",
+                                    "enum": [
+                                        "Log",
+                                        "Ignore"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "destination"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "namespaceSelector": {
+                    "description": "namespaceSelector is used to filter the set of namespaces serviced by the ingress controller. This is useful for implementing shards. \n If unset, the default is no filtering.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "nodePlacement": {
+                    "description": "nodePlacement enables explicit control over the scheduling of the ingress controller. \n If unset, defaults are used. See NodePlacement for more details.",
+                    "properties": {
+                        "nodeSelector": {
+                            "description": "nodeSelector is the node selector applied to ingress controller deployments. \n If set, the specified selector is used and replaces the default. \n If unset, the default depends on the value of the defaultPlacement field in the cluster config.openshift.io/v1/ingresses status. \n When defaultPlacement is Workers, the default is: \n kubernetes.io/os: linux node-role.kubernetes.io/worker: '' \n When defaultPlacement is ControlPlane, the default is: \n kubernetes.io/os: linux node-role.kubernetes.io/master: '' \n These defaults are subject to change. \n Note that using nodeSelector.matchExpressions is not supported.  Only nodeSelector.matchLabels may be used.  This is a limitation of the Kubernetes API: the pod spec does not allow complex expressions for node selectors.",
+                            "properties": {
+                                "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                        "properties": {
+                                            "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                            },
+                                            "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "operator"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                },
+                                "matchLabels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "tolerations": {
+                            "description": "tolerations is a list of tolerations applied to ingress controller deployments. \n The default is an empty list. \n See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
+                            "items": {
+                                "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                "properties": {
+                                    "effect": {
+                                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                        "type": "string"
+                                    },
+                                    "key": {
+                                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                        "type": "string"
+                                    },
+                                    "tolerationSeconds": {
+                                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                        "format": "int64",
+                                        "type": "integer",
+                                        "minimum": -9223372036854776000,
+                                        "maximum": 9223372036854776000
+                                    },
+                                    "value": {
+                                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "replicas": {
+                    "description": "replicas is the desired number of ingress controller replicas. If unset, the default depends on the value of the defaultPlacement field in the cluster config.openshift.io/v1/ingresses status. \n The value of replicas is set based on the value of a chosen field in the Infrastructure CR. If defaultPlacement is set to ControlPlane, the chosen field will be controlPlaneTopology. If it is set to Workers the chosen field will be infrastructureTopology. Replicas will then be set to 1 or 2 based whether the chosen field's value is SingleReplica or HighlyAvailable, respectively. \n These defaults are subject to change.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "routeAdmission": {
+                    "description": "routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces). \n If empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.",
+                    "properties": {
+                        "namespaceOwnership": {
+                            "description": "namespaceOwnership describes how host name claims across namespaces should be handled. \n Value must be one of: \n - Strict: Do not allow routes in different namespaces to claim the same host. \n - InterNamespaceAllowed: Allow routes to claim different paths of the same host name across namespaces. \n If empty, the default is Strict.",
+                            "enum": [
+                                "InterNamespaceAllowed",
+                                "Strict"
+                            ],
+                            "type": "string"
+                        },
+                        "wildcardPolicy": {
+                            "description": "wildcardPolicy describes how routes with wildcard policies should be handled for the ingress controller. WildcardPolicy controls use of routes [1] exposed by the ingress controller based on the route's wildcard policy. \n [1] https://github.com/openshift/api/blob/master/route/v1/types.go \n Note: Updating WildcardPolicy from WildcardsAllowed to WildcardsDisallowed will cause admitted routes with a wildcard policy of Subdomain to stop working. These routes must be updated to a wildcard policy of None to be readmitted by the ingress controller. \n WildcardPolicy supports WildcardsAllowed and WildcardsDisallowed values. \n If empty, defaults to \"WildcardsDisallowed\".",
+                            "enum": [
+                                "WildcardsAllowed",
+                                "WildcardsDisallowed"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "routeSelector": {
+                    "description": "routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards. \n If unset, the default is no filtering.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tlsSecurityProfile": {
+                    "description": "tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. \n If unset, the default is based on the apiservers.config.openshift.io/cluster resource. \n Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.",
+                    "properties": {
+                        "custom": {
+                            "description": "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: TLSv1.1",
+                            "properties": {
+                                "ciphers": {
+                                    "description": "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "minTLSVersion": {
+                                    "description": "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12",
+                                    "enum": [
+                                        "VersionTLS10",
+                                        "VersionTLS11",
+                                        "VersionTLS12",
+                                        "VersionTLS13"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": [
+                                "object",
+                                "null"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "intermediate": {
+                            "description": "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "modern": {
+                            "description": "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported.",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "old": {
+                            "description": "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: TLSv1.0",
+                            "type": [
+                                "object",
+                                "null"
+                            ]
+                        },
+                        "type": {
+                            "description": "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.",
+                            "enum": [
+                                "Old",
+                                "Intermediate",
+                                "Modern",
+                                "Custom"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tuningOptions": {
+                    "description": "tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details. \n Setting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.",
+                    "properties": {
+                        "clientFinTimeout": {
+                            "description": "clientFinTimeout defines how long a connection will be held open while waiting for the client response to the server/backend closing the connection. \n If unset, the default timeout is 1s",
+                            "format": "duration",
+                            "type": "string"
+                        },
+                        "clientTimeout": {
+                            "description": "clientTimeout defines how long a connection will be held open while waiting for a client response. \n If unset, the default timeout is 30s",
+                            "format": "duration",
+                            "type": "string"
+                        },
+                        "headerBufferBytes": {
+                            "description": "headerBufferBytes describes how much memory should be reserved (in bytes) for IngressController connection sessions. Note that this value must be at least 16384 if HTTP/2 is enabled for the IngressController (https://tools.ietf.org/html/rfc7540). If this field is empty, the IngressController will use a default value of 32768 bytes. \n Setting this field is generally not recommended as headerBufferBytes values that are too small may break the IngressController and headerBufferBytes values that are too large could cause the IngressController to use significantly more memory than necessary.",
+                            "format": "int32",
+                            "minimum": 16384,
+                            "type": "integer",
+                            "maximum": 2147483647
+                        },
+                        "headerBufferMaxRewriteBytes": {
+                            "description": "headerBufferMaxRewriteBytes describes how much memory should be reserved (in bytes) from headerBufferBytes for HTTP header rewriting and appending for IngressController connection sessions. Note that incoming HTTP requests will be limited to (headerBufferBytes - headerBufferMaxRewriteBytes) bytes, meaning headerBufferBytes must be greater than headerBufferMaxRewriteBytes. If this field is empty, the IngressController will use a default value of 8192 bytes. \n Setting this field is generally not recommended as headerBufferMaxRewriteBytes values that are too small may break the IngressController and headerBufferMaxRewriteBytes values that are too large could cause the IngressController to use significantly more memory than necessary.",
+                            "format": "int32",
+                            "minimum": 4096,
+                            "type": "integer",
+                            "maximum": 2147483647
+                        },
+                        "healthCheckInterval": {
+                            "description": "healthCheckInterval defines how long the router waits between two consecutive health checks on its configured backends.  This value is applied globally as a default for all routes, but may be overridden per-route by the route annotation \"router.openshift.io/haproxy.health.check.interval\". \n Expects an unsigned duration string of decimal numbers, each with optional fraction and a unit suffix, eg \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\" U+00B5 or \"μs\" U+03BC), \"ms\", \"s\", \"m\", \"h\". \n Setting this to less than 5s can cause excess traffic due to too frequent TCP health checks and accompanying SYN packet storms.  Alternatively, setting this too high can result in increased latency, due to backend servers that are no longer available, but haven't yet been detected as such. \n An empty or zero healthCheckInterval means no opinion and IngressController chooses a default, which is subject to change over time. Currently the default healthCheckInterval value is 5s. \n Currently the minimum allowed value is 1s and the maximum allowed value is 2147483647ms (24.85 days).  Both are subject to change over time.",
+                            "pattern": "^(0|([0-9]+(\\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$",
+                            "type": "string"
+                        },
+                        "maxConnections": {
+                            "description": "maxConnections defines the maximum number of simultaneous connections that can be established per HAProxy process. Increasing this value allows each ingress controller pod to handle more connections but at the cost of additional system resources being consumed. \n Permitted values are: empty, 0, -1, and the range 2000-2000000. \n If this field is empty or 0, the IngressController will use the default value of 50000, but the default is subject to change in future releases. \n If the value is -1 then HAProxy will dynamically compute a maximum value based on the available ulimits in the running container. Selecting -1 (i.e., auto) will result in a large value being computed (~520000 on OpenShift >=4.10 clusters) and therefore each HAProxy process will incur significant memory usage compared to the current default of 50000. \n Setting a value that is greater than the current operating system limit will prevent the HAProxy process from starting. \n If you choose a discrete value (e.g., 750000) and the router pod is migrated to a new node, there's no guarantee that that new node has identical ulimits configured. In such a scenario the pod would fail to start. If you have nodes with different ulimits configured (e.g., different tuned profiles) and you choose a discrete value then the guidance is to use -1 and let the value be computed dynamically at runtime. \n You can monitor memory usage for router containers with the following metric: 'container_memory_working_set_bytes{container=\"router\",namespace=\"openshift-ingress\"}'. \n You can monitor memory usage of individual HAProxy processes in router containers with the following metric: 'container_memory_working_set_bytes{container=\"router\",namespace=\"openshift-ingress\"}/container_processes{container=\"router\",namespace=\"openshift-ingress\"}'.",
+                            "format": "int32",
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                        },
+                        "reloadInterval": {
+                            "description": "reloadInterval defines the minimum interval at which the router is allowed to reload to accept new changes. Increasing this value can prevent the accumulation of HAProxy processes, depending on the scenario. Increasing this interval can also lessen load imbalance on a backend's servers when using the roundrobin balancing algorithm. Alternatively, decreasing this value may decrease latency since updates to HAProxy's configuration can take effect more quickly. \n The value must be a time duration value; see <https://pkg.go.dev/time#ParseDuration>. Currently, the minimum value allowed is 1s, and the maximum allowed value is 120s. Minimum and maximum allowed values may change in future versions of OpenShift. Note that if a duration outside of these bounds is provided, the value of reloadInterval will be capped/floored and not rejected (e.g. a duration of over 120s will be capped to 120s; the IngressController will not reject and replace this disallowed value with the default). \n A zero value for reloadInterval tells the IngressController to choose the default, which is currently 5s and subject to change without notice. \n This field expects an unsigned duration string of decimal numbers, each with optional fraction and a unit suffix, e.g. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\" U+00B5 or \"μs\" U+03BC), \"ms\", \"s\", \"m\", \"h\". \n Note: Setting a value significantly larger than the default of 5s can cause latency in observing updates to routes and their endpoints. HAProxy's configuration will be reloaded less frequently, and newly created routes will not be served until the subsequent reload.",
+                            "pattern": "^(0|([0-9]+(\\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$",
+                            "type": "string"
+                        },
+                        "serverFinTimeout": {
+                            "description": "serverFinTimeout defines how long a connection will be held open while waiting for the server/backend response to the client closing the connection. \n If unset, the default timeout is 1s",
+                            "format": "duration",
+                            "type": "string"
+                        },
+                        "serverTimeout": {
+                            "description": "serverTimeout defines how long a connection will be held open while waiting for a server/backend response. \n If unset, the default timeout is 30s",
+                            "format": "duration",
+                            "type": "string"
+                        },
+                        "threadCount": {
+                            "description": "threadCount defines the number of threads created per HAProxy process. Creating more threads allows each ingress controller pod to handle more connections, at the cost of more system resources being used. HAProxy currently supports up to 64 threads. If this field is empty, the IngressController will use the default value.  The current default is 4 threads, but this may change in future releases. \n Setting this field is generally not recommended. Increasing the number of HAProxy threads allows ingress controller pods to utilize more CPU time under load, potentially starving other pods if set too high. Reducing the number of threads may cause the ingress controller to perform poorly.",
+                            "format": "int32",
+                            "maximum": 64,
+                            "minimum": 1,
+                            "type": "integer"
+                        },
+                        "tlsInspectDelay": {
+                            "description": "tlsInspectDelay defines how long the router can hold data to find a matching route. \n Setting this too short can cause the router to fall back to the default certificate for edge-terminated or reencrypt routes even when a better matching certificate could be used. \n If unset, the default inspect delay is 5s",
+                            "format": "duration",
+                            "type": "string"
+                        },
+                        "tunnelTimeout": {
+                            "description": "tunnelTimeout defines how long a tunnel connection (including websockets) will be held open while the tunnel is idle. \n If unset, the default timeout is 1h",
+                            "format": "duration",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides allows specifying unsupported configuration options.  Its use is unsupported.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the IngressController.",
+            "properties": {
+                "availableReplicas": {
+                    "description": "availableReplicas is number of observed available replicas according to the ingress controller deployment.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status. \n Available means the ingress controller deployment is available and servicing route and ingress resources (i.e, .status.availableReplicas equals .spec.replicas) \n There are additional conditions which indicate the status of other ingress controller features and capabilities. \n * LoadBalancerManaged - True if the following conditions are met: * The endpoint publishing strategy requires a service load balancer. - False if any of those conditions are unsatisfied. \n * LoadBalancerReady - True if the following conditions are met: * A load balancer is managed. * The load balancer is ready. - False if any of those conditions are unsatisfied. \n * DNSManaged - True if the following conditions are met: * The endpoint publishing strategy and platform support DNS. * The ingress controller domain is set. * dns.config.openshift.io/cluster configures DNS zones. - False if any of those conditions are unsatisfied. \n * DNSReady - True if the following conditions are met: * DNS is managed. * DNS records have been successfully created. - False if any of those conditions are unsatisfied.",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "domain": {
+                    "description": "domain is the actual domain in use.",
+                    "type": "string"
+                },
+                "endpointPublishingStrategy": {
+                    "description": "endpointPublishingStrategy is the actual strategy in use.",
+                    "properties": {
+                        "hostNetwork": {
+                            "description": "hostNetwork holds parameters for the HostNetwork endpoint publishing strategy. Present only if type is HostNetwork.",
+                            "properties": {
+                                "httpPort": {
+                                    "default": 80,
+                                    "description": "httpPort is the port on the host which should be used to listen for HTTP requests. This field should be set when port 80 is already in use. The value should not coincide with the NodePort range of the cluster. When the value is 0 or is not specified it defaults to 80.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "httpsPort": {
+                                    "default": 443,
+                                    "description": "httpsPort is the port on the host which should be used to listen for HTTPS requests. This field should be set when port 443 is already in use. The value should not coincide with the NodePort range of the cluster. When the value is 0 or is not specified it defaults to 443.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                },
+                                "statsPort": {
+                                    "default": 1936,
+                                    "description": "statsPort is the port on the host where the stats from the router are published. The value should not coincide with the NodePort range of the cluster. If an external load balancer is configured to forward connections to this IngressController, the load balancer should use this port for health checks. The load balancer can send HTTP probes on this port on a given node, with the path /healthz/ready to determine if the ingress controller is ready to receive traffic on the node. For proper operation the load balancer must not forward traffic to a node until the health check reports ready. The load balancer should also stop forwarding requests within a maximum of 45 seconds after /healthz/ready starts reporting not-ready. Probing every 5 to 10 seconds, with a 5-second timeout and with a threshold of two successful or failed requests to become healthy or unhealthy respectively, are well-tested values. When the value is 0 or is not specified it defaults to 1936.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 0,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "loadBalancer": {
+                            "description": "loadBalancer holds parameters for the load balancer. Present only if type is LoadBalancerService.",
+                            "properties": {
+                                "allowedSourceRanges": {
+                                    "description": "allowedSourceRanges specifies an allowlist of IP address ranges to which access to the load balancer should be restricted.  Each range must be specified using CIDR notation (e.g. \"10.0.0.0/8\" or \"fd00::/8\"). If no range is specified, \"0.0.0.0/0\" for IPv4 and \"::/0\" for IPv6 are used by default, which allows all source addresses. \n To facilitate migration from earlier versions of OpenShift that did not have the allowedSourceRanges field, you may set the service.beta.kubernetes.io/load-balancer-source-ranges annotation on the \"router-<ingresscontroller name>\" service in the \"openshift-ingress\" namespace, and this annotation will take effect if allowedSourceRanges is empty on OpenShift 4.12.",
+                                    "items": {
+                                        "description": "CIDR is an IP address range in CIDR notation (for example, \"10.0.0.0/8\" or \"fd00::/8\").",
+                                        "pattern": "(^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$)|(^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\\/(12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))$)",
+                                        "type": "string"
+                                    },
+                                    "type": [
+                                        "array",
+                                        "null"
+                                    ]
+                                },
+                                "dnsManagementPolicy": {
+                                    "default": "Managed",
+                                    "description": "dnsManagementPolicy indicates if the lifecycle of the wildcard DNS record associated with the load balancer service will be managed by the ingress operator. It defaults to Managed. Valid values are: Managed and Unmanaged.",
+                                    "enum": [
+                                        "Managed",
+                                        "Unmanaged"
+                                    ],
+                                    "type": "string"
+                                },
+                                "providerParameters": {
+                                    "description": "providerParameters holds desired load balancer information specific to the underlying infrastructure provider. \n If empty, defaults will be applied. See specific providerParameters fields for details about their defaults.",
+                                    "properties": {
+                                        "aws": {
+                                            "description": "aws provides configuration settings that are specific to AWS load balancers. \n If empty, defaults will be applied. See specific aws fields for details about their defaults.",
+                                            "properties": {
+                                                "classicLoadBalancer": {
+                                                    "description": "classicLoadBalancerParameters holds configuration parameters for an AWS classic load balancer. Present only if type is Classic.",
+                                                    "properties": {
+                                                        "connectionIdleTimeout": {
+                                                            "description": "connectionIdleTimeout specifies the maximum time period that a connection may be idle before the load balancer closes the connection.  The value must be parseable as a time duration value; see <https://pkg.go.dev/time#ParseDuration>.  A nil or zero value means no opinion, in which case a default value is used.  The default value for this field is 60s.  This default is subject to change.",
+                                                            "format": "duration",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                },
+                                                "networkLoadBalancer": {
+                                                    "description": "networkLoadBalancerParameters holds configuration parameters for an AWS network load balancer. Present only if type is NLB.",
+                                                    "type": "object"
+                                                },
+                                                "type": {
+                                                    "description": "type is the type of AWS load balancer to instantiate for an ingresscontroller. \n Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb",
+                                                    "enum": [
+                                                        "Classic",
+                                                        "NLB"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "type"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "gcp": {
+                                            "description": "gcp provides configuration settings that are specific to GCP load balancers. \n If empty, defaults will be applied. See specific gcp fields for details about their defaults.",
+                                            "properties": {
+                                                "clientAccess": {
+                                                    "description": "clientAccess describes how client access is restricted for internal load balancers. \n Valid values are: * \"Global\": Specifying an internal load balancer with Global client access allows clients from any region within the VPC to communicate with the load balancer. \n https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access \n * \"Local\": Specifying an internal load balancer with Local client access means only clients within the same region (and VPC) as the GCP load balancer can communicate with the load balancer. Note that this is the default behavior. \n https://cloud.google.com/load-balancing/docs/internal#client_access",
+                                                    "enum": [
+                                                        "Global",
+                                                        "Local"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "ibm": {
+                                            "description": "ibm provides configuration settings that are specific to IBM Cloud load balancers. \n If empty, defaults will be applied. See specific ibm fields for details about their defaults.",
+                                            "properties": {
+                                                "protocol": {
+                                                    "description": "protocol specifies whether the load balancer uses PROXY protocol to forward connections to the IngressController. See \"service.kubernetes.io/ibm-load-balancer-cloud-provider-enable-features: \"proxy-protocol\"\" at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas\" \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n Valid values for protocol are TCP, PROXY and omitted. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is TCP, without the proxy protocol enabled.",
+                                                    "enum": [
+                                                        "",
+                                                        "TCP",
+                                                        "PROXY"
+                                                    ],
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": {
+                                            "description": "type is the underlying infrastructure provider for the load balancer. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"IBM\", \"Nutanix\", \"OpenStack\", and \"VSphere\".",
+                                            "enum": [
+                                                "AWS",
+                                                "Azure",
+                                                "BareMetal",
+                                                "GCP",
+                                                "Nutanix",
+                                                "OpenStack",
+                                                "VSphere",
+                                                "IBM"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "scope": {
+                                    "description": "scope indicates the scope at which the load balancer is exposed. Possible values are \"External\" and \"Internal\".",
+                                    "enum": [
+                                        "Internal",
+                                        "External"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "dnsManagementPolicy",
+                                "scope"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "nodePort": {
+                            "description": "nodePort holds parameters for the NodePortService endpoint publishing strategy. Present only if type is NodePortService.",
+                            "properties": {
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "private": {
+                            "description": "private holds parameters for the Private endpoint publishing strategy. Present only if type is Private.",
+                            "properties": {
+                                "protocol": {
+                                    "description": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol. \n PROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol. \n The following values are valid for this field: \n * The empty string. * \"TCP\". * \"PROXY\". \n The empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
+                                    "enum": [
+                                        "",
+                                        "TCP",
+                                        "PROXY"
+                                    ],
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the publishing strategy to use. Valid values are: \n * LoadBalancerService \n Publishes the ingress controller using a Kubernetes LoadBalancer Service. \n In this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer \n If domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. \n Wildcard DNS management is currently supported only on the AWS, Azure, and GCP platforms. \n * HostNetwork \n Publishes the ingress controller on node ports where the ingress controller is deployed. \n In this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports. \n * Private \n Does not publish the ingress controller. \n In this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller. \n * NodePortService \n Publishes the ingress controller using a Kubernetes NodePort Service. \n In this configuration, the ingress controller deployment uses container networking. A NodePort Service is created to publish the deployment. The specific node ports are dynamically allocated by OpenShift; however, to support static port allocations, user changes to the node port field of the managed NodePort Service will preserved.",
+                            "enum": [
+                                "LoadBalancerService",
+                                "HostNetwork",
+                                "Private",
+                                "NodePortService"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "namespaceSelector": {
+                    "description": "namespaceSelector is the actual namespaceSelector in use.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the most recent generation observed.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "routeSelector": {
+                    "description": "routeSelector is the actual routeSelector in use.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "selector": {
+                    "description": "selector is a label selector, in string format, for ingress controller pods corresponding to the IngressController. The number of matching pods should equal the value of availableReplicas.",
+                    "type": "string"
+                },
+                "tlsProfile": {
+                    "description": "tlsProfile is the TLS connection configuration that is in effect.",
+                    "properties": {
+                        "ciphers": {
+                            "description": "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "minTLSVersion": {
+                            "description": "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12",
+                            "enum": [
+                                "VersionTLS10",
+                                "VersionTLS11",
+                                "VersionTLS12",
+                                "VersionTLS13"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/insightsdatagather_config.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/insightsdatagather_config.openshift.io_v1alpha1.json
@@ -1,0 +1,56 @@
+{
+    "description": "InsightsDataGather provides data gather configuration options for the the Insights Operator. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "gatherConfig": {
+                    "description": "gatherConfig spec attribute includes all the configuration options related to gathering of the Insights data and its uploading to the ingress.",
+                    "properties": {
+                        "dataPolicy": {
+                            "description": "dataPolicy allows user to enable additional global obfuscation of the IP addresses and base domain in the Insights archive data. Valid values are \"None\" and \"ObfuscateNetworking\". When set to None the data is not obfuscated. When set to ObfuscateNetworking the IP addresses and the cluster domain name are obfuscated. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is None.",
+                            "enum": [
+                                "",
+                                "None",
+                                "ObfuscateNetworking"
+                            ],
+                            "type": "string"
+                        },
+                        "disabledGatherers": {
+                            "description": "disabledGatherers is a list of gatherers to be excluded from the gathering. All the gatherers can be disabled by providing \"all\" value. If all the gatherers are disabled, the Insights operator does not gather any data. The particular gatherers IDs can be found at https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md. Run the following command to get the names of last active gatherers: \"oc get insightsoperators.operator.openshift.io cluster -o json | jq '.status.gatherStatus.gatherers[].name'\" An example of disabling gatherers looks like this: `disabledGatherers: [\"clusterconfig/machine_configs\", \"workloads/workload_info\"]`",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/insightsoperator_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/insightsoperator_operator.openshift.io_v1.json
@@ -1,0 +1,313 @@
+{
+    "description": "InsightsOperator holds cluster-wide information about the Insights Operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the Insights.",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the Insights operator.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "gatherStatus": {
+                    "description": "gatherStatus provides basic information about the last Insights data gathering. When omitted, this means no data gathering has taken place yet.",
+                    "properties": {
+                        "gatherers": {
+                            "description": "gatherers is a list of active gatherers (and their statuses) in the last gathering.",
+                            "items": {
+                                "description": "gathererStatus represents information about a particular data gatherer.",
+                                "properties": {
+                                    "conditions": {
+                                        "description": "conditions provide details on the status of each gatherer.",
+                                        "items": {
+                                            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                                            "properties": {
+                                                "lastTransitionTime": {
+                                                    "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                                    "format": "date-time",
+                                                    "type": "string"
+                                                },
+                                                "message": {
+                                                    "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                                    "type": "string"
+                                                },
+                                                "observedGeneration": {
+                                                    "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                                    "format": "int64",
+                                                    "type": "integer",
+                                                    "minimum": -9223372036854776000,
+                                                    "maximum": 9223372036854776000
+                                                },
+                                                "reason": {
+                                                    "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "description": "status of the condition, one of True, False, Unknown.",
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "lastTransitionTime",
+                                                "message",
+                                                "reason",
+                                                "status",
+                                                "type"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "minItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "lastGatherDuration": {
+                                        "description": "lastGatherDuration represents the time spent gathering.",
+                                        "pattern": "^([1-9][0-9]*(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "name is the name of the gatherer.",
+                                        "maxLength": 256,
+                                        "minLength": 5,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "conditions",
+                                    "lastGatherDuration",
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        },
+                        "lastGatherDuration": {
+                            "description": "lastGatherDuration is the total time taken to process all gatherers during the last gather event.",
+                            "pattern": "^0|([1-9][0-9]*(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+                            "type": "string"
+                        },
+                        "lastGatherTime": {
+                            "description": "lastGatherTime is the last time when Insights data gathering finished. An empty value means that no data has been gathered yet.",
+                            "format": "date-time",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "insightsReport": {
+                    "description": "insightsReport provides general Insights analysis results. When omitted, this means no data gathering has taken place yet.",
+                    "properties": {
+                        "downloadedAt": {
+                            "description": "downloadedAt is the time when the last Insights report was downloaded. An empty value means that there has not been any Insights report downloaded yet and it usually appears in disconnected clusters (or clusters when the Insights data gathering is disabled).",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "healthChecks": {
+                            "description": "healthChecks provides basic information about active Insights health checks in a cluster.",
+                            "items": {
+                                "description": "healthCheck represents an Insights health check attributes.",
+                                "properties": {
+                                    "advisorURI": {
+                                        "description": "advisorURI provides the URL link to the Insights Advisor.",
+                                        "pattern": "^https:\\/\\/\\S+",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "description provides basic description of the healtcheck.",
+                                        "maxLength": 2048,
+                                        "minLength": 10,
+                                        "type": "string"
+                                    },
+                                    "state": {
+                                        "description": "state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.",
+                                        "enum": [
+                                            "Enabled",
+                                            "Disabled"
+                                        ],
+                                        "type": "string"
+                                    },
+                                    "totalRisk": {
+                                        "description": "totalRisk of the healthcheck. Indicator of the total risk posed by the detected issue; combination of impact and likelihood. The values can be from 1 to 4, and the higher the number, the more important the issue.",
+                                        "format": "int32",
+                                        "maximum": 4,
+                                        "minimum": 1,
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "advisorURI",
+                                    "description",
+                                    "state",
+                                    "totalRisk"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/kubeapiserver_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/kubeapiserver_operator.openshift.io_v1.json
@@ -1,0 +1,272 @@
+{
+    "description": "KubeAPIServer provides information to configure an operator to manage kube-apiserver. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the Kubernetes API Server",
+            "properties": {
+                "failedRevisionLimit": {
+                    "description": "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "forceRedeploymentReason": {
+                    "description": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "succeededRevisionLimit": {
+                    "description": "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the Kubernetes API Server",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "latestAvailableRevision": {
+                    "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "latestAvailableRevisionReason": {
+                    "description": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
+                    "type": "string"
+                },
+                "nodeStatuses": {
+                    "description": "nodeStatuses track the deployment values and errors across individual nodes",
+                    "items": {
+                        "description": "NodeStatus provides information about the current state of a particular node managed by this operator.",
+                        "properties": {
+                            "currentRevision": {
+                                "description": "currentRevision is the generation of the most recently successful deployment",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedCount": {
+                                "description": "lastFailedCount is how often the installer pod of the last failed revision failed.",
+                                "type": "integer"
+                            },
+                            "lastFailedReason": {
+                                "description": "lastFailedReason is a machine readable failure reason string.",
+                                "type": "string"
+                            },
+                            "lastFailedRevision": {
+                                "description": "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedRevisionErrors": {
+                                "description": "lastFailedRevisionErrors is a list of human readable errors during the failed deployment referenced in lastFailedRevision.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "lastFailedTime": {
+                                "description": "lastFailedTime is the time the last failed revision failed the last time.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastFallbackCount": {
+                                "description": "lastFallbackCount is how often a fallback to a previous revision happened.",
+                                "type": "integer"
+                            },
+                            "nodeName": {
+                                "description": "nodeName is the name of the node",
+                                "type": "string"
+                            },
+                            "targetRevision": {
+                                "description": "targetRevision is the generation of the deployment we're trying to apply",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "serviceAccountIssuers": {
+                    "description": "serviceAccountIssuers tracks history of used service account issuers. The item without expiration time represents the currently used service account issuer. The other items represents service account issuers that were used previously and are still being trusted. The default expiration for the items is set by the platform and it defaults to 24h. see: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection",
+                    "items": {
+                        "properties": {
+                            "expirationTime": {
+                                "description": "expirationTime is the time after which this service account issuer will be pruned and removed from the trusted list of service account issuers.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the name of the service account issuer ---",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/kubecontrollermanager_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/kubecontrollermanager_operator.openshift.io_v1.json
@@ -1,0 +1,258 @@
+{
+    "description": "KubeControllerManager provides information to configure an operator to manage kube-controller-manager. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the Kubernetes Controller Manager",
+            "properties": {
+                "failedRevisionLimit": {
+                    "description": "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "forceRedeploymentReason": {
+                    "description": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "succeededRevisionLimit": {
+                    "description": "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "useMoreSecureServiceCA": {
+                    "default": false,
+                    "description": "useMoreSecureServiceCA indicates that the service-ca.crt provided in SA token volumes should include only enough certificates to validate service serving certificates. Once set to true, it cannot be set to false. Even if someone finds a way to set it back to false, the service-ca.crt files that previously existed will only have the more secure content.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the Kubernetes Controller Manager",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "latestAvailableRevision": {
+                    "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "latestAvailableRevisionReason": {
+                    "description": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
+                    "type": "string"
+                },
+                "nodeStatuses": {
+                    "description": "nodeStatuses track the deployment values and errors across individual nodes",
+                    "items": {
+                        "description": "NodeStatus provides information about the current state of a particular node managed by this operator.",
+                        "properties": {
+                            "currentRevision": {
+                                "description": "currentRevision is the generation of the most recently successful deployment",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedCount": {
+                                "description": "lastFailedCount is how often the installer pod of the last failed revision failed.",
+                                "type": "integer"
+                            },
+                            "lastFailedReason": {
+                                "description": "lastFailedReason is a machine readable failure reason string.",
+                                "type": "string"
+                            },
+                            "lastFailedRevision": {
+                                "description": "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedRevisionErrors": {
+                                "description": "lastFailedRevisionErrors is a list of human readable errors during the failed deployment referenced in lastFailedRevision.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "lastFailedTime": {
+                                "description": "lastFailedTime is the time the last failed revision failed the last time.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastFallbackCount": {
+                                "description": "lastFallbackCount is how often a fallback to a previous revision happened.",
+                                "type": "integer"
+                            },
+                            "nodeName": {
+                                "description": "nodeName is the name of the node",
+                                "type": "string"
+                            },
+                            "targetRevision": {
+                                "description": "targetRevision is the generation of the deployment we're trying to apply",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/kubeletconfig_machineconfiguration.openshift.io_v1.json
+++ b/openshift/v4.14-strict/kubeletconfig_machineconfiguration.openshift.io_v1.json
@@ -1,0 +1,189 @@
+{
+  "description": "KubeletConfig describes a customized Kubelet configuration.",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubeletConfigSpec defines the desired state of KubeletConfig",
+      "type": "object",
+      "properties": {
+        "autoSizingReserved": {
+          "description": "Automatically set optimal system reserved",
+          "type": "boolean"
+        },
+        "tlsSecurityProfile": {
+          "description": "tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers. \n If unset, the default is based on the apiservers.config.openshift.io/cluster resource. \n Note that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout. \n Note that the minimum TLS version for ingress controllers is 1.1, and the maximum TLS version is 1.2.  An implication of this restriction is that the Modern TLS profile type cannot be used because it requires TLS 1.3.",
+          "properties": {
+            "custom": {
+              "description": "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n   ciphers:     - ECDHE-ECDSA-CHACHA20-POLY1305     - ECDHE-RSA-CHACHA20-POLY1305     - ECDHE-RSA-AES128-GCM-SHA256     - ECDHE-ECDSA-AES128-GCM-SHA256   minTLSVersion: TLSv1.1",
+              "nullable": true,
+              "properties": {
+                "ciphers": {
+                  "description": "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n   ciphers:     - DES-CBC3-SHA",
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "minTLSVersion": {
+                  "description": "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n   minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12",
+                  "enum": [
+                    "VersionTLS10",
+                    "VersionTLS11",
+                    "VersionTLS12",
+                    "VersionTLS13"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "intermediate": {
+              "description": "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.2",
+              "nullable": true,
+              "type": "object"
+            },
+            "modern": {
+              "description": "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n   ciphers:     - TLS_AES_128_GCM_SHA256     - TLS_AES_256_GCM_SHA384     - TLS_CHACHA20_POLY1305_SHA256   minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported.",
+              "nullable": true,
+              "type": "object"
+            },
+            "old": {
+              "description": "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n   ciphers:     - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384     - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256     - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA     - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA     - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_AES_128_GCM_SHA256     - TLS_RSA_WITH_AES_256_GCM_SHA384     - TLS_RSA_WITH_AES_128_CBC_SHA256     - TLS_RSA_WITH_AES_128_CBC_SHA     - TLS_RSA_WITH_AES_256_CBC_SHA     - TLS_RSA_WITH_3DES_EDE_CBC_SHA   minTLSVersion: TLSv1.0",
+              "nullable": true,
+              "type": "object"
+            },
+            "type": {
+              "description": "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries.",
+              "enum": [
+                "Old",
+                "Intermediate",
+                "Modern",
+                "Custom"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logLevel": {
+          "description": "logLevel defines the log level of the Kubelet",
+          "type": "integer",
+          "format": "int64",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "kubeletConfig": {
+          "description": "The fields of the kubelet configuration are defined in kubernetes upstream. Please refer to the types defined in the version/commit used by OpenShift of the upstream kubernetes. It's important to note that, since the fields of the kubelet configuration are directly fetched from upstream the validation of those values is handled directly by the kubelet. Please refer to the upstream version of the relavent kubernetes for the valid values of these fields. Invalid values of the kubelet configuration fields may render cluster nodes unusable.",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "machineConfigPoolSelector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "KubeletConfigStatus defines the observed state of a KubeletConfig",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "KubeletConfigCondition defines the state of the KubeletConfig",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the time of the last update to the current status object.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message provides additional information about the current condition. This is only to be consumed by humans.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.  Reasons are PascalCase",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "type specifies the state of the operator's reconciliation functionality.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.14-strict/kubescheduler_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/kubescheduler_operator.openshift.io_v1.json
@@ -1,0 +1,253 @@
+{
+    "description": "KubeScheduler provides information to configure an operator to manage scheduler. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the Kubernetes Scheduler",
+            "properties": {
+                "failedRevisionLimit": {
+                    "description": "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "forceRedeploymentReason": {
+                    "description": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
+                    "type": "string"
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "succeededRevisionLimit": {
+                    "description": "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the Kubernetes Scheduler",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "latestAvailableRevision": {
+                    "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "latestAvailableRevisionReason": {
+                    "description": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
+                    "type": "string"
+                },
+                "nodeStatuses": {
+                    "description": "nodeStatuses track the deployment values and errors across individual nodes",
+                    "items": {
+                        "description": "NodeStatus provides information about the current state of a particular node managed by this operator.",
+                        "properties": {
+                            "currentRevision": {
+                                "description": "currentRevision is the generation of the most recently successful deployment",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedCount": {
+                                "description": "lastFailedCount is how often the installer pod of the last failed revision failed.",
+                                "type": "integer"
+                            },
+                            "lastFailedReason": {
+                                "description": "lastFailedReason is a machine readable failure reason string.",
+                                "type": "string"
+                            },
+                            "lastFailedRevision": {
+                                "description": "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            },
+                            "lastFailedRevisionErrors": {
+                                "description": "lastFailedRevisionErrors is a list of human readable errors during the failed deployment referenced in lastFailedRevision.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "lastFailedTime": {
+                                "description": "lastFailedTime is the time the last failed revision failed the last time.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "lastFallbackCount": {
+                                "description": "lastFallbackCount is how often a fallback to a previous revision happened.",
+                                "type": "integer"
+                            },
+                            "nodeName": {
+                                "description": "nodeName is the name of the node",
+                                "type": "string"
+                            },
+                            "targetRevision": {
+                                "description": "targetRevision is the generation of the deployment we're trying to apply",
+                                "format": "int32",
+                                "type": "integer",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/kubestorageversionmigrator_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/kubestorageversionmigrator_operator.openshift.io_v1.json
@@ -1,0 +1,162 @@
+{
+    "description": "KubeStorageVersionMigrator provides information to configure an operator to manage kube-storage-version-migrator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/machine_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/machine_machine.openshift.io_v1beta1.json
@@ -1,0 +1,367 @@
+{
+    "description": "Machine is the Schema for the machines API Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "MachineSpec defines the desired state of Machine",
+            "properties": {
+                "lifecycleHooks": {
+                    "description": "LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.",
+                    "properties": {
+                        "preDrain": {
+                            "description": "PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.",
+                            "items": {
+                                "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                        "maxLength": 256,
+                                        "minLength": 3,
+                                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                        "type": "string"
+                                    },
+                                    "owner": {
+                                        "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                        "maxLength": 512,
+                                        "minLength": 3,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "owner"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                        },
+                        "preTerminate": {
+                            "description": "PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.",
+                            "items": {
+                                "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                        "maxLength": 256,
+                                        "minLength": 3,
+                                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                        "type": "string"
+                                    },
+                                    "owner": {
+                                        "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                        "maxLength": 512,
+                                        "minLength": 3,
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "owner"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-map-keys": [
+                                "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "metadata": {
+                    "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+                    "properties": {
+                        "annotations": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                            "type": "object"
+                        },
+                        "generateName": {
+                            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                            "type": "string"
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                            "type": "object"
+                        },
+                        "name": {
+                            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                            "type": "string"
+                        },
+                        "ownerReferences": {
+                            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                            "items": {
+                                "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "API version of the referent.",
+                                        "type": "string"
+                                    },
+                                    "blockOwnerDeletion": {
+                                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                        "type": "boolean"
+                                    },
+                                    "controller": {
+                                        "description": "If true, this reference points to the managing controller.",
+                                        "type": "boolean"
+                                    },
+                                    "kind": {
+                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                        "type": "string"
+                                    },
+                                    "uid": {
+                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "apiVersion",
+                                    "kind",
+                                    "name",
+                                    "uid"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "providerID": {
+                    "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                    "type": "string"
+                },
+                "providerSpec": {
+                    "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+                    "properties": {
+                        "value": {
+                            "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+                            "type": "object",
+                            "x-kubernetes-preserve-unknown-fields": true
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "taints": {
+                    "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+                    "items": {
+                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                        "properties": {
+                            "effect": {
+                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                "type": "string"
+                            },
+                            "key": {
+                                "description": "Required. The taint key to be applied to a node.",
+                                "type": "string"
+                            },
+                            "timeAdded": {
+                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "The taint value corresponding to the taint key.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "effect",
+                            "key"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "MachineStatus defines the observed state of Machine",
+            "properties": {
+                "addresses": {
+                    "description": "Addresses is a list of addresses assigned to the machine. Queried from cloud provider, if available.",
+                    "items": {
+                        "description": "NodeAddress contains information for the node's address.",
+                        "properties": {
+                            "address": {
+                                "description": "The node address.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Node address type, one of Hostname, ExternalIP or InternalIP.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "address",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "conditions": {
+                    "description": "Conditions defines the current state of the Machine",
+                    "items": {
+                        "description": "Condition defines an observation of a Machine API resource operational state.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "severity": {
+                                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "errorMessage": {
+                    "description": "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+                    "type": "string"
+                },
+                "errorReason": {
+                    "description": "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.",
+                    "type": "string"
+                },
+                "lastOperation": {
+                    "description": "LastOperation describes the last-operation performed by the machine-controller. This API should be useful as a history in terms of the latest operation performed on the specific machine. It should also convey the state of the latest-operation for example if it is still on-going, failed or completed successfully.",
+                    "properties": {
+                        "description": {
+                            "description": "Description is the human-readable description of the last operation.",
+                            "type": "string"
+                        },
+                        "lastUpdated": {
+                            "description": "LastUpdated is the timestamp at which LastOperation API was last-updated.",
+                            "format": "date-time",
+                            "type": "string"
+                        },
+                        "state": {
+                            "description": "State is the current status of the last performed operation. E.g. Processing, Failed, Successful etc",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "Type is the type of operation which was last performed. E.g. Create, Delete, Update etc",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "lastUpdated": {
+                    "description": "LastUpdated identifies when this status was last observed.",
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "nodeRef": {
+                    "description": "NodeRef will point to the corresponding Node if it exists.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                },
+                "phase": {
+                    "description": "Phase represents the current phase of machine actuation. One of: Failed, Provisioning, Provisioned, Running, Deleting",
+                    "type": "string"
+                },
+                "providerStatus": {
+                    "description": "ProviderStatus details a Provider-specific status. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field.",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/machineconfig_machineconfiguration.openshift.io_v1.json
+++ b/openshift/v4.14-strict/machineconfig_machineconfiguration.openshift.io_v1.json
@@ -1,0 +1,401 @@
+{
+  "description": "MachineConfig defines the configuration for a machine",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineConfigSpec is the spec for MachineConfig",
+      "type": "object",
+      "properties": {
+        "baseOSExtensionsContainerImage": {
+          "description": "baseOSExtensionsContainerImage specifies the remote location that will be used to fetch the extensions container matching a new-format OS image",
+          "type": "string"
+        },
+        "config": {
+          "description": "Config is a Ignition Config object.",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true,
+          "required": [
+            "ignition"
+          ],
+          "properties": {
+            "ignition": {
+              "description": "Ignition section contains metadata about the configuration itself. We only permit a subsection of ignition fields for MachineConfigs.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+              "properties": {
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "append": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string"
+                          },
+                          "verification": {
+                            "type": "object",
+                            "properties": {
+                              "hash": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "replace": {
+                      "type": "object",
+                      "properties": {
+                        "source": {
+                          "type": "string"
+                        },
+                        "verification": {
+                          "type": "object",
+                          "properties": {
+                            "hash": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "security": {
+                  "type": "object",
+                  "properties": {
+                    "tls": {
+                      "type": "object",
+                      "properties": {
+                        "certificateAuthorities": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string"
+                              },
+                              "verification": {
+                                "type": "object",
+                                "properties": {
+                                  "hash": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "timeouts": {
+                  "type": "object",
+                  "properties": {
+                    "httpResponseHeaders": {
+                      "type": "integer"
+                    },
+                    "httpTotal": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "version": {
+                  "description": "Version string is the semantic version number of the spec",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "passwd": {
+              "type": "object",
+              "properties": {
+                "users": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of user. Must be \\\"core\\\" user.",
+                        "type": "string"
+                      },
+                      "sshAuthorizedKeys": {
+                        "description": "Public keys to be assigned to user core.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "passwordHash": {
+                        "description": "Password hash to set for the core user.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "storage": {
+              "description": "Storage describes the desired state of the system's storage devices.",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true,
+              "properties": {
+                "directories": {
+                  "description": "Directories is the list of directories to be created",
+                  "type": "array",
+                  "items": {
+                    "description": "Items is list of directories to be written",
+                    "type": "object",
+                    "properties": {
+                      "filesystem": {
+                        "description": "Filesystem is the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier.",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group object specifies group of the owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Mode is the file's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0644 -> 420)",
+                        "type": "integer"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite specifies whether to delete preexisting nodes at the path",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Path is the absolute path to the file",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User object specifies the file's owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "files": {
+                  "description": "Files is the list of files to be created/modified",
+                  "type": "array",
+                  "items": {
+                    "description": "Items is list of files to be written",
+                    "type": "object",
+                    "x-kubernetes-preserve-unknown-fields": true,
+                    "properties": {
+                      "contents": {
+                        "description": "Contents specifies options related to the contents of the file",
+                        "type": "object",
+                        "properties": {
+                          "compression": {
+                            "description": "The type of compression used on the contents (null or gzip). Compression cannot be used with S3.",
+                            "type": "string"
+                          },
+                          "source": {
+                            "description": "Source is the URL of the file contents. Supported schemes are http, https, tftp, s3, and data. When using http, it is advisable to use the verification option to ensure the contents haven't been modified.",
+                            "type": "string"
+                          },
+                          "verification": {
+                            "description": "Verification specifies options related to the verification of the file contents",
+                            "type": "object",
+                            "properties": {
+                              "hash": {
+                                "description": "Hash is the hash of the config, in the form <type>-<value> where type is sha512",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "filesystem": {
+                        "description": "Filesystem is the internal identifier of the filesystem in which to write the file. This matches the last filesystem with the given identifier",
+                        "type": "string"
+                      },
+                      "group": {
+                        "description": "Group object specifies group of the owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID specifies group ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the group name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "mode": {
+                        "description": "Mode specifies the file's permission mode. Note that the mode must be properly specified as a decimal value (i.e. 0644 -> 420)",
+                        "type": "integer"
+                      },
+                      "overwrite": {
+                        "description": "Overwrite specifies whether to delete preexisting nodes at the path",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Path is the absolute path to the file",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "User object specifies the file's owner",
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "description": "ID is the user ID of the owner",
+                            "type": "integer"
+                          },
+                          "name": {
+                            "description": "Name is the user name of the owner",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "systemd": {
+              "description": "systemd describes the desired state of the systemd units",
+              "type": "object",
+              "properties": {
+                "units": {
+                  "description": "Units is a list of units to be configured",
+                  "type": "array",
+                  "items": {
+                    "description": "Items describes unit configuration",
+                    "type": "object",
+                    "properties": {
+                      "contents": {
+                        "description": "Contents is the contents of the unit",
+                        "type": "string"
+                      },
+                      "dropins": {
+                        "description": "Dropins is the list of drop-ins for the unit",
+                        "type": "array",
+                        "items": {
+                          "description": "Items describes unit dropin",
+                          "type": "object",
+                          "properties": {
+                            "contents": {
+                              "description": "Contents is the contents of the drop-in",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the drop-in. This must be suffixed with '.conf'",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "enabled": {
+                        "description": "Enabled describes whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section",
+                        "type": "boolean"
+                      },
+                      "mask": {
+                        "description": "Mask describes whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null\"",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "Name is the name of the unit. This must be suffixed with a valid unit type (e.g. 'thing.service')",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "extensions": {
+          "description": "List of additional features that can be enabled on host",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true
+        },
+        "fips": {
+          "description": "FIPS controls FIPS mode",
+          "type": "boolean"
+        },
+        "kernelArguments": {
+          "description": "KernelArguments contains a list of kernel arguments to be added",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "nullable": true
+        },
+        "kernelType": {
+          "description": "Contains which kernel we want to be running like default (traditional), realtime",
+          "type": "string"
+        },
+        "osImageURL": {
+          "description": "OSImageURL specifies the remote location that will be used to fetch the OS",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.14-strict/machineconfigpool_machineconfiguration.openshift.io_v1.json
+++ b/openshift/v4.14-strict/machineconfigpool_machineconfiguration.openshift.io_v1.json
@@ -1,0 +1,365 @@
+{
+  "description": "MachineConfigPool describes a pool of MachineConfigs.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "MachineConfigPoolSpec is the spec for MachineConfigPool resource.",
+      "type": "object",
+      "properties": {
+        "configuration": {
+          "description": "The targeted MachineConfig object for the machine config pool.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "source": {
+              "description": "source is the list of MachineConfig objects that were used to generate the single MachineConfig object specified in `content`.",
+              "type": "array",
+              "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "machineConfigSelector": {
+          "description": "machineConfigSelector specifies a label selector for MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ on how label and selectors work.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "maxUnavailable": {
+          "description": "maxUnavailable defines either an integer number or percentage of nodes in the corresponding pool that can go Unavailable during an update. This includes nodes Unavailable for any reason, including user initiated cordons, failing nodes, etc. The default value is 1. A value larger than 1 will mean multiple nodes going unavailable during the update, which may affect your workload stress on the remaining nodes. You cannot set this value to 0 to stop updates (it will default back to 1); to stop updates, use the 'paused' property instead. Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum guards, even if maxUnavailable is greater than one.",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        },
+        "nodeSelector": {
+          "description": "nodeSelector specifies a label selector for Machines",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "paused": {
+          "description": "paused specifies whether or not changes to this machine config pool should be stopped. This includes generating new desiredMachineConfig and update of machines.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "MachineConfigPoolStatus is the status for MachineConfigPool resource.",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the latest available observations of current state.",
+          "type": "array",
+          "items": {
+            "description": "MachineConfigPoolCondition contains condition information for an MachineConfigPool.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the timestamp corresponding to the last status change of this condition.",
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              },
+              "message": {
+                "description": "message is a human readable description of the details of the last transition, complementing reason.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is a brief machine readable explanation for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of ('True', 'False', 'Unknown').",
+                "type": "string"
+              },
+              "type": {
+                "description": "type of the condition, currently ('Done', 'Updating', 'Failed').",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "configuration": {
+          "description": "configuration represents the MachineConfig object that last successfully rolled out to all nodes.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "source": {
+              "description": "source is the list of MachineConfig objects that were used to generate the single MachineConfig object specified in `content`.",
+              "type": "array",
+              "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "uid": {
+              "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "degradedMachineCount": {
+          "description": "degradedMachineCount represents the total number of machines marked degraded (or unreconcilable). A node is marked degraded if applying a configuration failed..",
+          "type": "integer",
+          "format": "int32"
+        },
+        "machineCount": {
+          "description": "machineCount represents the total number of machines in the machine config pool.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "observedGeneration": {
+          "description": "observedGeneration represents the generation observed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "readyMachineCount": {
+          "description": "readyMachineCount represents the total number of ready machines targeted by the pool.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "unavailableMachineCount": {
+          "description": "unavailableMachineCount represents the total number of unavailable (non-ready) machines targeted by the pool. A node is marked unavailable if it is in updating state or NodeReady condition is false.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "updatedMachineCount": {
+          "description": "updatedMachineCount represents the total number of machines targeted by the pool that have the CurrentMachineConfig as their config.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "certExpirys": {
+          "description": "The certificate expiry dates from the controller config",
+          "type": "array",
+          "items": {
+            "description": "the certExpiry contains specific information about a certificate stored in the controllerConfig.",
+            "type": "object",
+            "properties": {
+              "bundle": {
+                "description": "the bundle for which the expiry applies",
+                "type": "string"
+              },
+              "subject": {
+                "description": "the subject of the cert",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/openshift/v4.14-strict/machinehealthcheck_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/machinehealthcheck_machine.openshift.io_v1beta1.json
@@ -1,0 +1,211 @@
+{
+    "description": "MachineHealthCheck is the Schema for the machinehealthchecks API Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Specification of machine health check policy",
+            "properties": {
+                "maxUnhealthy": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "default": "100%",
+                    "description": "Any farther remediation is only allowed if at most \"MaxUnhealthy\" machines selected by \"selector\" are not healthy. Expects either a postive integer value or a percentage value. Percentage values must be positive whole numbers and are capped at 100%. Both 0 and 0% are valid and will block all remediation.",
+                    "pattern": "^((100|[0-9]{1,2})%|[0-9]+)$",
+                    "x-kubernetes-int-or-string": true
+                },
+                "nodeStartupTimeout": {
+                    "default": "10m",
+                    "description": "Machines older than this duration without a node will be considered to have failed and will be remediated. To prevent Machines without Nodes from being removed, disable startup checks by setting this value explicitly to \"0\". Expects an unsigned duration string of decimal numbers each with optional fraction and a unit suffix, eg \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
+                    "pattern": "^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+                    "type": "string"
+                },
+                "remediationTemplate": {
+                    "description": "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Machine API Operator.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "API version of the referent.",
+                            "type": "string"
+                        },
+                        "fieldPath": {
+                            "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                            "type": "string"
+                        },
+                        "resourceVersion": {
+                            "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                            "type": "string"
+                        },
+                        "uid": {
+                            "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic",
+                    "additionalProperties": false
+                },
+                "selector": {
+                    "description": "Label selector to match machines whose health will be exercised. Note: An empty selector will match all machines.",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "unhealthyConditions": {
+                    "description": "UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.",
+                    "items": {
+                        "description": "UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.",
+                        "properties": {
+                            "status": {
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "timeout": {
+                                "description": "Expects an unsigned duration string of decimal numbers each with optional fraction and a unit suffix, eg \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".",
+                                "pattern": "^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$",
+                                "type": "string"
+                            },
+                            "type": {
+                                "minLength": 1,
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Most recently observed status of MachineHealthCheck resource",
+            "properties": {
+                "conditions": {
+                    "description": "Conditions defines the current state of the MachineHealthCheck",
+                    "items": {
+                        "description": "Condition defines an observation of a Machine API resource operational state.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "A human readable message indicating details about the transition. This field may be empty.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "severity": {
+                                "description": "Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "currentHealthy": {
+                    "description": "total number of machines counted by this machine health check",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "expectedMachines": {
+                    "description": "total number of machines counted by this machine health check",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "remediationsAllowed": {
+                    "description": "RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer",
+                    "maximum": 2147483647
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/machineset_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/machineset_machine.openshift.io_v1beta1.json
@@ -1,0 +1,424 @@
+{
+    "description": "MachineSet ensures that a specified number of machines replicas are running at any given time. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "MachineSetSpec defines the desired state of MachineSet",
+            "properties": {
+                "deletePolicy": {
+                    "description": "DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to \"Random\".  Valid values are \"Random, \"Newest\", \"Oldest\"",
+                    "enum": [
+                        "Random",
+                        "Newest",
+                        "Oldest"
+                    ],
+                    "type": "string"
+                },
+                "minReadySeconds": {
+                    "description": "MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "replicas": {
+                    "default": 1,
+                    "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "selector": {
+                    "description": "Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+                    "properties": {
+                        "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                "properties": {
+                                    "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                    },
+                                    "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                    },
+                                    "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "operator"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        },
+                        "matchLabels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "template": {
+                    "description": "Template is the object that describes the machine that will be created if insufficient replicas are detected.",
+                    "properties": {
+                        "metadata": {
+                            "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "properties": {
+                                "annotations": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                                    "type": "object"
+                                },
+                                "generateName": {
+                                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                    "type": "string"
+                                },
+                                "labels": {
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    },
+                                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                                    "type": "object"
+                                },
+                                "name": {
+                                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                    "type": "string"
+                                },
+                                "namespace": {
+                                    "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                                    "type": "string"
+                                },
+                                "ownerReferences": {
+                                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                    "items": {
+                                        "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                        "properties": {
+                                            "apiVersion": {
+                                                "description": "API version of the referent.",
+                                                "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                                "type": "boolean"
+                                            },
+                                            "controller": {
+                                                "description": "If true, this reference points to the managing controller.",
+                                                "type": "boolean"
+                                            },
+                                            "kind": {
+                                                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                                "type": "string"
+                                            },
+                                            "uid": {
+                                                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "apiVersion",
+                                            "kind",
+                                            "name",
+                                            "uid"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "spec": {
+                            "description": "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                            "properties": {
+                                "lifecycleHooks": {
+                                    "description": "LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.",
+                                    "properties": {
+                                        "preDrain": {
+                                            "description": "PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.",
+                                            "items": {
+                                                "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                                        "maxLength": 256,
+                                                        "minLength": 3,
+                                                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                                        "type": "string"
+                                                    },
+                                                    "owner": {
+                                                        "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                                        "maxLength": 512,
+                                                        "minLength": 3,
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "owner"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-map-keys": [
+                                                "name"
+                                            ],
+                                            "x-kubernetes-list-type": "map"
+                                        },
+                                        "preTerminate": {
+                                            "description": "PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.",
+                                            "items": {
+                                                "description": "LifecycleHook represents a single instance of a lifecycle hook",
+                                                "properties": {
+                                                    "name": {
+                                                        "description": "Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.",
+                                                        "maxLength": 256,
+                                                        "minLength": 3,
+                                                        "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                                                        "type": "string"
+                                                    },
+                                                    "owner": {
+                                                        "description": "Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.",
+                                                        "maxLength": 512,
+                                                        "minLength": 3,
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "owner"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-map-keys": [
+                                                "name"
+                                            ],
+                                            "x-kubernetes-list-type": "map"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "metadata": {
+                                    "description": "ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.",
+                                    "properties": {
+                                        "annotations": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                                            "type": "object"
+                                        },
+                                        "generateName": {
+                                            "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                            "type": "string"
+                                        },
+                                        "labels": {
+                                            "additionalProperties": {
+                                                "type": "string"
+                                            },
+                                            "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                                            "type": "object"
+                                        },
+                                        "name": {
+                                            "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                                            "type": "string"
+                                        },
+                                        "ownerReferences": {
+                                            "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                            "items": {
+                                                "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                                "properties": {
+                                                    "apiVersion": {
+                                                        "description": "API version of the referent.",
+                                                        "type": "string"
+                                                    },
+                                                    "blockOwnerDeletion": {
+                                                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "controller": {
+                                                        "description": "If true, this reference points to the managing controller.",
+                                                        "type": "boolean"
+                                                    },
+                                                    "kind": {
+                                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                                        "type": "string"
+                                                    },
+                                                    "uid": {
+                                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "apiVersion",
+                                                    "kind",
+                                                    "name",
+                                                    "uid"
+                                                ],
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "providerID": {
+                                    "description": "ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.",
+                                    "type": "string"
+                                },
+                                "providerSpec": {
+                                    "description": "ProviderSpec details Provider-specific configuration to use during node creation.",
+                                    "properties": {
+                                        "value": {
+                                            "description": "Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.",
+                                            "type": "object",
+                                            "x-kubernetes-preserve-unknown-fields": true
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "taints": {
+                                    "description": "The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints",
+                                    "items": {
+                                        "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+                                        "properties": {
+                                            "effect": {
+                                                "description": "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+                                                "type": "string"
+                                            },
+                                            "key": {
+                                                "description": "Required. The taint key to be applied to a node.",
+                                                "type": "string"
+                                            },
+                                            "timeAdded": {
+                                                "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
+                                                "format": "date-time",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "The taint value corresponding to the taint key.",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "effect",
+                                            "key"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "MachineSetStatus defines the observed state of MachineSet",
+            "properties": {
+                "availableReplicas": {
+                    "description": "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "errorMessage": {
+                    "type": "string"
+                },
+                "errorReason": {
+                    "description": "In the event that there is a terminal problem reconciling the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason will be populated with a succinct value suitable for machine interpretation, while ErrorMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output.",
+                    "type": "string"
+                },
+                "fullyLabeledReplicas": {
+                    "description": "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "observedGeneration": {
+                    "description": "ObservedGeneration reflects the generation of the most recently observed MachineSet.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "replicas": {
+                    "description": "Replicas is the most recently observed number of replicas.",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/myoperatorresource_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/myoperatorresource_operator.openshift.io_v1.json
@@ -1,0 +1,162 @@
+{
+    "description": "MyOperatorResource is an example operator configuration type \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/netnamespace_network.openshift.io_v1.json
+++ b/openshift/v4.14-strict/netnamespace_network.openshift.io_v1.json
@@ -1,0 +1,44 @@
+{
+    "description": "NetNamespace describes a single isolated network. When using the redhat/openshift-ovs-multitenant plugin, every Namespace will have a corresponding NetNamespace object with the same name. (When using redhat/openshift-ovs-subnet, NetNamespaces are not used.) \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "egressIPs": {
+            "description": "EgressIPs is a list of reserved IPs that will be used as the source for external traffic coming from pods in this namespace. (If empty, external traffic will be masqueraded to Node IPs.)",
+            "items": {
+                "description": "NetNamespaceEgressIP is a single egress IP out of a list of reserved IPs used as source of external traffic coming from pods in this namespace",
+                "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$",
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "netid": {
+            "description": "NetID is the network identifier of the network namespace assigned to each overlay network packet. This can be manipulated with the \"oc adm pod-network\" commands.",
+            "format": "int32",
+            "maximum": 16777215,
+            "minimum": 0,
+            "type": "integer"
+        },
+        "netname": {
+            "description": "NetName is the name of the network namespace. (This is the same as the object's name, but both fields must be set.)",
+            "pattern": "^[a-z0-9.-]+$",
+            "type": "string"
+        }
+    },
+    "required": [
+        "netid",
+        "netname"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/network_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/network_config.openshift.io_v1.json
@@ -1,0 +1,210 @@
+{
+    "description": "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.",
+            "properties": {
+                "clusterNetwork": {
+                    "description": "IP address pool to use for pod IPs. This field is immutable after installation.",
+                    "items": {
+                        "description": "ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.",
+                        "properties": {
+                            "cidr": {
+                                "description": "The complete block for pod IPs.",
+                                "type": "string"
+                            },
+                            "hostPrefix": {
+                                "description": "The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.",
+                                "format": "int32",
+                                "minimum": 0,
+                                "type": "integer",
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "externalIP": {
+                    "description": "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
+                    "properties": {
+                        "autoAssignCIDRs": {
+                            "description": "autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called \"IngressIPs\". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "policy": {
+                            "description": "policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.",
+                            "properties": {
+                                "allowedCIDRs": {
+                                    "description": "allowedCIDRs is the list of allowed CIDRs.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "rejectedCIDRs": {
+                                    "description": "rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "networkType": {
+                    "description": "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
+                    "type": "string"
+                },
+                "serviceNetwork": {
+                    "description": "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "serviceNodePortRange": {
+                    "description": "The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.",
+                    "pattern": "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "clusterNetwork": {
+                    "description": "IP address pool to use for pod IPs.",
+                    "items": {
+                        "description": "ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.",
+                        "properties": {
+                            "cidr": {
+                                "description": "The complete block for pod IPs.",
+                                "type": "string"
+                            },
+                            "hostPrefix": {
+                                "description": "The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.",
+                                "format": "int32",
+                                "minimum": 0,
+                                "type": "integer",
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "clusterNetworkMTU": {
+                    "description": "ClusterNetworkMTU is the MTU for inter-pod networking.",
+                    "type": "integer"
+                },
+                "migration": {
+                    "description": "Migration contains the cluster network migration configuration.",
+                    "properties": {
+                        "mtu": {
+                            "description": "MTU contains the MTU migration configuration.",
+                            "properties": {
+                                "machine": {
+                                    "description": "Machine contains MTU migration configuration for the machine's uplink.",
+                                    "properties": {
+                                        "from": {
+                                            "description": "From is the MTU to migrate from.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "to": {
+                                            "description": "To is the MTU to migrate to.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "network": {
+                                    "description": "Network contains MTU migration configuration for the default network.",
+                                    "properties": {
+                                        "from": {
+                                            "description": "From is the MTU to migrate from.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "to": {
+                                            "description": "To is the MTU to migrate to.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "networkType": {
+                            "description": "NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes",
+                            "enum": [
+                                "OpenShiftSDN",
+                                "OVNKubernetes"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "networkType": {
+                    "description": "NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).",
+                    "type": "string"
+                },
+                "serviceNetwork": {
+                    "description": "IP address pool for services. Currently, we only support a single entry here.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/network_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/network_operator.openshift.io_v1.json
@@ -1,0 +1,833 @@
+{
+    "description": "Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "NetworkSpec is the top-level network configuration object.",
+            "properties": {
+                "additionalNetworks": {
+                    "description": "additionalNetworks is a list of extra networks to make available to pods when multiple networks are enabled.",
+                    "items": {
+                        "description": "AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one \"Config\" that matches the type.",
+                        "properties": {
+                            "name": {
+                                "description": "name is the name of the network. This will be populated in the resulting CRD This must be unique.",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.",
+                                "type": "string"
+                            },
+                            "rawCNIConfig": {
+                                "description": "rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD",
+                                "type": "string"
+                            },
+                            "simpleMacvlanConfig": {
+                                "description": "SimpleMacvlanConfig configures the macvlan interface in case of type:NetworkTypeSimpleMacvlan",
+                                "properties": {
+                                    "ipamConfig": {
+                                        "description": "IPAMConfig configures IPAM module will be used for IP Address Management (IPAM).",
+                                        "properties": {
+                                            "staticIPAMConfig": {
+                                                "description": "StaticIPAMConfig configures the static IP address in case of type:IPAMTypeStatic",
+                                                "properties": {
+                                                    "addresses": {
+                                                        "description": "Addresses configures IP address for the interface",
+                                                        "items": {
+                                                            "description": "StaticIPAMAddresses provides IP address and Gateway for static IPAM addresses",
+                                                            "properties": {
+                                                                "address": {
+                                                                    "description": "Address is the IP address in CIDR format",
+                                                                    "type": "string"
+                                                                },
+                                                                "gateway": {
+                                                                    "description": "Gateway is IP inside of subnet to designate as the gateway",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "dns": {
+                                                        "description": "DNS configures DNS for the interface",
+                                                        "properties": {
+                                                            "domain": {
+                                                                "description": "Domain configures the domainname the local domain used for short hostname lookups",
+                                                                "type": "string"
+                                                            },
+                                                            "nameservers": {
+                                                                "description": "Nameservers points DNS servers for IP lookup",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            },
+                                                            "search": {
+                                                                "description": "Search configures priority ordered search domains for short hostname lookups",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                            }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "routes": {
+                                                        "description": "Routes configures IP routes for the interface",
+                                                        "items": {
+                                                            "description": "StaticIPAMRoutes provides Destination/Gateway pairs for static IPAM routes",
+                                                            "properties": {
+                                                                "destination": {
+                                                                    "description": "Destination points the IP route destination",
+                                                                    "type": "string"
+                                                                },
+                                                                "gateway": {
+                                                                    "description": "Gateway is the route's next-hop IP address If unset, a default gateway is assumed (as determined by the CNI plugin).",
+                                                                    "type": "string"
+                                                                }
+                                                            },
+                                                            "type": "object",
+                                                            "additionalProperties": false
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": {
+                                                "description": "Type is the type of IPAM module will be used for IP Address Management(IPAM). The supported values are IPAMTypeDHCP, IPAMTypeStatic",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "master": {
+                                        "description": "master is the host interface to create the macvlan interface from. If not specified, it will be default route interface",
+                                        "type": "string"
+                                    },
+                                    "mode": {
+                                        "description": "mode is the macvlan mode: bridge, private, vepa, passthru. The default is bridge",
+                                        "type": "string"
+                                    },
+                                    "mtu": {
+                                        "description": "mtu is the mtu to use for the macvlan interface. if unset, host's kernel will select the value.",
+                                        "format": "int32",
+                                        "minimum": 0,
+                                        "type": "integer",
+                                        "maximum": 2147483647
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": {
+                                "description": "type is the type of network The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "clusterNetwork": {
+                    "description": "clusterNetwork is the IP address pool to use for pod IPs. Some network providers, e.g. OpenShift SDN, support multiple ClusterNetworks. Others only support one. This is equivalent to the cluster-cidr.",
+                    "items": {
+                        "description": "ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks",
+                        "properties": {
+                            "cidr": {
+                                "type": "string"
+                            },
+                            "hostPrefix": {
+                                "format": "int32",
+                                "minimum": 0,
+                                "type": "integer",
+                                "maximum": 2147483647
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "defaultNetwork": {
+                    "description": "defaultNetwork is the \"default\" network that all pods will receive",
+                    "properties": {
+                        "kuryrConfig": {
+                            "description": "KuryrConfig configures the kuryr plugin",
+                            "properties": {
+                                "controllerProbesPort": {
+                                    "description": "The port kuryr-controller will listen for readiness and liveness requests.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "daemonProbesPort": {
+                                    "description": "The port kuryr-daemon will listen for readiness and liveness requests.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "enablePortPoolsPrepopulation": {
+                                    "description": "enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. It creates a number of ports when the first pod that is configured to use the dedicated network for pods is created in a namespace, and keeps them ready to be attached to pods. Port prepopulation is disabled by default.",
+                                    "type": "boolean"
+                                },
+                                "mtu": {
+                                    "description": "mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has. This also affects the services network created by cluster-network-operator.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "openStackServiceNetwork": {
+                                    "description": "openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.",
+                                    "type": "string"
+                                },
+                                "poolBatchPorts": {
+                                    "description": "poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.",
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "poolMaxPorts": {
+                                    "description": "poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.",
+                                    "minimum": 0,
+                                    "type": "integer"
+                                },
+                                "poolMinPorts": {
+                                    "description": "poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.",
+                                    "minimum": 1,
+                                    "type": "integer"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "openshiftSDNConfig": {
+                            "description": "openShiftSDNConfig configures the openshift-sdn plugin",
+                            "properties": {
+                                "enableUnidling": {
+                                    "description": "enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.",
+                                    "type": "boolean"
+                                },
+                                "mode": {
+                                    "description": "mode is one of \"Multitenant\", \"Subnet\", or \"NetworkPolicy\"",
+                                    "type": "string"
+                                },
+                                "mtu": {
+                                    "description": "mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "useExternalOpenvswitch": {
+                                    "description": "useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6",
+                                    "type": "boolean"
+                                },
+                                "vxlanPort": {
+                                    "description": "vxlanPort is the port to use for all vxlan packets. The default is 4789.",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ovnKubernetesConfig": {
+                            "description": "ovnKubernetesConfig configures the ovn-kubernetes plugin.",
+                            "properties": {
+                                "egressIPConfig": {
+                                    "description": "egressIPConfig holds the configuration for EgressIP options.",
+                                    "properties": {
+                                        "reachabilityTotalTimeoutSeconds": {
+                                            "description": "reachabilityTotalTimeout configures the EgressIP node reachability check total timeout in seconds. If the EgressIP node cannot be reached within this timeout, the node is declared down. Setting a large value may cause the EgressIP feature to react slowly to node changes. In particular, it may react slowly for EgressIP nodes that really have a genuine problem and are unreachable. When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is 1 second. A value of 0 disables the EgressIP node's reachability check.",
+                                            "format": "int32",
+                                            "maximum": 60,
+                                            "minimum": 0,
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "gatewayConfig": {
+                                    "description": "gatewayConfig holds the configuration for node gateway options.",
+                                    "properties": {
+                                        "ipForwarding": {
+                                            "description": "IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to \"Global\". The supported values are \"Restricted\" and \"Global\".",
+                                            "type": "string"
+                                        },
+                                        "ipv4": {
+                                            "description": "ipv4 allows users to configure IP settings for IPv4 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv4 for details of default values.",
+                                            "properties": {
+                                                "internalMasqueradeSubnet": {
+                                                    "description": "internalMasqueradeSubnet contains the masquerade addresses in IPV4 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /29). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is 169.254.169.0/29 The value must be in proper IPV4 CIDR format",
+                                                    "maxLength": 18,
+                                                    "type": "string",
+                                                    "x-kubernetes-validations": [
+                                                        {
+                                                            "message": "CIDR format must contain exactly one '/'",
+                                                            "rule": "self.indexOf('/') == self.lastIndexOf('/')"
+                                                        },
+                                                        {
+                                                            "message": "subnet must be in the range /0 to /29 inclusive",
+                                                            "rule": "[int(self.split('/')[1])].all(x, x <= 29 && x >= 0)"
+                                                        },
+                                                        {
+                                                            "message": "a valid IPv4 address must contain 4 octets",
+                                                            "rule": "self.split('/')[0].split('.').size() == 4"
+                                                        },
+                                                        {
+                                                            "message": "first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255",
+                                                            "rule": "[self.findAll('[0-9]+')[0]].all(x, x != '0' && int(x) <= 255 && !x.startsWith('0'))"
+                                                        },
+                                                        {
+                                                            "message": "IP address octets must not contain leading zeros, and must be less or equal to 255",
+                                                            "rule": "[self.findAll('[0-9]+')[1], self.findAll('[0-9]+')[2], self.findAll('[0-9]+')[3]].all(x, int(x) <= 255 && (x == '0' || !x.startsWith('0')))"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "ipv6": {
+                                            "description": "ipv6 allows users to configure IP settings for IPv6 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv6 for details of default values.",
+                                            "properties": {
+                                                "internalMasqueradeSubnet": {
+                                                    "description": "internalMasqueradeSubnet contains the masquerade addresses in IPV6 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /125). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is fd69::/125 Note that IPV6 dual addresses are not permitted",
+                                                    "type": "string",
+                                                    "x-kubernetes-validations": [
+                                                        {
+                                                            "message": "CIDR format must contain exactly one '/'",
+                                                            "rule": "self.indexOf('/') == self.lastIndexOf('/')"
+                                                        },
+                                                        {
+                                                            "message": "subnet must be in the range /0 to /125 inclusive",
+                                                            "rule": "self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)"
+                                                        },
+                                                        {
+                                                            "message": "IPv6 addresses must contain at most one '::' and may only be shortened once",
+                                                            "rule": "self.indexOf('::') == self.lastIndexOf('::')"
+                                                        },
+                                                        {
+                                                            "message": "a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments",
+                                                            "rule": "self.contains('::') ? self.split('/')[0].split(':').size() <= 8 : self.split('/')[0].split(':').size() == 8"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 1",
+                                                            "rule": "self.split('/')[0].split(':').size() >=1 ? [self.split('/')[0].split(':', 8)[0]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2",
+                                                            "rule": "self.split('/')[0].split(':').size() >=2 ? [self.split('/')[0].split(':', 8)[1]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 3",
+                                                            "rule": "self.split('/')[0].split(':').size() >=3 ? [self.split('/')[0].split(':', 8)[2]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 4",
+                                                            "rule": "self.split('/')[0].split(':').size() >=4 ? [self.split('/')[0].split(':', 8)[3]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 5",
+                                                            "rule": "self.split('/')[0].split(':').size() >=5 ? [self.split('/')[0].split(':', 8)[4]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 6",
+                                                            "rule": "self.split('/')[0].split(':').size() >=6 ? [self.split('/')[0].split(':', 8)[5]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 7",
+                                                            "rule": "self.split('/')[0].split(':').size() >=7 ? [self.split('/')[0].split(':', 8)[6]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 8",
+                                                            "rule": "self.split('/')[0].split(':').size() >=8 ? [self.split('/')[0].split(':', 8)[7]].all(x, x == '' || x.matches('[0-9A-Fa-f]{1,4}')) : true"
+                                                        },
+                                                        {
+                                                            "message": "IPv6 dual addresses are not permitted, value should not contain `.` characters",
+                                                            "rule": "!self.contains('.')"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "routingViaHost": {
+                                            "default": false,
+                                            "description": "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
+                                            "type": "boolean"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "genevePort": {
+                                    "description": "geneve port is the UDP port to be used by geneve encapulation. Default is 6081",
+                                    "format": "int32",
+                                    "minimum": 1,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "hybridOverlayConfig": {
+                                    "description": "HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.",
+                                    "properties": {
+                                        "hybridClusterNetwork": {
+                                            "description": "HybridClusterNetwork defines a network space given to nodes on an additional overlay network.",
+                                            "items": {
+                                                "description": "ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks",
+                                                "properties": {
+                                                    "cidr": {
+                                                        "type": "string"
+                                                    },
+                                                    "hostPrefix": {
+                                                        "format": "int32",
+                                                        "minimum": 0,
+                                                        "type": "integer",
+                                                        "maximum": 2147483647
+                                                    }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                        },
+                                        "hybridOverlayVXLANPort": {
+                                            "description": "HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789",
+                                            "format": "int32",
+                                            "type": "integer",
+                                            "minimum": -2147483648,
+                                            "maximum": 2147483647
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "ipsecConfig": {
+                                    "description": "ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.",
+                                    "type": "object"
+                                },
+                                "mtu": {
+                                    "description": "mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400",
+                                    "format": "int32",
+                                    "minimum": 0,
+                                    "type": "integer",
+                                    "maximum": 2147483647
+                                },
+                                "policyAuditConfig": {
+                                    "description": "policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.",
+                                    "properties": {
+                                        "destination": {
+                                            "default": "null",
+                                            "description": "destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - \"libc\" -> to use the libc syslog() function of the host node's journdald process - \"udp:host:port\" -> for sending syslog over UDP - \"unix:file\" -> for using the UNIX domain socket directly - \"null\" -> to discard all messages logged to syslog The default is \"null\"",
+                                            "type": "string"
+                                        },
+                                        "maxFileSize": {
+                                            "default": 50,
+                                            "description": "maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB",
+                                            "format": "int32",
+                                            "minimum": 1,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "maxLogFiles": {
+                                            "default": 5,
+                                            "description": "maxLogFiles specifies the maximum number of ACL_audit log files that can be present.",
+                                            "format": "int32",
+                                            "minimum": 1,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "rateLimit": {
+                                            "default": 20,
+                                            "description": "rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.",
+                                            "format": "int32",
+                                            "minimum": 1,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "syslogFacility": {
+                                            "default": "local0",
+                                            "description": "syslogFacility the RFC5424 facility for generated messages, e.g. \"kern\". Default is \"local0\"",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "v4InternalSubnet": {
+                                    "description": "v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16",
+                                    "type": "string"
+                                },
+                                "v6InternalSubnet": {
+                                    "description": "v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": {
+                            "description": "type is the type of network All NetworkTypes are supported except for NetworkTypeRaw",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "deployKubeProxy": {
+                    "description": "deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.",
+                    "type": "boolean"
+                },
+                "disableMultiNetwork": {
+                    "description": "disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.",
+                    "type": "boolean"
+                },
+                "disableNetworkDiagnostics": {
+                    "default": false,
+                    "description": "disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck CRs from a test pod to every node, apiserver and LB should be disabled or not. If unset, this property defaults to 'false' and network diagnostics is enabled. Setting this to 'true' would reduce the additional load of the pods performing the checks.",
+                    "type": "boolean"
+                },
+                "exportNetworkFlows": {
+                    "description": "exportNetworkFlows enables and configures the export of network flow metadata from the pod network by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin. If unset, flows will not be exported to any collector.",
+                    "properties": {
+                        "ipfix": {
+                            "description": "ipfix defines IPFIX configuration.",
+                            "properties": {
+                                "collectors": {
+                                    "description": "ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items",
+                                    "items": {
+                                        "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+                                        "type": "string"
+                                    },
+                                    "maxItems": 10,
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "netFlow": {
+                            "description": "netFlow defines the NetFlow configuration.",
+                            "properties": {
+                                "collectors": {
+                                    "description": "netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items",
+                                    "items": {
+                                        "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+                                        "type": "string"
+                                    },
+                                    "maxItems": 10,
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "sFlow": {
+                            "description": "sFlow defines the SFlow configuration.",
+                            "properties": {
+                                "collectors": {
+                                    "description": "sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items",
+                                    "items": {
+                                        "pattern": "^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$",
+                                        "type": "string"
+                                    },
+                                    "maxItems": 10,
+                                    "minItems": 1,
+                                    "type": "array"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "kubeProxyConfig": {
+                    "description": "kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.",
+                    "properties": {
+                        "bindAddress": {
+                            "description": "The address to \"bind\" on Defaults to 0.0.0.0",
+                            "type": "string"
+                        },
+                        "iptablesSyncPeriod": {
+                            "description": "An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s",
+                            "type": "string"
+                        },
+                        "proxyArguments": {
+                            "additionalProperties": {
+                                "description": "ProxyArgumentList is a list of arguments to pass to the kubeproxy process",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "description": "Any additional arguments to pass to the kubeproxy process",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "migration": {
+                    "description": "migration enables and configures the cluster network migration. The migration procedure allows to change the network type and the MTU.",
+                    "properties": {
+                        "features": {
+                            "description": "features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.",
+                            "properties": {
+                                "egressFirewall": {
+                                    "default": true,
+                                    "description": "egressFirewall specifies whether or not the Egress Firewall configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress Firewall configure is migrated.",
+                                    "type": "boolean"
+                                },
+                                "egressIP": {
+                                    "default": true,
+                                    "description": "egressIP specifies whether or not the Egress IP configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress IP configure is migrated.",
+                                    "type": "boolean"
+                                },
+                                "multicast": {
+                                    "default": true,
+                                    "description": "multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "mtu": {
+                            "description": "mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.",
+                            "properties": {
+                                "machine": {
+                                    "description": "machine contains MTU migration configuration for the machine's uplink. Needs to be migrated along with the default network MTU unless the current uplink MTU already accommodates the default network MTU.",
+                                    "properties": {
+                                        "from": {
+                                            "description": "from is the MTU to migrate from.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "to": {
+                                            "description": "to is the MTU to migrate to.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "network": {
+                                    "description": "network contains information about MTU migration for the default network. Migrations are only allowed to MTU values lower than the machine's uplink MTU by the minimum appropriate offset.",
+                                    "properties": {
+                                        "from": {
+                                            "description": "from is the MTU to migrate from.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        },
+                                        "to": {
+                                            "description": "to is the MTU to migrate to.",
+                                            "format": "int32",
+                                            "minimum": 0,
+                                            "type": "integer",
+                                            "maximum": 2147483647
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "networkType": {
+                            "description": "networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "serviceNetwork": {
+                    "description": "serviceNetwork is the ip address pool to use for Service IPs Currently, all existing network providers only support a single value here, but this is an array to allow for growth.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "useMultiNetworkPolicy": {
+                    "description": "useMultiNetworkPolicy enables a controller which allows for MultiNetworkPolicy objects to be used on additional networks as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy objects, but NetworkPolicy objects only apply to the primary interface. With MultiNetworkPolicy, you can control the traffic that a pod can receive over the secondary interfaces. If unset, this property defaults to 'false' and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is 'true' then the value of this field is ignored.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "NetworkStatus is detailed operator status, which is distilled up to the Network clusteroperator object.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/node_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/node_config.openshift.io_v1.json
@@ -1,0 +1,51 @@
+{
+    "description": "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "cgroupMode": {
+                    "description": "CgroupMode determines the cgroups version on the node",
+                    "enum": [
+                        "v1",
+                        "v2",
+                        ""
+                    ],
+                    "type": "string"
+                },
+                "workerLatencyProfile": {
+                    "description": "WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster",
+                    "enum": [
+                        "Default",
+                        "MediumUpdateAverageReaction",
+                        "LowUpdateSlowReaction"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/notstableconfigtype_example.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/notstableconfigtype_example.openshift.io_v1alpha1.json
@@ -1,0 +1,90 @@
+{
+    "description": "NotStableConfigType is a stable config type that is TechPreviewNoUpgrade only. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the NotStableConfigType.",
+            "properties": {
+                "newField": {
+                    "description": "newField is a field that is tech preview, but because the entire type is gated, there is no marker on the field.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "newField"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the NotStableConfigType.",
+            "properties": {
+                "conditions": {
+                    "description": "Represents the observations of a foo's current state. Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/nutanixmachineproviderconfig_machine.openshift.io_v1.json
+++ b/openshift/v4.14-strict/nutanixmachineproviderconfig_machine.openshift.io_v1.json
@@ -1,0 +1,241 @@
+{
+    "description": "NutanixMachineProviderConfig is the Schema for the nutanixmachineproviderconfigs API Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "bootType": {
+            "description": "bootType indicates the boot type (Legacy, UEFI or SecureBoot) the Machine's VM uses to boot. If this field is empty or omitted, the VM will use the default boot type \"Legacy\" to boot. \"SecureBoot\" depends on \"UEFI\" boot, i.e., enabling \"SecureBoot\" means that \"UEFI\" boot is also enabled.",
+            "enum": [
+                "",
+                "Legacy",
+                "UEFI",
+                "SecureBoot"
+            ],
+            "type": "string"
+        },
+        "categories": {
+            "description": "categories optionally adds one or more prism categories (each with key and value) for the Machine's VM to associate with. All the category key and value pairs specified must already exist in the prism central.",
+            "items": {
+                "description": "NutanixCategory identifies a pair of prism category key and value",
+                "properties": {
+                    "key": {
+                        "description": "key is the prism category key name",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "value": {
+                        "description": "value is the prism category value associated with the key",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "key",
+                    "value"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array",
+            "x-kubernetes-list-map-keys": [
+                "key"
+            ],
+            "x-kubernetes-list-type": "map"
+        },
+        "cluster": {
+            "description": "cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
+            "properties": {
+                "name": {
+                    "description": "name is the resource name in the PC",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the identifier type to use for this resource.",
+                    "enum": [
+                        "uuid",
+                        "name"
+                    ],
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "uuid is the UUID of the resource in the PC.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "credentialsSecret": {
+            "description": "credentialsSecret is a local reference to a secret that contains the credentials data to access Nutanix PC client",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "image": {
+            "description": "image is to identify the rhcos image uploaded to the Prism Central (PC) The image identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
+            "properties": {
+                "name": {
+                    "description": "name is the resource name in the PC",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the identifier type to use for this resource.",
+                    "enum": [
+                        "uuid",
+                        "name"
+                    ],
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "uuid is the UUID of the resource in the PC.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "memorySize": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "memorySize is the memory size (in Quantity format) of the VM The minimum memorySize is 2Gi bytes",
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "project": {
+            "description": "project optionally identifies a Prism project for the Machine's VM to associate with.",
+            "properties": {
+                "name": {
+                    "description": "name is the resource name in the PC",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is the identifier type to use for this resource.",
+                    "enum": [
+                        "uuid",
+                        "name"
+                    ],
+                    "type": "string"
+                },
+                "uuid": {
+                    "description": "uuid is the UUID of the resource in the PC.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "subnets": {
+            "description": "subnets holds a list of identifiers (one or more) of the cluster's network subnets for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.",
+            "items": {
+                "description": "NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)",
+                "properties": {
+                    "name": {
+                        "description": "name is the resource name in the PC",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type is the identifier type to use for this resource.",
+                        "enum": [
+                            "uuid",
+                            "name"
+                        ],
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "description": "uuid is the UUID of the resource in the PC.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "minItems": 1,
+            "type": "array"
+        },
+        "systemDiskSize": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "systemDiskSize is size (in Quantity format) of the system disk of the VM The minimum systemDiskSize is 20Gi bytes",
+            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+            "x-kubernetes-int-or-string": true
+        },
+        "userDataSecret": {
+            "description": "userDataSecret is a local reference to a secret that contains the UserData to apply to the VM",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "vcpuSockets": {
+            "description": "vcpuSockets is the number of vCPU sockets of the VM",
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer",
+            "maximum": 2147483647
+        },
+        "vcpusPerSocket": {
+            "description": "vcpusPerSocket is the number of vCPUs per socket of the VM",
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer",
+            "maximum": 2147483647
+        }
+    },
+    "required": [
+        "cluster",
+        "credentialsSecret",
+        "image",
+        "memorySize",
+        "subnets",
+        "systemDiskSize",
+        "vcpuSockets",
+        "vcpusPerSocket"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauth_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauth_config.openshift.io_v1.json
@@ -1,0 +1,635 @@
+{
+    "description": "OAuth holds cluster-wide information about OAuth.  The canonical name is `cluster`. It is used to configure the integrated OAuth server. This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "identityProviders": {
+                    "description": "identityProviders is an ordered list of ways for a user to identify themselves. When this list is empty, no identities are provisioned for users.",
+                    "items": {
+                        "description": "IdentityProvider provides identities for users authenticating using credentials",
+                        "properties": {
+                            "basicAuth": {
+                                "description": "basicAuth contains configuration options for the BasicAuth IdP",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "tlsClientCert": {
+                                        "description": "tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key \"tls.crt\" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "tlsClientKey": {
+                                        "description": "tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key \"tls.key\" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "url": {
+                                        "description": "url is the remote URL to connect to",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "github": {
+                                "description": "github enables user authentication using GitHub credentials",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. This can only be configured when hostname is set to a non-empty value. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "clientID": {
+                                        "description": "clientID is the oauth client ID",
+                                        "type": "string"
+                                    },
+                                    "clientSecret": {
+                                        "description": "clientSecret is a required reference to the secret by name containing the oauth client secret. The key \"clientSecret\" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "hostname": {
+                                        "description": "hostname is the optional domain (e.g. \"mycompany.com\") for use with a hosted instance of GitHub Enterprise. It must match the GitHub Enterprise settings value configured at /setup/settings#hostname.",
+                                        "type": "string"
+                                    },
+                                    "organizations": {
+                                        "description": "organizations optionally restricts which organizations are allowed to log in",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "teams": {
+                                        "description": "teams optionally restricts which teams are allowed to log in. Format is <org>/<team>.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "gitlab": {
+                                "description": "gitlab enables user authentication using GitLab credentials",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "clientID": {
+                                        "description": "clientID is the oauth client ID",
+                                        "type": "string"
+                                    },
+                                    "clientSecret": {
+                                        "description": "clientSecret is a required reference to the secret by name containing the oauth client secret. The key \"clientSecret\" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "url": {
+                                        "description": "url is the oauth server base URL",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "google": {
+                                "description": "google enables user authentication using Google credentials",
+                                "properties": {
+                                    "clientID": {
+                                        "description": "clientID is the oauth client ID",
+                                        "type": "string"
+                                    },
+                                    "clientSecret": {
+                                        "description": "clientSecret is a required reference to the secret by name containing the oauth client secret. The key \"clientSecret\" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "hostedDomain": {
+                                        "description": "hostedDomain is the optional Google App domain (e.g. \"mycompany.com\") to restrict logins to",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "htpasswd": {
+                                "description": "htpasswd enables user authentication using an HTPasswd file to validate credentials",
+                                "properties": {
+                                    "fileData": {
+                                        "description": "fileData is a required reference to a secret by name containing the data to use as the htpasswd file. The key \"htpasswd\" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. If the specified htpasswd data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "keystone": {
+                                "description": "keystone enables user authentication using keystone password credentials",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "domainName": {
+                                        "description": "domainName is required for keystone v3",
+                                        "type": "string"
+                                    },
+                                    "tlsClientCert": {
+                                        "description": "tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key \"tls.crt\" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "tlsClientKey": {
+                                        "description": "tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key \"tls.key\" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "url": {
+                                        "description": "url is the remote URL to connect to",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "ldap": {
+                                "description": "ldap enables user authentication using LDAP credentials",
+                                "properties": {
+                                    "attributes": {
+                                        "description": "attributes maps LDAP attributes to identities",
+                                        "properties": {
+                                            "email": {
+                                                "description": "email is the list of attributes whose values should be used as the email address. Optional. If unspecified, no email is set for the identity",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "id": {
+                                                "description": "id is the list of attributes whose values should be used as the user ID. Required. First non-empty attribute is used. At least one attribute is required. If none of the listed attribute have a value, authentication fails. LDAP standard identity attribute is \"dn\"",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "name": {
+                                                "description": "name is the list of attributes whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity LDAP standard display name attribute is \"cn\"",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "preferredUsername": {
+                                                "description": "preferredUsername is the list of attributes whose values should be used as the preferred username. LDAP standard login attribute is \"uid\"",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "bindDN": {
+                                        "description": "bindDN is an optional DN to bind with during the search phase.",
+                                        "type": "string"
+                                    },
+                                    "bindPassword": {
+                                        "description": "bindPassword is an optional reference to a secret by name containing a password to bind with during the search phase. The key \"bindPassword\" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "insecure": {
+                                        "description": "insecure, if true, indicates the connection should not use TLS WARNING: Should not be set to `true` with the URL scheme \"ldaps://\" as \"ldaps://\" URLs always attempt to connect using TLS, even when `insecure` is set to `true` When `true`, \"ldap://\" URLS connect insecurely. When `false`, \"ldap://\" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830.",
+                                        "type": "boolean"
+                                    },
+                                    "url": {
+                                        "description": "url is an RFC 2255 URL which specifies the LDAP search parameters to use. The syntax of the URL is: ldap://host:port/basedn?attribute?scope?filter",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "mappingMethod": {
+                                "description": "mappingMethod determines how identities from this provider are mapped to users Defaults to \"claim\"",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is used to qualify the identities returned by this provider. - It MUST be unique and not shared by any other identity provider used - It MUST be a valid path segment: name cannot equal \".\" or \"..\" or contain \"/\" or \"%\" or \":\" Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName",
+                                "type": "string"
+                            },
+                            "openID": {
+                                "description": "openID enables user authentication using OpenID credentials",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca.crt\" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "claims": {
+                                        "description": "claims mappings",
+                                        "properties": {
+                                            "email": {
+                                                "description": "email is the list of claims whose values should be used as the email address. Optional. If unspecified, no email is set for the identity",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "groups": {
+                                                "description": "groups is the list of claims value of which should be used to synchronize groups from the OIDC provider to OpenShift for the user. If multiple claims are specified, the first one with a non-empty value is used.",
+                                                "items": {
+                                                    "description": "OpenIDClaim represents a claim retrieved from an OpenID provider's tokens or userInfo responses",
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "name": {
+                                                "description": "name is the list of claims whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "preferredUsername": {
+                                                "description": "preferredUsername is the list of claims whose values should be used as the preferred username. If unspecified, the preferred username is determined from the value of the sub claim",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                            }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "clientID": {
+                                        "description": "clientID is the oauth client ID",
+                                        "type": "string"
+                                    },
+                                    "clientSecret": {
+                                        "description": "clientSecret is a required reference to the secret by name containing the oauth client secret. The key \"clientSecret\" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced secret",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "extraAuthorizeParameters": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "extraAuthorizeParameters are any custom parameters to add to the authorize request.",
+                                        "type": "object"
+                                    },
+                                    "extraScopes": {
+                                        "description": "extraScopes are any scopes to request in addition to the standard \"openid\" scope.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "issuer": {
+                                        "description": "issuer is the URL that the OpenID Provider asserts as its Issuer Identifier. It must use the https scheme with no query or fragment component.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "requestHeader": {
+                                "description": "requestHeader enables user authentication using request header credentials",
+                                "properties": {
+                                    "ca": {
+                                        "description": "ca is a required reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. Specifically, it allows verification of incoming requests to prevent header spoofing. The key \"ca.crt\" is used to locate the data. If the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. The namespace for this config map is openshift-config.",
+                                        "properties": {
+                                            "name": {
+                                                "description": "name is the metadata.name of the referenced config map",
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "challengeURL": {
+                                        "description": "challengeURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect WWW-Authenticate challenges will be redirected here. ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when challenge is set to true.",
+                                        "type": "string"
+                                    },
+                                    "clientCommonNames": {
+                                        "description": "clientCommonNames is an optional list of common names to require a match from. If empty, any client certificate validated against the clientCA bundle is considered authoritative.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "emailHeaders": {
+                                        "description": "emailHeaders is the set of headers to check for the email address",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "headers": {
+                                        "description": "headers is the set of headers to check for identity information",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "loginURL": {
+                                        "description": "loginURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect interactive logins will be redirected here ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when login is set to true.",
+                                        "type": "string"
+                                    },
+                                    "nameHeaders": {
+                                        "description": "nameHeaders is the set of headers to check for the display name",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "preferredUsernameHeaders": {
+                                        "description": "preferredUsernameHeaders is the set of headers to check for the preferred username",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": {
+                                "description": "type identifies the identity provider type for this entry.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                },
+                "templates": {
+                    "description": "templates allow you to customize pages like the login page.",
+                    "properties": {
+                        "error": {
+                            "description": "error is the name of a secret that specifies a go template to use to render error pages during the authentication or grant flow. The key \"errors.html\" is used to locate the template data. If specified and the secret or expected key is not found, the default error page is used. If the specified template is not valid, the default error page is used. If unspecified, the default error page is used. The namespace for this secret is openshift-config.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "login": {
+                            "description": "login is the name of a secret that specifies a go template to use to render the login page. The key \"login.html\" is used to locate the template data. If specified and the secret or expected key is not found, the default login page is used. If the specified template is not valid, the default login page is used. If unspecified, the default login page is used. The namespace for this secret is openshift-config.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "providerSelection": {
+                            "description": "providerSelection is the name of a secret that specifies a go template to use to render the provider selection page. The key \"providers.html\" is used to locate the template data. If specified and the secret or expected key is not found, the default provider selection page is used. If the specified template is not valid, the default provider selection page is used. If unspecified, the default provider selection page is used. The namespace for this secret is openshift-config.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "tokenConfig": {
+                    "description": "tokenConfig contains options for authorization and access tokens",
+                    "properties": {
+                        "accessTokenInactivityTimeout": {
+                            "description": "accessTokenInactivityTimeout defines the token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Takes valid time duration string such as \"5m\", \"1.5h\" or \"2h45m\". The minimum allowed value for duration is 300s (5 minutes). If the timeout is configured per client, then that value takes precedence. If the timeout value is not specified and the client does not override the value, then tokens are valid until their lifetime. \n WARNING: existing tokens' timeout will not be affected (lowered) by changing this value",
+                            "type": "string"
+                        },
+                        "accessTokenInactivityTimeoutSeconds": {
+                            "description": "accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.",
+                            "format": "int32",
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                        },
+                        "accessTokenMaxAgeSeconds": {
+                            "description": "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
+                            "format": "int32",
+                            "type": "integer",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauthaccesstoken_oauth.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauthaccesstoken_oauth.openshift.io_v1.json
@@ -1,0 +1,64 @@
+{
+    "description": "OAuthAccessToken describes an OAuth access token. The name of a token must be prefixed with a `sha256~` string, must not contain \"/\" or \"%\" characters and must be at least 32 characters long. \n The name of the token is constructed from the actual token by sha256-hashing it and using URL-safe unpadded base64-encoding (as described in RFC4648) on the hashed result. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "authorizeToken": {
+            "description": "AuthorizeToken contains the token that authorized this token",
+            "type": "string"
+        },
+        "clientName": {
+            "description": "ClientName references the client that created this token.",
+            "type": "string"
+        },
+        "expiresIn": {
+            "description": "ExpiresIn is the seconds from CreationTime before this token expires.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "inactivityTimeoutSeconds": {
+            "description": "InactivityTimeoutSeconds is the value in seconds, from the CreationTimestamp, after which this token can no longer be used. The value is automatically incremented when the token is used.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "redirectURI": {
+            "description": "RedirectURI is the redirection associated with the token.",
+            "type": "string"
+        },
+        "refreshToken": {
+            "description": "RefreshToken is the value by which this token can be renewed. Can be blank.",
+            "type": "string"
+        },
+        "scopes": {
+            "description": "Scopes is an array of the requested scopes.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "userName": {
+            "description": "UserName is the user name associated with this token",
+            "type": "string"
+        },
+        "userUID": {
+            "description": "UserUID is the unique UID associated with this token",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauthauthorizetoken_oauth.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauthauthorizetoken_oauth.openshift.io_v1.json
@@ -1,0 +1,61 @@
+{
+    "description": "OAuthAuthorizeToken describes an OAuth authorization token \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "clientName": {
+            "description": "ClientName references the client that created this token.",
+            "type": "string"
+        },
+        "codeChallenge": {
+            "description": "CodeChallenge is the optional code_challenge associated with this authorization code, as described in rfc7636",
+            "type": "string"
+        },
+        "codeChallengeMethod": {
+            "description": "CodeChallengeMethod is the optional code_challenge_method associated with this authorization code, as described in rfc7636",
+            "type": "string"
+        },
+        "expiresIn": {
+            "description": "ExpiresIn is the seconds from CreationTime before this token expires.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "redirectURI": {
+            "description": "RedirectURI is the redirection associated with the token.",
+            "type": "string"
+        },
+        "scopes": {
+            "description": "Scopes is an array of the requested scopes.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "state": {
+            "description": "State data from request",
+            "type": "string"
+        },
+        "userName": {
+            "description": "UserName is the user name associated with this token",
+            "type": "string"
+        },
+        "userUID": {
+            "description": "UserUID is the unique UID associated with this token. UserUID and UserName must both match for this token to be valid.",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauthclient_oauth.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauthclient_oauth.openshift.io_v1.json
@@ -1,0 +1,107 @@
+{
+    "description": "OAuthClient describes an OAuth client \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "accessTokenInactivityTimeoutSeconds": {
+            "description": "AccessTokenInactivityTimeoutSeconds overrides the default token inactivity timeout for tokens granted to this client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. This value needs to be set only if the default set in configuration is not appropriate for this client. Valid values are: - 0: Tokens for this client never time out - X: Tokens time out if there is no activity for X seconds The current minimum allowed value for X is 300 (5 minutes) \n WARNING: existing tokens' timeout will not be affected (lowered) by changing this value",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "accessTokenMaxAgeSeconds": {
+            "description": "AccessTokenMaxAgeSeconds overrides the default access token max age for tokens granted to this client. 0 means no expiration.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "additionalSecrets": {
+            "description": "AdditionalSecrets holds other secrets that may be used to identify the client.  This is useful for rotation and for service account token validation",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "grantMethod": {
+            "description": "GrantMethod is a required field which determines how to handle grants for this client. Valid grant handling methods are: - auto:   always approves grant requests, useful for trusted clients - prompt: prompts the end user for approval of grant requests, useful for third-party clients",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "redirectURIs": {
+            "description": "RedirectURIs is the valid redirection URIs associated with a client",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "respondWithChallenges": {
+            "description": "RespondWithChallenges indicates whether the client wants authentication needed responses made in the form of challenges instead of redirects",
+            "type": "boolean"
+        },
+        "scopeRestrictions": {
+            "description": "ScopeRestrictions describes which scopes this client can request.  Each requested scope is checked against each restriction.  If any restriction matches, then the scope is allowed. If no restriction matches, then the scope is denied.",
+            "items": {
+                "description": "ScopeRestriction describe one restriction on scopes.  Exactly one option must be non-nil.",
+                "properties": {
+                    "clusterRole": {
+                        "description": "ClusterRole describes a set of restrictions for cluster role scoping.",
+                        "properties": {
+                            "allowEscalation": {
+                                "description": "AllowEscalation indicates whether you can request roles and their escalating resources",
+                                "type": "boolean"
+                            },
+                            "namespaces": {
+                                "description": "Namespaces is the list of namespaces that can be referenced.  * means any of them (including *)",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "roleNames": {
+                                "description": "RoleNames is the list of cluster roles that can referenced.  * means anything",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "allowEscalation",
+                            "namespaces",
+                            "roleNames"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "literals": {
+                        "description": "ExactValues means the scope has to match a particular set of strings exactly",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "secret": {
+            "description": "Secret is the unique secret associated with a client",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauthclientauthorization_oauth.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauthclientauthorization_oauth.openshift.io_v1.json
@@ -1,0 +1,38 @@
+{
+    "description": "OAuthClientAuthorization describes an authorization created by an OAuth client \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "clientName": {
+            "description": "ClientName references the client that created this authorization",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "scopes": {
+            "description": "Scopes is an array of the granted scopes.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "userName": {
+            "description": "UserName is the user name that authorized this client",
+            "type": "string"
+        },
+        "userUID": {
+            "description": "UserUID is the unique UID associated with this authorization. UserUID and UserName must both match for this authorization to be valid.",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/oauthredirectreference_oauth.openshift.io_v1.json
+++ b/openshift/v4.14-strict/oauthredirectreference_oauth.openshift.io_v1.json
@@ -1,0 +1,43 @@
+{
+    "description": "OAuthRedirectReference is a reference to an OAuth redirect object. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "reference": {
+            "description": "The reference to an redirect object in the current namespace.",
+            "properties": {
+                "group": {
+                    "description": "The group of the target that is being referred to.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "The kind of the target that is being referred to.  Currently, only 'Route' is allowed.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "The name of the target that is being referred to. e.g. name of the Route.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "group",
+                "kind",
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/olm_operator.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/olm_operator.openshift.io_v1alpha1.json
@@ -1,0 +1,171 @@
+{
+    "description": "OLM provides information to configure an operator to manage the OLM controllers \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec"
+    ],
+    "type": "object",
+    "x-kubernetes-validations": [
+        {
+            "message": "olm is a singleton, .metadata.name must be 'cluster'",
+            "rule": "self.metadata.name == 'cluster'"
+        }
+    ],
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/openshiftapiserver_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/openshiftapiserver_operator.openshift.io_v1.json
@@ -1,0 +1,171 @@
+{
+    "description": "OpenShiftAPIServer provides information to configure an operator to manage openshift-apiserver. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the OpenShift API Server.",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status defines the observed status of the OpenShift API Server.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "latestAvailableRevision": {
+                    "description": "latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer",
+                    "maximum": 2147483647
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/openshiftcontrollermanager_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/openshiftcontrollermanager_operator.openshift.io_v1.json
@@ -1,0 +1,162 @@
+{
+    "description": "OpenShiftControllerManager provides information to configure an operator to manage openshift-controller-manager. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/openstackproviderspec_machine.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/openstackproviderspec_machine.openshift.io_v1alpha1.json
@@ -1,0 +1,559 @@
+{
+    "description": "OpenstackProviderSpec is the type that will be embedded in a Machine.Spec.ProviderSpec field for an OpenStack Instance. It is used by the Openstack machine actuator to create a single machine instance. Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "availabilityZone": {
+            "description": "The availability zone from which to launch the server.",
+            "type": "string"
+        },
+        "cloudName": {
+            "description": "The name of the cloud to use from the clouds secret",
+            "type": "string"
+        },
+        "cloudsSecret": {
+            "description": "The name of the secret containing the openstack credentials",
+            "properties": {
+                "name": {
+                    "description": "name is unique within a namespace to reference a secret resource.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "namespace defines the space within which the secret name must be unique.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "configDrive": {
+            "description": "Config Drive support",
+            "type": "boolean"
+        },
+        "flavor": {
+            "description": "The flavor reference for the flavor for your server instance.",
+            "type": "string"
+        },
+        "floatingIP": {
+            "description": "floatingIP specifies a floating IP to be associated with the machine. Note that it is not safe to use this parameter in a MachineSet, as only one Machine may be assigned the same floating IP. \n Deprecated: floatingIP will be removed in a future release as it cannot be implemented correctly.",
+            "type": "string"
+        },
+        "image": {
+            "description": "The name of the image to use for your server instance. If the RootVolume is specified, this will be ignored and use rootVolume directly.",
+            "type": "string"
+        },
+        "keyName": {
+            "description": "The ssh key to inject in the instance",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "networks": {
+            "description": "A networks object. Required parameter when there are multiple networks defined for the tenant. When you do not specify the networks parameter, the server attaches to the only network created for the current tenant.",
+            "items": {
+                "properties": {
+                    "filter": {
+                        "description": "Filters for optional network query",
+                        "properties": {
+                            "adminStateUp": {
+                                "description": "Deprecated: adminStateUp is silently ignored. It has no replacement.",
+                                "type": "boolean"
+                            },
+                            "description": {
+                                "description": "description filters networks by description.",
+                                "type": "string"
+                            },
+                            "id": {
+                                "description": "Deprecated: use NetworkParam.uuid instead. Ignored if NetworkParam.uuid is set.",
+                                "type": "string"
+                            },
+                            "limit": {
+                                "description": "Deprecated: limit is silently ignored. It has no replacement.",
+                                "type": "integer"
+                            },
+                            "marker": {
+                                "description": "Deprecated: marker is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name filters networks by name.",
+                                "type": "string"
+                            },
+                            "notTags": {
+                                "description": "notTags filters by networks which don't match all specified tags. NOT (t1 AND t2...) Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "notTagsAny": {
+                                "description": "notTagsAny filters by networks which don't match any specified tags. NOT (t1 OR t2...) Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "projectId": {
+                                "description": "projectId filters networks by project ID.",
+                                "type": "string"
+                            },
+                            "shared": {
+                                "description": "Deprecated: shared is silently ignored. It has no replacement.",
+                                "type": "boolean"
+                            },
+                            "sortDir": {
+                                "description": "Deprecated: sortDir is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "sortKey": {
+                                "description": "Deprecated: sortKey is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Deprecated: status is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "tags": {
+                                "description": "tags filters by networks containing all specified tags. Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "tagsAny": {
+                                "description": "tagsAny filters by networks containing any specified tags. Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "tenantId": {
+                                "description": "tenantId filters networks by tenant ID. Deprecated: use projectId instead. tenantId will be ignored if projectId is set.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "fixedIp": {
+                        "description": "A fixed IPv4 address for the NIC.",
+                        "type": "string"
+                    },
+                    "noAllowedAddressPairs": {
+                        "description": "NoAllowedAddressPairs disables creation of allowed address pairs for the network ports",
+                        "type": "boolean"
+                    },
+                    "portSecurity": {
+                        "description": "PortSecurity optionally enables or disables security on ports managed by OpenStack",
+                        "type": "boolean"
+                    },
+                    "portTags": {
+                        "description": "PortTags allows users to specify a list of tags to add to ports created in a given network",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "profile": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A dictionary that enables the application running on the specified host to pass and receive virtual network interface (VIF) port-specific information to the plug-in.",
+                        "type": "object"
+                    },
+                    "subnets": {
+                        "description": "Subnet within a network to use",
+                        "items": {
+                            "properties": {
+                                "filter": {
+                                    "description": "Filters for optional network query",
+                                    "properties": {
+                                        "cidr": {
+                                            "description": "cidr filters subnets by CIDR.",
+                                            "type": "string"
+                                        },
+                                        "description": {
+                                            "description": "description filters subnets by description.",
+                                            "type": "string"
+                                        },
+                                        "enableDhcp": {
+                                            "description": "Deprecated: enableDhcp is silently ignored. It has no replacement.",
+                                            "type": "boolean"
+                                        },
+                                        "gateway_ip": {
+                                            "description": "gateway_ip filters subnets by gateway IP.",
+                                            "type": "string"
+                                        },
+                                        "id": {
+                                            "description": "id is the uuid of a specific subnet to use. If specified, id will not be validated. Instead server creation will fail with an appropriate error.",
+                                            "type": "string"
+                                        },
+                                        "ipVersion": {
+                                            "description": "ipVersion filters subnets by IP version.",
+                                            "type": "integer"
+                                        },
+                                        "ipv6AddressMode": {
+                                            "description": "ipv6AddressMode filters subnets by IPv6 address mode.",
+                                            "type": "string"
+                                        },
+                                        "ipv6RaMode": {
+                                            "description": "ipv6RaMode filters subnets by IPv6 router adversiement mode.",
+                                            "type": "string"
+                                        },
+                                        "limit": {
+                                            "description": "Deprecated: limit is silently ignored. It has no replacement.",
+                                            "type": "integer"
+                                        },
+                                        "marker": {
+                                            "description": "Deprecated: marker is silently ignored. It has no replacement.",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name filters subnets by name.",
+                                            "type": "string"
+                                        },
+                                        "networkId": {
+                                            "description": "Deprecated: networkId is silently ignored. Set uuid on the containing network definition instead.",
+                                            "type": "string"
+                                        },
+                                        "notTags": {
+                                            "description": "notTags filters by subnets which don't match all specified tags. NOT (t1 AND t2...) Multiple tags are comma separated.",
+                                            "type": "string"
+                                        },
+                                        "notTagsAny": {
+                                            "description": "notTagsAny filters by subnets which don't match any specified tags. NOT (t1 OR t2...) Multiple tags are comma separated.",
+                                            "type": "string"
+                                        },
+                                        "projectId": {
+                                            "description": "projectId filters subnets by project ID.",
+                                            "type": "string"
+                                        },
+                                        "sortDir": {
+                                            "description": "Deprecated: sortDir is silently ignored. It has no replacement.",
+                                            "type": "string"
+                                        },
+                                        "sortKey": {
+                                            "description": "Deprecated: sortKey is silently ignored. It has no replacement.",
+                                            "type": "string"
+                                        },
+                                        "subnetpoolId": {
+                                            "description": "subnetpoolId filters subnets by subnet pool ID.",
+                                            "type": "string"
+                                        },
+                                        "tags": {
+                                            "description": "tags filters by subnets containing all specified tags. Multiple tags are comma separated.",
+                                            "type": "string"
+                                        },
+                                        "tagsAny": {
+                                            "description": "tagsAny filters by subnets containing any specified tags. Multiple tags are comma separated.",
+                                            "type": "string"
+                                        },
+                                        "tenantId": {
+                                            "description": "tenantId filters subnets by tenant ID. Deprecated: use projectId instead. tenantId will be ignored if projectId is set.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "portSecurity": {
+                                    "description": "PortSecurity optionally enables or disables security on ports managed by OpenStack",
+                                    "type": "boolean"
+                                },
+                                "portTags": {
+                                    "description": "PortTags are tags that are added to ports created on this subnet",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "type": "array"
+                                },
+                                "uuid": {
+                                    "description": "The UUID of the network. Required if you omit the port attribute.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": "array"
+                    },
+                    "uuid": {
+                        "description": "The UUID of the network. Required if you omit the port attribute.",
+                        "type": "string"
+                    },
+                    "vnicType": {
+                        "description": "The virtual network interface card (vNIC) type that is bound to the neutron port.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "ports": {
+            "description": "Create and assign additional ports to instances",
+            "items": {
+                "properties": {
+                    "adminStateUp": {
+                        "description": "adminStateUp sets the administrative state of the created port to up (true), or down (false).",
+                        "type": "boolean"
+                    },
+                    "allowedAddressPairs": {
+                        "description": "allowedAddressPairs specifies a set of allowed address pairs to add to the port.",
+                        "items": {
+                            "properties": {
+                                "ipAddress": {
+                                    "type": "string"
+                                },
+                                "macAddress": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": "array"
+                    },
+                    "description": {
+                        "description": "description specifies the description of the created port.",
+                        "type": "string"
+                    },
+                    "fixedIPs": {
+                        "description": "fixedIPs specifies a set of fixed IPs to assign to the port. They must all be valid for the port's network.",
+                        "items": {
+                            "properties": {
+                                "ipAddress": {
+                                    "description": "ipAddress is a specific IP address to use in the given subnet. Port creation will fail if the address is not available. If not specified, an available IP from the given subnet will be selected automatically.",
+                                    "type": "string"
+                                },
+                                "subnetID": {
+                                    "description": "subnetID specifies the ID of the subnet where the fixed IP will be allocated.",
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "type": "array"
+                    },
+                    "hostID": {
+                        "description": "The ID of the host where the port is allocated. Do not use this field: it cannot be used correctly. Deprecated: hostID is silently ignored. It will be removed with no replacement.",
+                        "type": "string"
+                    },
+                    "macAddress": {
+                        "description": "macAddress specifies the MAC address of the created port.",
+                        "type": "string"
+                    },
+                    "nameSuffix": {
+                        "description": "If nameSuffix is specified the created port will be named <machine name>-<nameSuffix>. If not specified the port will be named <machine-name>-<index of this port>.",
+                        "type": "string"
+                    },
+                    "networkID": {
+                        "description": "networkID is the ID of the network the port will be created in. It is required.",
+                        "type": "string"
+                    },
+                    "portSecurity": {
+                        "description": "enable or disable security on a given port incompatible with securityGroups and allowedAddressPairs",
+                        "type": "boolean"
+                    },
+                    "profile": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A dictionary that enables the application running on the specified host to pass and receive virtual network interface (VIF) port-specific information to the plug-in.",
+                        "type": "object"
+                    },
+                    "projectID": {
+                        "description": "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended.",
+                        "type": "string"
+                    },
+                    "securityGroups": {
+                        "description": "securityGroups specifies a set of security group UUIDs to use instead of the machine's default security groups. The default security groups will be used if this is left empty or not specified.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "tags": {
+                        "description": "tags species a set of tags to add to the port.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "tenantID": {
+                        "description": "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: use projectID instead. It will be ignored if projectID is set.",
+                        "type": "string"
+                    },
+                    "trunk": {
+                        "description": "Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.",
+                        "type": "boolean"
+                    },
+                    "vnicType": {
+                        "description": "The virtual network interface card (vNIC) type that is bound to the neutron port.",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "primarySubnet": {
+            "description": "The subnet that a set of machines will get ingress/egress traffic from",
+            "type": "string"
+        },
+        "rootVolume": {
+            "description": "The volume metadata to boot from",
+            "properties": {
+                "availabilityZone": {
+                    "description": "availabilityZone specifies the Cinder availability where the root volume will be created.",
+                    "type": "string"
+                },
+                "deviceType": {
+                    "description": "Deprecated: deviceType will be silently ignored. There is no replacement.",
+                    "type": "string"
+                },
+                "diskSize": {
+                    "description": "diskSize specifies the size, in GB, of the created root volume.",
+                    "type": "integer"
+                },
+                "sourceType": {
+                    "description": "Deprecated: sourceType will be silently ignored. There is no replacement.",
+                    "type": "string"
+                },
+                "sourceUUID": {
+                    "description": "sourceUUID specifies the UUID of a glance image used to populate the root volume. Deprecated: set image in the platform spec instead. This will be ignored if image is set in the platform spec.",
+                    "type": "string"
+                },
+                "volumeType": {
+                    "description": "volumeType specifies a volume type to use when creating the root volume. If not specified the default volume type will be used.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "securityGroups": {
+            "description": "The names of the security groups to assign to the instance",
+            "items": {
+                "properties": {
+                    "filter": {
+                        "description": "Filters used to query security groups in openstack",
+                        "properties": {
+                            "description": {
+                                "description": "description filters security groups by description.",
+                                "type": "string"
+                            },
+                            "id": {
+                                "description": "id specifies the ID of a security group to use. If set, id will not be validated before use. An invalid id will result in failure to create a server with an appropriate error message.",
+                                "type": "string"
+                            },
+                            "limit": {
+                                "description": "Deprecated: limit is silently ignored. It has no replacement.",
+                                "type": "integer"
+                            },
+                            "marker": {
+                                "description": "Deprecated: marker is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name filters security groups by name.",
+                                "type": "string"
+                            },
+                            "notTags": {
+                                "description": "notTags filters by security groups which don't match all specified tags. NOT (t1 AND t2...) Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "notTagsAny": {
+                                "description": "notTagsAny filters by security groups which don't match any specified tags. NOT (t1 OR t2...) Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "projectId": {
+                                "description": "projectId filters security groups by project ID.",
+                                "type": "string"
+                            },
+                            "sortDir": {
+                                "description": "Deprecated: sortDir is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "sortKey": {
+                                "description": "Deprecated: sortKey is silently ignored. It has no replacement.",
+                                "type": "string"
+                            },
+                            "tags": {
+                                "description": "tags filters by security groups containing all specified tags. Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "tagsAny": {
+                                "description": "tagsAny filters by security groups containing any specified tags. Multiple tags are comma separated.",
+                                "type": "string"
+                            },
+                            "tenantId": {
+                                "description": "tenantId filters security groups by tenant ID. Deprecated: use projectId instead. tenantId will be ignored if projectId is set.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "name": {
+                        "description": "Security Group name",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "description": "Security Group UUID",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "serverGroupID": {
+            "description": "The server group to assign the machine to.",
+            "type": "string"
+        },
+        "serverGroupName": {
+            "description": "The server group to assign the machine to. A server group with that name will be created if it does not exist. If both ServerGroupID and ServerGroupName are non-empty, they must refer to the same OpenStack resource.",
+            "type": "string"
+        },
+        "serverMetadata": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Metadata mapping. Allows you to create a map of key value pairs to add to the server instance.",
+            "type": "object"
+        },
+        "sshUserName": {
+            "description": "The machine ssh username",
+            "type": "string"
+        },
+        "tags": {
+            "description": "Machine tags Requires Nova api 2.52 minimum!",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "trunk": {
+            "description": "Whether the server instance is created on a trunk port or not.",
+            "type": "boolean"
+        },
+        "userDataSecret": {
+            "description": "The name of the secret containing the user data (startup script in most cases)",
+            "properties": {
+                "name": {
+                    "description": "name is unique within a namespace to reference a secret resource.",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "namespace defines the space within which the secret name must be unique.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/operatorhub_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/operatorhub_config.openshift.io_v1.json
@@ -1,0 +1,87 @@
+{
+    "description": "OperatorHub is the Schema for the operatorhubs API. It can be used to change the state of the default hub sources for OperatorHub on the cluster from enabled to disabled and vice versa. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "OperatorHubSpec defines the desired state of OperatorHub",
+            "properties": {
+                "disableAllDefaultSources": {
+                    "description": "disableAllDefaultSources allows you to disable all the default hub sources. If this is true, a specific entry in sources can be used to enable a default source. If this is false, a specific entry in sources can be used to disable or enable a default source.",
+                    "type": "boolean"
+                },
+                "sources": {
+                    "description": "sources is the list of default hub sources and their configuration. If the list is empty, it implies that the default hub sources are enabled on the cluster unless disableAllDefaultSources is true. If disableAllDefaultSources is true and sources is not empty, the configuration present in sources will take precedence. The list of default hub sources and their current state will always be reflected in the status block.",
+                    "items": {
+                        "description": "HubSource is used to specify the hub source and its configuration",
+                        "properties": {
+                            "disabled": {
+                                "description": "disabled is used to disable a default hub source on cluster",
+                                "type": "boolean"
+                            },
+                            "name": {
+                                "description": "name is the name of one of the default hub sources",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "OperatorHubStatus defines the observed state of OperatorHub. The current state of the default hub sources will always be reflected here.",
+            "properties": {
+                "sources": {
+                    "description": "sources encapsulates the result of applying the configuration for each hub source",
+                    "items": {
+                        "description": "HubSourceStatus is used to reflect the current state of applying the configuration to a default source",
+                        "properties": {
+                            "disabled": {
+                                "description": "disabled is used to disable a default hub source on cluster",
+                                "type": "boolean"
+                            },
+                            "message": {
+                                "description": "message provides more information regarding failures",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name is the name of one of the default hub sources",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status indicates success or failure in applying the configuration",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/platformoperator_platform.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/platformoperator_platform.openshift.io_v1alpha1.json
@@ -1,0 +1,119 @@
+{
+    "description": "PlatformOperator is the Schema for the PlatformOperators API. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "PlatformOperatorSpec defines the desired state of PlatformOperator.",
+            "properties": {
+                "package": {
+                    "description": "package contains the desired package and its configuration for this PlatformOperator.",
+                    "properties": {
+                        "name": {
+                            "description": "name contains the desired OLM-based Operator package name that is defined in an existing CatalogSource resource in the cluster. \n This configured package will be managed with the cluster's lifecycle. In the current implementation, it will be retrieving this name from a list of supported operators out of the catalogs included with OpenShift. \n ---",
+                            "maxLength": 56,
+                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "package"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "PlatformOperatorStatus defines the observed state of PlatformOperator",
+            "properties": {
+                "activeBundleDeployment": {
+                    "description": "activeBundleDeployment is the reference to the BundleDeployment resource that's being managed by this PO resource. If this field is not populated in the status then it means the PlatformOperator has either not been installed yet or is failing to install.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced BundleDeployment object.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "conditions": {
+                    "description": "conditions represent the latest available observations of a platform operator's current state.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/podnetworkconnectivitycheck_controlplane.operator.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/podnetworkconnectivitycheck_controlplane.operator.openshift.io_v1alpha1.json
@@ -1,0 +1,306 @@
+{
+    "description": "PodNetworkConnectivityCheck \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec defines the source and target of the connectivity check",
+            "properties": {
+                "sourcePod": {
+                    "description": "SourcePod names the pod from which the condition will be checked",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                },
+                "targetEndpoint": {
+                    "description": "EndpointAddress to check. A TCP address of the form host:port. Note that if host is a DNS name, then the check would fail if the DNS name cannot be resolved. Specify an IP address for host to bypass DNS name lookup.",
+                    "pattern": "^\\S+:\\d*$",
+                    "type": "string"
+                },
+                "tlsClientCert": {
+                    "description": "TLSClientCert, if specified, references a kubernetes.io/tls type secret with 'tls.crt' and 'tls.key' entries containing an optional TLS client certificate and key to be used when checking endpoints that require a client certificate in order to gracefully preform the scan without causing excessive logging in the endpoint process. The secret must exist in the same namespace as this resource.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced secret",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "sourcePod",
+                "targetEndpoint"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status contains the observed status of the connectivity check",
+            "properties": {
+                "conditions": {
+                    "description": "Conditions summarize the status of the check",
+                    "items": {
+                        "description": "PodNetworkConnectivityCheckCondition represents the overall status of the pod network connectivity.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "Last time the condition transitioned from one status to another.",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "message": {
+                                "description": "Message indicating details about last transition in a human readable format.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason for the condition's last status transition in a machine readable format.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of the condition",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "failures": {
+                    "description": "Failures contains logs of unsuccessful check actions",
+                    "items": {
+                        "description": "LogEntry records events",
+                        "properties": {
+                            "latency": {
+                                "description": "Latency records how long the action mentioned in the entry took.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "message": {
+                                "description": "Message explaining status in a human readable format.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason for status in a machine readable format.",
+                                "type": "string"
+                            },
+                            "success": {
+                                "description": "Success indicates if the log entry indicates a success or failure.",
+                                "type": "boolean"
+                            },
+                            "time": {
+                                "description": "Start time of check action.",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "success",
+                            "time"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "outages": {
+                    "description": "Outages contains logs of time periods of outages",
+                    "items": {
+                        "description": "OutageEntry records time period of an outage",
+                        "properties": {
+                            "end": {
+                                "description": "End of outage detected",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "endLogs": {
+                                "description": "EndLogs contains log entries related to the end of this outage. Should contain the success entry that resolved the outage and possibly a few of the failure log entries that preceded it.",
+                                "items": {
+                                    "description": "LogEntry records events",
+                                    "properties": {
+                                        "latency": {
+                                            "description": "Latency records how long the action mentioned in the entry took.",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "message": {
+                                            "description": "Message explaining status in a human readable format.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "Reason for status in a machine readable format.",
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "description": "Success indicates if the log entry indicates a success or failure.",
+                                            "type": "boolean"
+                                        },
+                                        "time": {
+                                            "description": "Start time of check action.",
+                                            "format": "date-time",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "time"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "message": {
+                                "description": "Message summarizes outage details in a human readable format.",
+                                "type": "string"
+                            },
+                            "start": {
+                                "description": "Start of outage detected",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "startLogs": {
+                                "description": "StartLogs contains log entries related to the start of this outage. Should contain the original failure, any entries where the failure mode changed.",
+                                "items": {
+                                    "description": "LogEntry records events",
+                                    "properties": {
+                                        "latency": {
+                                            "description": "Latency records how long the action mentioned in the entry took.",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        },
+                                        "message": {
+                                            "description": "Message explaining status in a human readable format.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "Reason for status in a machine readable format.",
+                                            "type": "string"
+                                        },
+                                        "success": {
+                                            "description": "Success indicates if the log entry indicates a success or failure.",
+                                            "type": "boolean"
+                                        },
+                                        "time": {
+                                            "description": "Start time of check action.",
+                                            "format": "date-time",
+                                            "type": [
+                                                "string",
+                                                "null"
+                                            ]
+                                        }
+                                    },
+                                    "required": [
+                                        "success",
+                                        "time"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "start"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "successes": {
+                    "description": "Successes contains logs successful check actions",
+                    "items": {
+                        "description": "LogEntry records events",
+                        "properties": {
+                            "latency": {
+                                "description": "Latency records how long the action mentioned in the entry took.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "message": {
+                                "description": "Message explaining status in a human readable format.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason for status in a machine readable format.",
+                                "type": "string"
+                            },
+                            "success": {
+                                "description": "Success indicates if the log entry indicates a success or failure.",
+                                "type": "boolean"
+                            },
+                            "time": {
+                                "description": "Start time of check action.",
+                                "format": "date-time",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "success",
+                            "time"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/powervsmachineproviderconfig_machine.openshift.io_v1.json
+++ b/openshift/v4.14-strict/powervsmachineproviderconfig_machine.openshift.io_v1.json
@@ -1,0 +1,193 @@
+{
+    "description": "PowerVSMachineProviderConfig is the type that will be embedded in a Machine.Spec.ProviderSpec field for a PowerVS virtual machine. It is used by the PowerVS machine actuator to create a single Machine. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "credentialsSecret": {
+            "description": "credentialsSecret is a reference to the secret with IBM Cloud credentials.",
+            "properties": {
+                "name": {
+                    "description": "Name of the secret.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "image": {
+            "description": "image is to identify the rhcos image uploaded to IBM COS bucket which is used to create the instance. supported image identifier in PowerVSResource are Name and ID and that can be obtained from IBM Cloud UI or IBM Cloud cli.",
+            "properties": {
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of resource",
+                    "type": "string"
+                },
+                "regex": {
+                    "description": "Regex to find resource Regex contains the pattern to match to find a resource",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type identifies the resource type for this entry. Valid values are ID, Name and RegEx",
+                    "enum": [
+                        "ID",
+                        "Name",
+                        "RegEx"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "keyPairName": {
+            "description": "keyPairName is the name of the KeyPair to use for SSH. The key pair will be exposed to the instance via the instance metadata service. On boot, the OS will copy the public keypair into the authorized keys for the core user.",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "loadBalancers": {
+            "description": "loadBalancers is the set of load balancers to which the new control plane instance should be added once it is created.",
+            "items": {
+                "description": "LoadBalancerReference is a reference to a load balancer on IBM Cloud virtual private cloud(VPC).",
+                "properties": {
+                    "name": {
+                        "description": "name of the LoadBalancer in IBM Cloud VPC. The name should be between 1 and 63 characters long and may consist of lowercase alphanumeric characters and hyphens only. The value must not end with a hyphen. It is a reference to existing LoadBalancer created by openshift installer component.",
+                        "maxLength": 63,
+                        "minLength": 1,
+                        "pattern": "^([a-z]|[a-z][-a-z0-9]*[a-z0-9]|[0-9][-a-z0-9]*([a-z]|[-a-z][-a-z0-9]*[a-z0-9]))$",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "type of the LoadBalancer service supported by IBM Cloud VPC. Currently, only Application LoadBalancer is supported. More details about Application LoadBalancer https://cloud.ibm.com/docs/vpc?topic=vpc-load-balancers-about&interface=ui Supported values are Application.",
+                        "enum": [
+                            "Application"
+                        ],
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name",
+                    "type"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "memoryGiB": {
+            "description": "memoryGiB is the size of a virtual machine's memory, in GiB. maximum value for the MemoryGiB depends on the selected SystemType. when SystemType is set to e880 maximum MemoryGiB value is 7463 GiB. when SystemType is set to e980 maximum MemoryGiB value is 15307 GiB. when SystemType is set to s922 maximum MemoryGiB value is 942 GiB. The minimum memory is 32 GiB. When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is 32.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "network": {
+            "description": "network is the reference to the Network to use for this instance. supported network identifier in PowerVSResource are Name, ID and RegEx and that can be obtained from IBM Cloud UI or IBM Cloud cli.",
+            "properties": {
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of resource",
+                    "type": "string"
+                },
+                "regex": {
+                    "description": "Regex to find resource Regex contains the pattern to match to find a resource",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type identifies the resource type for this entry. Valid values are ID, Name and RegEx",
+                    "enum": [
+                        "ID",
+                        "Name",
+                        "RegEx"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "processorType": {
+            "description": "processorType is the VM instance processor type. It must be set to one of the following values: Dedicated, Capped or Shared. Dedicated: resources are allocated for a specific client, The hypervisor makes a 1:1 binding of a partition’s processor to a physical processor core. Shared: Shared among other clients. Capped: Shared, but resources do not expand beyond those that are requested, the amount of CPU time is Capped to the value specified for the entitlement. if the processorType is selected as Dedicated, then processors value cannot be fractional. When omitted, this means that the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Shared.",
+            "enum": [
+                "Dedicated",
+                "Shared",
+                "Capped",
+                ""
+            ],
+            "type": "string"
+        },
+        "processors": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "description": "processors is the number of virtual processors in a virtual machine. when the processorType is selected as Dedicated the processors value cannot be fractional. maximum value for the Processors depends on the selected SystemType. when SystemType is set to e880 or e980 maximum Processors value is 143. when SystemType is set to s922 maximum Processors value is 15. minimum value for Processors depends on the selected ProcessorType. when ProcessorType is set as Shared or Capped, The minimum processors is 0.5. when ProcessorType is set as Dedicated, The minimum processors is 1. When omitted, this means that the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The default is set based on the selected ProcessorType. when ProcessorType selected as Dedicated, the default is set to 1. when ProcessorType selected as Shared or Capped, the default is set to 0.5.",
+            "x-kubernetes-int-or-string": true
+        },
+        "serviceInstance": {
+            "description": "serviceInstance is the reference to the Power VS service on which the server instance(VM) will be created. Power VS service is a container for all Power VS instances at a specific geographic region. serviceInstance can be created via IBM Cloud catalog or CLI. supported serviceInstance identifier in PowerVSResource are Name and ID and that can be obtained from IBM Cloud UI or IBM Cloud cli. More detail about Power VS service instance. https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-creating-power-virtual-server",
+            "properties": {
+                "id": {
+                    "description": "ID of resource",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of resource",
+                    "type": "string"
+                },
+                "regex": {
+                    "description": "Regex to find resource Regex contains the pattern to match to find a resource",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type identifies the resource type for this entry. Valid values are ID, Name and RegEx",
+                    "enum": [
+                        "ID",
+                        "Name",
+                        "RegEx"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "systemType": {
+            "description": "systemType is the System type used to host the instance. systemType determines the number of cores and memory that is available. Few of the supported SystemTypes are s922,e880,e980. e880 systemType available only in Dallas Datacenters. e980 systemType available in Datacenters except Dallas and Washington. When omitted, this means that the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is s922 which is generally available.",
+            "type": "string"
+        },
+        "userDataSecret": {
+            "description": "userDataSecret contains a local reference to a secret that contains the UserData to apply to the instance.",
+            "properties": {
+                "name": {
+                    "description": "Name of the secret.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/project_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/project_config.openshift.io_v1.json
@@ -1,0 +1,48 @@
+{
+    "description": "Project holds cluster-wide information about Project.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "projectRequestMessage": {
+                    "description": "projectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint",
+                    "type": "string"
+                },
+                "projectRequestTemplate": {
+                    "description": "projectRequestTemplate is the template to use for creating projects in response to projectrequest. This must point to a template in 'openshift-config' namespace. It is optional. If it is not specified, a default template is used.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced project request template",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/project_project.openshift.io_v1.json
+++ b/openshift/v4.14-strict/project_project.openshift.io_v1.json
@@ -1,0 +1,78 @@
+{
+    "description": "Projects are the unit of isolation and collaboration in OpenShift. A project has one or more members, a quota on the resources that the project may consume, and the security controls on the resources in the project. Within a project, members may have different roles - project administrators can set membership, editors can create and manage the resources, and viewers can see but not access running containers. In a normal cluster project administrators are not able to alter their quotas - that is restricted to cluster administrators. \n Listing or watching projects will return only projects the user has the reader role on. \n An OpenShift project is an alternative representation of a Kubernetes namespace. Projects are exposed as editable to end users while namespaces are not. Direct creation of a project is typically restricted to administrators, while end users should use the requestproject resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec defines the behavior of the Namespace.",
+            "properties": {
+                "finalizers": {
+                    "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage",
+                    "items": {
+                        "description": "FinalizerName is the name identifying a finalizer during namespace lifecycle.",
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Status describes the current status of a Namespace",
+            "properties": {
+                "conditions": {
+                    "description": "Represents the latest available observations of the project current state.",
+                    "items": {
+                        "description": "NamespaceCondition contains details about state of namespace.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of namespace controller condition.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "phase": {
+                    "description": "Phase is the current lifecycle phase of the project",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/projecthelmchartrepository_helm.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/projecthelmchartrepository_helm.openshift.io_v1beta1.json
@@ -1,0 +1,153 @@
+{
+    "description": "ProjectHelmChartRepository holds namespace-wide configuration for proxied Helm chart repository \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "connectionConfig": {
+                    "description": "Required configuration for connecting to the chart repo",
+                    "properties": {
+                        "basicAuthConfig": {
+                            "description": "basicAuthConfig is an optional reference to a secret by name that contains the basic authentication credentials to present when connecting to the server. The key \"username\" is used locate the username. The key \"password\" is used to locate the password. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "ca": {
+                            "description": "ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key \"ca-bundle.crt\" is used to locate the data. If empty, the default system roots are used. The namespace for this configmap must be same as the namespace where the project helm chart repository is getting instantiated.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced config map",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "tlsClientConfig": {
+                            "description": "tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key \"tls.crt\" is used to locate the client certificate. The key \"tls.key\" is used to locate the private key. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.",
+                            "properties": {
+                                "name": {
+                                    "description": "name is the metadata.name of the referenced secret",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object",
+                            "additionalProperties": false
+                        },
+                        "url": {
+                            "description": "Chart repository URL",
+                            "maxLength": 2048,
+                            "pattern": "^https?:\\/\\/",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "description": {
+                    "description": "Optional human readable repository description, it can be used by UI for displaying purposes",
+                    "maxLength": 2048,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                "disabled": {
+                    "description": "If set to true, disable the repo usage in the namespace",
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Optional associated human readable repository name, it can be used by UI for displaying purposes",
+                    "maxLength": 100,
+                    "minLength": 1,
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "Observed status of the repository within the namespace..",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their statuses",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/projectrequest_project.openshift.io_v1.json
+++ b/openshift/v4.14-strict/projectrequest_project.openshift.io_v1.json
@@ -1,0 +1,27 @@
+{
+    "description": "ProjectRequest is the set of options necessary to fully qualify a project request \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "description": {
+            "description": "Description is the description to apply to a project",
+            "type": "string"
+        },
+        "displayName": {
+            "description": "DisplayName is the display name to apply to a project",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/proxy_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/proxy_config.openshift.io_v1.json
@@ -1,0 +1,81 @@
+{
+    "description": "Proxy holds cluster-wide information on how to configure default proxies for the cluster. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec holds user-settable values for the proxy configuration",
+            "properties": {
+                "httpProxy": {
+                    "description": "httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.",
+                    "type": "string"
+                },
+                "httpsProxy": {
+                    "description": "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
+                    "type": "string"
+                },
+                "noProxy": {
+                    "description": "noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.",
+                    "type": "string"
+                },
+                "readinessEndpoints": {
+                    "description": "readinessEndpoints is a list of endpoints used to verify readiness of the proxy.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "trustedCA": {
+                    "description": "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "httpProxy": {
+                    "description": "httpProxy is the URL of the proxy for HTTP requests.",
+                    "type": "string"
+                },
+                "httpsProxy": {
+                    "description": "httpsProxy is the URL of the proxy for HTTPS requests.",
+                    "type": "string"
+                },
+                "noProxy": {
+                    "description": "noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/rangeallocation_security.internal.openshift.io_v1.json
+++ b/openshift/v4.14-strict/rangeallocation_security.internal.openshift.io_v1.json
@@ -1,0 +1,29 @@
+{
+    "description": "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group This is an internal API, not intended for external consumption. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "data": {
+            "description": "data is a byte array representing the serialized state of a range allocation.  It is a bitmap with each bit set to one to represent a range is taken.",
+            "format": "byte",
+            "type": "string",
+            "pattern": "^[\\w\\d+\\/=]*$"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "range": {
+            "description": "range is a string representing a unique label for a range of uids, \"1000000000-2000000000/10000\".",
+            "type": "string"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/rangeallocation_security.openshift.io_v1.json
+++ b/openshift/v4.14-strict/rangeallocation_security.openshift.io_v1.json
@@ -1,0 +1,33 @@
+{
+    "description": "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "data": {
+            "description": "data is a byte array representing the serialized state of a range allocation.  It is a bitmap with each bit set to one to represent a range is taken.",
+            "format": "byte",
+            "type": "string",
+            "pattern": "^[\\w\\d+\\/=]*$"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "range": {
+            "description": "range is a string representing a unique label for a range of uids, \"1000000000-2000000000/10000\".",
+            "type": "string"
+        }
+    },
+    "required": [
+        "data",
+        "range"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/role_authorization.openshift.io_v1.json
+++ b/openshift/v4.14-strict/role_authorization.openshift.io_v1.json
@@ -1,0 +1,73 @@
+{
+    "description": "Role is a logical grouping of PolicyRules that can be referenced as a unit by RoleBindings. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "rules": {
+            "description": "Rules holds all the PolicyRules for this Role",
+            "items": {
+                "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+                "properties": {
+                    "apiGroups": {
+                        "description": "APIGroups is the name of the APIGroup that contains the resources.  If this field is empty, then both kubernetes and origin API groups are assumed. That means that if an action is requested against one of the enumerated resources in either the kubernetes or the origin API group, the request will be allowed",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": [
+                            "array",
+                            "null"
+                        ]
+                    },
+                    "attributeRestrictions": {
+                        "description": "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
+                        "type": "object",
+                        "x-kubernetes-preserve-unknown-fields": true
+                    },
+                    "nonResourceURLs": {
+                        "description": "NonResourceURLsSlice is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "resourceNames": {
+                        "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "resources": {
+                        "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "verbs": {
+                        "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/rolebinding_authorization.openshift.io_v1.json
+++ b/openshift/v4.14-strict/rolebinding_authorization.openshift.io_v1.json
@@ -1,0 +1,107 @@
+{
+    "description": "RoleBinding references a Role, but not contain it.  It can reference any Role in the same namespace or in the global namespace. It adds who information via (Users and Groups) OR Subjects and namespace information by which namespace it exists in. RoleBindings in a given namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces). \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "groupNames": {
+            "description": "GroupNames holds all the groups directly bound to the role. This field should only be specified when supporting legacy clients and servers. See Subjects for further details.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "roleRef": {
+            "description": "RoleRef can only reference the current namespace and the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. Since Policy is a singleton, this is sufficient knowledge to locate a role.",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "subjects": {
+            "description": "Subjects hold object references to authorize with this rule. This field is ignored if UserNames or GroupNames are specified to support legacy clients and servers. Thus newer clients that do not need to support backwards compatibility should send only fully qualified Subjects and should omit the UserNames and GroupNames fields. Clients that need to support backwards compatibility can use this field to build the UserNames and GroupNames.",
+            "items": {
+                "description": "ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, \"must refer only to types A and B\" or \"UID not honored\" or \"name must be restricted\". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control. \n Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .",
+                "properties": {
+                    "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                    },
+                    "fieldPath": {
+                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                        "type": "string"
+                    },
+                    "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                        "type": "string"
+                    },
+                    "resourceVersion": {
+                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                        "type": "string"
+                    },
+                    "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        },
+        "userNames": {
+            "description": "UserNames holds all the usernames directly bound to the role. This field should only be specified when supporting legacy clients and servers. See Subjects for further details.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/rolebindingrestriction_authorization.openshift.io_v1.json
+++ b/openshift/v4.14-strict/rolebindingrestriction_authorization.openshift.io_v1.json
@@ -1,0 +1,211 @@
+{
+    "description": "RoleBindingRestriction is an object that can be matched against a subject (user, group, or service account) to determine whether rolebindings on that subject are allowed in the namespace to which the RoleBindingRestriction belongs.  If any one of those RoleBindingRestriction objects matches a subject, rolebindings on that subject in the namespace are allowed. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "Spec defines the matcher.",
+            "properties": {
+                "grouprestriction": {
+                    "description": "GroupRestriction matches against group subjects.",
+                    "properties": {
+                        "groups": {
+                            "description": "Groups is a list of groups used to match against an individual user's groups. If the user is a member of one of the whitelisted groups, the user is allowed to be bound to a role.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "labels": {
+                            "description": "Selectors specifies a list of label selectors over group labels.",
+                            "items": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "properties": {
+                                    "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                },
+                                                "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "matchLabels": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        }
+                    },
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "additionalProperties": false
+                },
+                "serviceaccountrestriction": {
+                    "description": "ServiceAccountRestriction matches against service-account subjects.",
+                    "properties": {
+                        "namespaces": {
+                            "description": "Namespaces specifies a list of literal namespace names.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "serviceaccounts": {
+                            "description": "ServiceAccounts specifies a list of literal service-account names.",
+                            "items": {
+                                "description": "ServiceAccountReference specifies a service account and namespace by their names.",
+                                "properties": {
+                                    "name": {
+                                        "description": "Name is the name of the service account.",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "Namespace is the namespace of the service account.  Service accounts from inside the whitelisted namespaces are allowed to be bound to roles.  If Namespace is empty, then the namespace of the RoleBindingRestriction in which the ServiceAccountReference is embedded is used.",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "additionalProperties": false
+                },
+                "userrestriction": {
+                    "description": "UserRestriction matches against user subjects.",
+                    "properties": {
+                        "groups": {
+                            "description": "Groups specifies a list of literal group names.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "labels": {
+                            "description": "Selectors specifies a list of label selectors over user labels.",
+                            "items": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "properties": {
+                                    "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "properties": {
+                                                "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                },
+                                                "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                },
+                                                "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "operator"
+                                            ],
+                                            "type": "object",
+                                            "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                    },
+                                    "matchLabels": {
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        },
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": [
+                                "array",
+                                "null"
+                            ]
+                        },
+                        "users": {
+                            "description": "Users specifies a list of literal user names.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/route_route.openshift.io_v1.json
+++ b/openshift/v4.14-strict/route_route.openshift.io_v1.json
@@ -1,0 +1,475 @@
+{
+    "description": "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The route may further specify TLS options and a certificate, or specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An administrator typically configures their router to be visible outside the cluster firewall, and may also add additional security, caching, or traffic controls on the service content. Routers usually talk directly to the service endpoints. \n Once a route is created, the `host` field may not be changed. Generally, routers use the oldest route with a given host when resolving conflicts. \n Routers are subject to additional customization and may support additional controls via the annotations field. \n Because administrators may configure multiple routers, the route status field is used to return information to clients about the names and states of the route under each router. If a client chooses a duplicate name, for instance, the route status conditions are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN on a route it requires a custom (non-wildcard) certificate. This prevents connection coalescing by clients, notably web browsers. We do not support HTTP/2 ALPN on routes that use the default certificate because of the risk of connection re-use/coalescing. Routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the desired state of the route",
+            "properties": {
+                "alternateBackends": {
+                    "description": "alternateBackends allows up to 3 additional backends to be assigned to the route. Only the Service kind is allowed, and it will be defaulted to Service. Use the weight field in RouteTargetReference object to specify relative preference.",
+                    "items": {
+                        "description": "RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.",
+                        "properties": {
+                            "kind": {
+                                "default": "Service",
+                                "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                                "enum": [
+                                    "Service",
+                                    ""
+                                ],
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the service/target that is being referred to. e.g. name of the service",
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "weight": {
+                                "default": 100,
+                                "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.",
+                                "format": "int32",
+                                "maximum": 256,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "kind",
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "maxItems": 3,
+                    "type": "array"
+                },
+                "host": {
+                    "description": "host is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen. Must follow DNS952 subdomain conventions.",
+                    "maxLength": 253,
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                    "type": "string"
+                },
+                "httpHeaders": {
+                    "description": "httpHeaders defines policy for HTTP headers.",
+                    "properties": {
+                        "actions": {
+                            "description": "actions specifies options for modifying headers and their values. Note that this option only applies to cleartext HTTP connections and to secure HTTP connections for which the ingress controller terminates encryption (that is, edge-terminated or reencrypt connections).  Headers cannot be modified for TLS passthrough connections. Setting the HSTS (`Strict-Transport-Security`) header is not supported via actions. `Strict-Transport-Security` may only be configured using the \"haproxy.router.openshift.io/hsts_header\" route annotation, and only in accordance with the policy specified in Ingress.Spec.RequiredHSTSPolicies. In case of HTTP request headers, the actions specified in spec.httpHeaders.actions on the Route will be executed after the actions specified in the IngressController's spec.httpHeaders.actions field. In case of HTTP response headers, the actions specified in spec.httpHeaders.actions on the IngressController will be executed after the actions specified in the Route's spec.httpHeaders.actions field. The headers set via this API will not appear in access logs. Any actions defined here are applied after any actions related to the following other fields: cache-control, spec.clientTLS, spec.httpHeaders.forwardedHeaderPolicy, spec.httpHeaders.uniqueId, and spec.httpHeaders.headerNameCaseAdjustments. The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController. Please refer to the documentation for that API field for more details.",
+                            "properties": {
+                                "request": {
+                                    "description": "request is a list of HTTP request headers to modify. Currently, actions may define to either `Set` or `Delete` headers values. Actions defined here will modify the request headers of all requests made through a route. These actions are applied to a specific Route defined within a cluster i.e. connections made through a route. Currently, actions may define to either `Set` or `Delete` headers values. Route actions will be executed after IngressController actions for request headers. Actions are applied in sequence as defined in this list. A maximum of 20 request header actions may be configured. You can use this field to specify HTTP request headers that should be set or deleted when forwarding connections from the client to your application. Sample fetchers allowed are \"req.hdr\" and \"ssl_c_der\". Converters allowed are \"lower\" and \"base64\". Example header values: \"%[req.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\". Any request header configuration applied directly via a Route resource using this API will override header configuration for a header of the same name applied via spec.httpHeaders.actions on the IngressController or route annotation. Note: This field cannot be used if your route uses TLS passthrough.",
+                                    "items": {
+                                        "description": "RouteHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does. This field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value. Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. The value of this field must be no more than 16384 characters in length. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header. Possible values are Set or Delete. Set allows you to set HTTP request and response headers. Delete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are req.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:req\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                },
+                                "response": {
+                                    "description": "response is a list of HTTP response headers to modify. Currently, actions may define to either `Set` or `Delete` headers values. Actions defined here will modify the response headers of all requests made through a route. These actions are applied to a specific Route defined within a cluster i.e. connections made through a route. Route actions will be executed before IngressController actions for response headers. Actions are applied in sequence as defined in this list. A maximum of 20 response header actions may be configured. You can use this field to specify HTTP response headers that should be set or deleted when forwarding responses from your application to the client. Sample fetchers allowed are \"res.hdr\" and \"ssl_c_der\". Converters allowed are \"lower\" and \"base64\". Example header values: \"%[res.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\". Note: This field cannot be used if your route uses TLS passthrough.",
+                                    "items": {
+                                        "description": "RouteHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does. This field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value. Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. The value of this field must be no more than 16384 characters in length. Note that the total size of all net added headers *after* interpolating dynamic values must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the IngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header. Possible values are Set or Delete. Set allows you to set HTTP request and response headers. Delete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are res.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:res\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "path": {
+                    "description": "path that the router watches for, to route traffic for to the service. Optional",
+                    "pattern": "^/",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "If specified, the port to be used by the router. Most routers will use all endpoints exposed by the service by default - set this value to instruct routers which port to use.",
+                    "properties": {
+                        "targetPort": {
+                            "anyOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "description": "The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required",
+                            "x-kubernetes-int-or-string": true
+                        }
+                    },
+                    "required": [
+                        "targetPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "subdomain": {
+                    "description": "subdomain is a DNS subdomain that is requested within the ingress controller's domain (as a subdomain). If host is set this field is ignored. An ingress controller may choose to ignore this suggested name, in which case the controller will report the assigned name in the status.ingress array or refuse to admit the route. If this value is set and the server does not support this field host will be populated automatically. Otherwise host is left empty. The field may have multiple parts separated by a dot, but not all ingress controllers may honor the request. This field may not be changed after creation except by a user with the update routes/custom-host permission. \n Example: subdomain `frontend` automatically receives the router subdomain `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.",
+                    "maxLength": 253,
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                    "type": "string"
+                },
+                "tls": {
+                    "description": "The tls field provides the ability to configure certificates and termination for the route.",
+                    "properties": {
+                        "caCertificate": {
+                            "description": "caCertificate provides the cert authority certificate contents",
+                            "type": "string"
+                        },
+                        "certificate": {
+                            "description": "certificate provides certificate contents. This should be a single serving certificate, not a certificate chain. Do not include a CA certificate.",
+                            "type": "string"
+                        },
+                        "destinationCACertificate": {
+                            "description": "destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.",
+                            "type": "string"
+                        },
+                        "insecureEdgeTerminationPolicy": {
+                            "description": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+                            "enum": [
+                                "Allow",
+                                "None",
+                                "Redirect",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "key provides key file contents",
+                            "type": "string"
+                        },
+                        "termination": {
+                            "description": "termination indicates termination type. \n * edge - TLS termination is done by the router and http is used to communicate with the backend (default) * passthrough - Traffic is sent straight to the destination without the router providing TLS termination * reencrypt - TLS termination is done by the router and https is used to communicate with the backend \n Note: passthrough termination is incompatible with httpHeader actions",
+                            "enum": [
+                                "edge",
+                                "reencrypt",
+                                "passthrough"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "termination"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow",
+                            "rule": "has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "to": {
+                    "description": "to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.",
+                    "properties": {
+                        "kind": {
+                            "default": "Service",
+                            "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                            "enum": [
+                                "Service",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "name of the service/target that is being referred to. e.g. name of the service",
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "weight": {
+                            "default": 100,
+                            "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.",
+                            "format": "int32",
+                            "maximum": 256,
+                            "minimum": 0,
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "kind",
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "wildcardPolicy": {
+                    "default": "None",
+                    "description": "Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed.",
+                    "enum": [
+                        "None",
+                        "Subdomain",
+                        ""
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "to"
+            ],
+            "type": "object",
+            "x-kubernetes-validations": [
+                {
+                    "message": "header actions are not permitted when tls termination is passthrough.",
+                    "rule": "!has(self.tls) || self.tls.termination != 'passthrough' || !has(self.httpHeaders)"
+                }
+            ],
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the current state of the route",
+            "properties": {
+                "ingress": {
+                    "description": "ingress describes the places where the route may be exposed. The list of ingress points may contain duplicate Host or RouterName values. Routes are considered live once they are `Ready`",
+                    "items": {
+                        "description": "RouteIngress holds information about the places where a route is exposed.",
+                        "properties": {
+                            "conditions": {
+                                "description": "Conditions is the state of the route, may be empty.",
+                                "items": {
+                                    "description": "RouteIngressCondition contains details for the current condition of this route on a particular router.",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "RFC 3339 date and time when this condition last transitioned",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition, and is usually a machine and human readable constant",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status is the status of the condition. Can be True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type is the type of the condition. Currently only Admitted.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "host": {
+                                "description": "Host is the host string under which the route is exposed; this value is required",
+                                "type": "string"
+                            },
+                            "routerCanonicalHostname": {
+                                "description": "CanonicalHostname is the external host name for the router that can be used as a CNAME for the host requested for this route. This value is optional and may not be set in all cases.",
+                                "type": "string"
+                            },
+                            "routerName": {
+                                "description": "Name is a name chosen by the router to identify itself; this value is required",
+                                "type": "string"
+                            },
+                            "wildcardPolicy": {
+                                "description": "Wildcard policy is the wildcard policy that was allowed where this route is exposed.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/scheduler_config.openshift.io_v1.json
+++ b/openshift/v4.14-strict/scheduler_config.openshift.io_v1.json
@@ -1,0 +1,65 @@
+{
+    "description": "Scheduler holds cluster-wide config information to run the Kubernetes Scheduler and influence its placement decisions. The canonical name for this config is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "defaultNodeSelector": {
+                    "description": "defaultNodeSelector helps set the cluster-wide default node selector to restrict pod placement to specific nodes. This is applied to the pods created in all namespaces and creates an intersection with any existing nodeSelectors already set on a pod, additionally constraining that pod's selector. For example, defaultNodeSelector: \"type=user-node,region=east\" would set nodeSelector field in pod spec to \"type=user-node,region=east\" to all pods created in all namespaces. Namespaces having project-wide node selectors won't be impacted even if this field is set. This adds an annotation section to the namespace. For example, if a new namespace is created with node-selector='type=user-node,region=east', the annotation openshift.io/node-selector: type=user-node,region=east gets added to the project. When the openshift.io/node-selector annotation is set on the project the value is used in preference to the value we are setting for defaultNodeSelector field. For instance, openshift.io/node-selector: \"type=user-node,region=west\" means that the default of \"type=user-node,region=east\" set in defaultNodeSelector would not be applied.",
+                    "type": "string"
+                },
+                "mastersSchedulable": {
+                    "description": "MastersSchedulable allows masters nodes to be schedulable. When this flag is turned on, all the master nodes in the cluster will be made schedulable, so that workload pods can run on them. The default value for this field is false, meaning none of the master nodes are schedulable. Important Note: Once the workload pods start running on the master nodes, extreme care must be taken to ensure that cluster-critical control plane components are not impacted. Please turn on this field after doing due diligence.",
+                    "type": "boolean"
+                },
+                "policy": {
+                    "description": "DEPRECATED: the scheduler Policy API has been deprecated and will be removed in a future release. policy is a reference to a ConfigMap containing scheduler policy which has user specified predicates and priorities. If this ConfigMap is not available scheduler will default to use DefaultAlgorithmProvider. The namespace for this configmap is openshift-config.",
+                    "properties": {
+                        "name": {
+                            "description": "name is the metadata.name of the referenced config map",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "profile": {
+                    "description": "profile sets which scheduling profile should be set in order to configure scheduling decisions for new pods. \n Valid values are \"LowNodeUtilization\", \"HighNodeUtilization\", \"NoScoring\" Defaults to \"LowNodeUtilization\"",
+                    "enum": [
+                        "",
+                        "LowNodeUtilization",
+                        "HighNodeUtilization",
+                        "NoScoring"
+                    ],
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "type": "object"
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/securitycontextconstraints_security.openshift.io_v1.json
+++ b/openshift/v4.14-strict/securitycontextconstraints_security.openshift.io_v1.json
@@ -1,0 +1,350 @@
+{
+    "description": "SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "allowHostDirVolumePlugin": {
+            "description": "AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin",
+            "type": "boolean"
+        },
+        "allowHostIPC": {
+            "description": "AllowHostIPC determines if the policy allows host ipc in the containers.",
+            "type": "boolean"
+        },
+        "allowHostNetwork": {
+            "description": "AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
+            "type": "boolean"
+        },
+        "allowHostPID": {
+            "description": "AllowHostPID determines if the policy allows host pid in the containers.",
+            "type": "boolean"
+        },
+        "allowHostPorts": {
+            "description": "AllowHostPorts determines if the policy allows host ports in the containers.",
+            "type": "boolean"
+        },
+        "allowPrivilegeEscalation": {
+            "description": "AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
+            "type": [
+                "boolean",
+                "null"
+            ]
+        },
+        "allowPrivilegedContainer": {
+            "description": "AllowPrivilegedContainer determines if a container can request to be run as privileged.",
+            "type": "boolean"
+        },
+        "allowedCapabilities": {
+            "description": "AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field maybe added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities. To allow all capabilities you may use '*'.",
+            "items": {
+                "description": "Capability represent POSIX capabilities type",
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "allowedFlexVolumes": {
+            "description": "AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the \"Volumes\" field.",
+            "items": {
+                "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+                "properties": {
+                    "driver": {
+                        "description": "Driver is the name of the Flexvolume driver.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "driver"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "allowedUnsafeSysctls": {
+            "description": "AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc.",
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "defaultAddCapabilities": {
+            "description": "DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
+            "items": {
+                "description": "Capability represent POSIX capabilities type",
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "defaultAllowPrivilegeEscalation": {
+            "description": "DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.",
+            "type": [
+                "boolean",
+                "null"
+            ]
+        },
+        "forbiddenSysctls": {
+            "description": "ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc.",
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "fsGroup": {
+            "description": "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.",
+            "properties": {
+                "ranges": {
+                    "description": "Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
+                    "items": {
+                        "description": "IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.",
+                        "properties": {
+                            "max": {
+                                "description": "Max is the end of the range, inclusive.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "min": {
+                                "description": "Min is the start of the range, inclusive.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "description": "Type is the strategy that will dictate what FSGroup is used in the SecurityContext.",
+                    "type": "string"
+                }
+            },
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false
+        },
+        "groups": {
+            "description": "The groups that have permission to use this security context constraints",
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "priority": {
+            "description": "Priority influences the sort order of SCCs when evaluating which SCCs to try first for a given pod request based on access in the Users and Groups fields.  The higher the int, the higher priority. An unset value is considered a 0 priority. If scores for multiple SCCs are equal they will be sorted from most restrictive to least restrictive. If both priorities and restrictions are equal the SCCs will be sorted by name.",
+            "format": "int32",
+            "type": [
+                "integer",
+                "null"
+            ],
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "readOnlyRootFilesystem": {
+            "description": "ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the SCC should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+            "type": "boolean"
+        },
+        "requiredDropCapabilities": {
+            "description": "RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+            "items": {
+                "description": "Capability represent POSIX capabilities type",
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "runAsUser": {
+            "description": "RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.",
+            "properties": {
+                "type": {
+                    "description": "Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using namespace/service account allocated uids.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "uidRangeMax": {
+                    "description": "UIDRangeMax defines the max value for a strategy that allocates by range.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "uidRangeMin": {
+                    "description": "UIDRangeMin defines the min value for a strategy that allocates by range.",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                }
+            },
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false
+        },
+        "seLinuxContext": {
+            "description": "SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.",
+            "properties": {
+                "seLinuxOptions": {
+                    "description": "seLinuxOptions required to run as; required for MustRunAs",
+                    "properties": {
+                        "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                        },
+                        "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "type": {
+                    "description": "Type is the strategy that will dictate what SELinux context is used in the SecurityContext.",
+                    "type": "string"
+                }
+            },
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false
+        },
+        "seccompProfiles": {
+            "description": "SeccompProfiles lists the allowed profiles that may be set for the pod or container's seccomp annotations.  An unset (nil) or empty value means that no profiles may be specifid by the pod or container.\tThe wildcard '*' may be used to allow all profiles.  When used to generate a value for a pod the first non-wildcard profile will be used as the default.",
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "supplementalGroups": {
+            "description": "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.",
+            "properties": {
+                "ranges": {
+                    "description": "Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
+                    "items": {
+                        "description": "IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.",
+                        "properties": {
+                            "max": {
+                                "description": "Max is the end of the range, inclusive.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "min": {
+                                "description": "Min is the start of the range, inclusive.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "type": {
+                    "description": "Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
+                    "type": "string"
+                }
+            },
+            "type": [
+                "object",
+                "null"
+            ],
+            "additionalProperties": false
+        },
+        "users": {
+            "description": "The users who have permissions to use this security context constraints",
+            "items": {
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        },
+        "volumes": {
+            "description": "Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use \"*\". To allow no volumes, set to [\"none\"].",
+            "items": {
+                "description": "FS Type gives strong typing to different file systems that are used by volumes.",
+                "type": "string"
+            },
+            "type": [
+                "array",
+                "null"
+            ]
+        }
+    },
+    "required": [
+        "allowHostDirVolumePlugin",
+        "allowHostIPC",
+        "allowHostNetwork",
+        "allowHostPID",
+        "allowHostPorts",
+        "allowPrivilegedContainer",
+        "allowedCapabilities",
+        "defaultAddCapabilities",
+        "priority",
+        "readOnlyRootFilesystem",
+        "requiredDropCapabilities",
+        "volumes"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/serviceca_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/serviceca_operator.openshift.io_v1.json
@@ -1,0 +1,164 @@
+{
+    "description": "ServiceCA provides information to configure an operator to manage the service cert controllers \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/servicecatalogapiserver_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/servicecatalogapiserver_operator.openshift.io_v1.json
@@ -1,0 +1,162 @@
+{
+    "description": "ServiceCatalogAPIServer provides information to configure an operator to manage Service Catalog API Server DEPRECATED: will be removed in 4.6 \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/servicecatalogcontrollermanager_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/servicecatalogcontrollermanager_operator.openshift.io_v1.json
@@ -1,0 +1,162 @@
+{
+    "description": "ServiceCatalogControllerManager provides information to configure an operator to manage Service Catalog Controller Manager DEPRECATED: will be removed in 4.6 \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/servicecertsigneroperatorconfig_servicecertsigner.config.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/servicecertsigneroperatorconfig_servicecertsigner.config.openshift.io_v1alpha1.json
@@ -1,0 +1,164 @@
+{
+    "description": "ServiceCertSignerOperatorConfig provides information to configure an operator to manage the service cert signing controllers \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "metadata",
+        "spec",
+        "status"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/sharedconfigmap_sharedresource.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/sharedconfigmap_sharedresource.openshift.io_v1alpha1.json
@@ -1,0 +1,105 @@
+{
+    "description": "SharedConfigMap allows a ConfigMap to be shared across namespaces. Pods can mount the shared ConfigMap by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedConfigMap in the volume attributes: \n spec: volumes: - name: shared-configmap csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedConfigMap: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedConfigMap object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedconfigmaps.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case ConfigMaps, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired shared configmap",
+            "properties": {
+                "configMapRef": {
+                    "description": "configMapRef is a reference to the ConfigMap to share",
+                    "properties": {
+                        "name": {
+                            "description": "name represents the name of the ConfigMap that is being referenced.",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "namespace represents the namespace where the referenced ConfigMap is located.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "namespace"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "description": {
+                    "description": "description is a user readable explanation of what the backing resource provides.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "configMapRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the observed status of the shared configmap",
+            "properties": {
+                "conditions": {
+                    "description": "conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/sharedsecret_sharedresource.openshift.io_v1alpha1.json
+++ b/openshift/v4.14-strict/sharedsecret_sharedresource.openshift.io_v1alpha1.json
@@ -1,0 +1,105 @@
+{
+    "description": "SharedSecret allows a Secret to be shared across namespaces. Pods can mount the shared Secret by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedSecret in the volume attributes: \n spec: volumes: - name: shared-secret csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedSecret: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedSecret object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedsecrets.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case Secrets, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support.",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired shared secret",
+            "properties": {
+                "description": {
+                    "description": "description is a user readable explanation of what the backing resource provides.",
+                    "type": "string"
+                },
+                "secretRef": {
+                    "description": "secretRef is a reference to the Secret to share",
+                    "properties": {
+                        "name": {
+                            "description": "name represents the name of the Secret that is being referenced.",
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "description": "namespace represents the namespace where the referenced Secret is located.",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "namespace"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the observed status of the shared secret",
+            "properties": {
+                "conditions": {
+                    "description": "conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/stableconfigtype_example.openshift.io_v1.json
+++ b/openshift/v4.14-strict/stableconfigtype_example.openshift.io_v1.json
@@ -1,0 +1,165 @@
+{
+    "description": "StableConfigType is a stable config type that may include TechPreviewNoUpgrade fields. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the specification of the desired behavior of the StableConfigType.",
+            "properties": {
+                "celUnion": {
+                    "description": "celUnion demonstrates how to validate a discrminated union using CEL",
+                    "properties": {
+                        "optionalMember": {
+                            "description": "optionalMember is a union member that is optional.",
+                            "type": "string"
+                        },
+                        "requiredMember": {
+                            "description": "requiredMember is a union member that is required.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "type determines which of the union members should be populated.",
+                            "enum": [
+                                "RequiredMember",
+                                "OptionalMember",
+                                "EmptyMember"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "requiredMember is required when type is RequiredMember, and forbidden otherwise",
+                            "rule": "has(self.type) && self.type == 'RequiredMember' ?  has(self.requiredMember) : !has(self.requiredMember)"
+                        },
+                        {
+                            "message": "optionalMember is forbidden when type is not OptionalMember",
+                            "rule": "has(self.type) && self.type == 'OptionalMember' ?  true : !has(self.optionalMember)"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "evolvingUnion": {
+                    "description": "evolvingUnion demonstrates how to phase in new values into discriminated union",
+                    "properties": {
+                        "type": {
+                            "description": "type is the discriminator. It has different values for Default and for TechPreviewNoUpgrade",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "immutableField": {
+                    "description": "immutableField is a field that is immutable once the object has been created. It is required at all times.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "immutableField is immutable",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                },
+                "optionalImmutableField": {
+                    "description": "optionalImmutableField is a field that is immutable once set. It is optional but may not be changed once set.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "optionalImmutableField is immutable once set",
+                            "rule": "oldSelf == '' || self == oldSelf"
+                        }
+                    ]
+                },
+                "stableField": {
+                    "description": "stableField is a field that is present on default clusters and on tech preview clusters \n If empty, the platform will choose a good default, which may change over time without notice.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "immutableField"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the most recently observed status of the StableConfigType.",
+            "properties": {
+                "conditions": {
+                    "description": "Represents the observations of a foo's current state. Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
+                    "items": {
+                        "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                                "type": "string"
+                            },
+                            "observedGeneration": {
+                                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "reason": {
+                                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "status of the condition, one of True, False, Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "type"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "immutableField": {
+                    "description": "immutableField is a field that is immutable once the object has been created. It is required at all times.",
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "immutableField is immutable",
+                            "rule": "self == oldSelf"
+                        }
+                    ]
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/storage_operator.openshift.io_v1.json
+++ b/openshift/v4.14-strict/storage_operator.openshift.io_v1.json
@@ -1,0 +1,179 @@
+{
+    "description": "Storage provides a means to configure an operator to manage the cluster storage operator. `cluster` is the canonical name. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec holds user settable values for configuration",
+            "properties": {
+                "logLevel": {
+                    "default": "Normal",
+                    "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "managementState": {
+                    "description": "managementState indicates whether and how the operator should manage the component",
+                    "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                    "type": "string"
+                },
+                "observedConfig": {
+                    "description": "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "operatorLogLevel": {
+                    "default": "Normal",
+                    "description": "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
+                    "enum": [
+                        "",
+                        "Normal",
+                        "Debug",
+                        "Trace",
+                        "TraceAll"
+                    ],
+                    "type": "string"
+                },
+                "unsupportedConfigOverrides": {
+                    "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "x-kubernetes-preserve-unknown-fields": true
+                },
+                "vsphereStorageDriver": {
+                    "description": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.",
+                    "enum": [
+                        "",
+                        "LegacyDeprecatedInTreeDriver",
+                        "CSIWithMigrationDriver"
+                    ],
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver",
+                            "rule": "self != \"LegacyDeprecatedInTreeDriver\""
+                        }
+                    ]
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status holds observed values from the cluster. They may not be overridden.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions is a list of conditions and their status",
+                    "items": {
+                        "description": "OperatorCondition is just the standard condition fields.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "generations": {
+                    "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+                    "items": {
+                        "description": "GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.",
+                        "properties": {
+                            "group": {
+                                "description": "group is the group of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "hash": {
+                                "description": "hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps",
+                                "type": "string"
+                            },
+                            "lastGeneration": {
+                                "description": "lastGeneration is the last generation of the workload controller involved",
+                                "format": "int64",
+                                "type": "integer",
+                                "minimum": -9223372036854776000,
+                                "maximum": 9223372036854776000
+                            },
+                            "name": {
+                                "description": "name is the name of the thing you're tracking",
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "description": "namespace is where the thing you're tracking is",
+                                "type": "string"
+                            },
+                            "resource": {
+                                "description": "resource is the resource type of the thing you're tracking",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "observedGeneration": {
+                    "description": "observedGeneration is the last generation change you've dealt with",
+                    "format": "int64",
+                    "type": "integer",
+                    "minimum": -9223372036854776000,
+                    "maximum": 9223372036854776000
+                },
+                "readyReplicas": {
+                    "description": "readyReplicas indicates how many replicas are ready and at the desired state",
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "version": {
+                    "description": "version is the level this availability applies to",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/template_template.openshift.io_v1.json
+++ b/openshift/v4.14-strict/template_template.openshift.io_v1.json
@@ -1,0 +1,84 @@
+{
+    "description": "Template contains the inputs needed to produce a Config. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "labels": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "labels is a optional set of labels that are applied to every object during the Template to Config transformation.",
+            "type": "object"
+        },
+        "message": {
+            "description": "message is an optional instructional message that will be displayed when this template is instantiated. This field should inform the user how to utilize the newly created resources. Parameter substitution will be performed on the message before being displayed so that generated credentials and other parameters can be included in the output.",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "objects": {
+            "description": "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace.",
+            "items": {
+                "type": "object",
+                "x-kubernetes-preserve-unknown-fields": true
+            },
+            "type": "array",
+            "x-kubernetes-preserve-unknown-fields": true
+        },
+        "parameters": {
+            "description": "parameters is an optional array of Parameters used during the Template to Config transformation.",
+            "items": {
+                "description": "Parameter defines a name/value variable that is to be processed during the Template to Config transformation.",
+                "properties": {
+                    "description": {
+                        "description": "Description of a parameter. Optional.",
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "description": "Optional: The name that will show in UI instead of parameter 'Name'",
+                        "type": "string"
+                    },
+                    "from": {
+                        "description": "From is an input value for the generator. Optional.",
+                        "type": "string"
+                    },
+                    "generate": {
+                        "description": "generate specifies the generator to be used to generate random string from an input value specified by From field. The result string is stored into Value field. If empty, no generator is being used, leaving the result Value untouched. Optional. \n The only supported generator is \"expression\", which accepts a \"from\" value in the form of a simple regular expression containing the range expression \"[a-zA-Z0-9]\", and the length expression \"a{length}\". \n Examples: \n from             | value ----------------------------- \"test[0-9]{1}x\"  | \"test7x\" \"[0-1]{8}\"       | \"01001100\" \"0x[A-F0-9]{4}\"  | \"0xB3AF\" \"[a-zA-Z0-9]{8}\" | \"hW4yQU5i\"",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name must be set and it can be referenced in Template Items using ${PARAMETER_NAME}. Required.",
+                        "type": "string"
+                    },
+                    "required": {
+                        "description": "Optional: Indicates the parameter must have a value.  Defaults to false.",
+                        "type": "boolean"
+                    },
+                    "value": {
+                        "description": "Value holds the Parameter data. If specified, the generator will be ignored. The value replaces all occurrences of the Parameter ${Name} expression during the Template to Config transformation. Optional.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "additionalProperties": false
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "objects"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/templateinstance_template.openshift.io_v1.json
+++ b/openshift/v4.14-strict/templateinstance_template.openshift.io_v1.json
@@ -1,0 +1,252 @@
+{
+    "description": "TemplateInstance requests and records the instantiation of a Template. TemplateInstance is part of an experimental API. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec describes the desired state of this TemplateInstance.",
+            "properties": {
+                "requester": {
+                    "description": "requester holds the identity of the agent requesting the template instantiation.",
+                    "properties": {
+                        "extra": {
+                            "additionalProperties": {
+                                "description": "ExtraValue masks the value so protobuf can generate",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "description": "extra holds additional information provided by the authenticator.",
+                            "type": "object"
+                        },
+                        "groups": {
+                            "description": "groups represent the groups this user is a part of.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "uid": {
+                            "description": "uid is a unique value that identifies this user across time; if this user is deleted and another user by the same name is added, they will have different UIDs.",
+                            "type": "string"
+                        },
+                        "username": {
+                            "description": "username uniquely identifies this user among all active users.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "secret": {
+                    "description": "secret is a reference to a Secret object containing the necessary template parameters.",
+                    "properties": {
+                        "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "template": {
+                    "description": "template is a full copy of the template for instantiation.",
+                    "properties": {
+                        "apiVersion": {
+                            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                            "type": "string"
+                        },
+                        "kind": {
+                            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                        },
+                        "labels": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "labels is a optional set of labels that are applied to every object during the Template to Config transformation.",
+                            "type": "object"
+                        },
+                        "message": {
+                            "description": "message is an optional instructional message that will be displayed when this template is instantiated. This field should inform the user how to utilize the newly created resources. Parameter substitution will be performed on the message before being displayed so that generated credentials and other parameters can be included in the output.",
+                            "type": "string"
+                        },
+                        "metadata": {
+                            "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "type": "object"
+                        },
+                        "objects": {
+                            "description": "objects is an array of resources to include in this template. If a namespace value is hardcoded in the object, it will be removed during template instantiation, however if the namespace value is, or contains, a ${PARAMETER_REFERENCE}, the resolved value after parameter substitution will be respected and the object will be created in that namespace.",
+                            "items": {
+                                "type": "object",
+                                "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "type": "array",
+                            "x-kubernetes-preserve-unknown-fields": true
+                        },
+                        "parameters": {
+                            "description": "parameters is an optional array of Parameters used during the Template to Config transformation.",
+                            "items": {
+                                "description": "Parameter defines a name/value variable that is to be processed during the Template to Config transformation.",
+                                "properties": {
+                                    "description": {
+                                        "description": "Description of a parameter. Optional.",
+                                        "type": "string"
+                                    },
+                                    "displayName": {
+                                        "description": "Optional: The name that will show in UI instead of parameter 'Name'",
+                                        "type": "string"
+                                    },
+                                    "from": {
+                                        "description": "From is an input value for the generator. Optional.",
+                                        "type": "string"
+                                    },
+                                    "generate": {
+                                        "description": "generate specifies the generator to be used to generate random string from an input value specified by From field. The result string is stored into Value field. If empty, no generator is being used, leaving the result Value untouched. Optional. \n The only supported generator is \"expression\", which accepts a \"from\" value in the form of a simple regular expression containing the range expression \"[a-zA-Z0-9]\", and the length expression \"a{length}\". \n Examples: \n from             | value ----------------------------- \"test[0-9]{1}x\"  | \"test7x\" \"[0-1]{8}\"       | \"01001100\" \"0x[A-F0-9]{4}\"  | \"0xB3AF\" \"[a-zA-Z0-9]{8}\" | \"hW4yQU5i\"",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name must be set and it can be referenced in Template Items using ${PARAMETER_NAME}. Required.",
+                                        "type": "string"
+                                    },
+                                    "required": {
+                                        "description": "Optional: Indicates the parameter must have a value.  Defaults to false.",
+                                        "type": "boolean"
+                                    },
+                                    "value": {
+                                        "description": "Value holds the Parameter data. If specified, the generator will be ignored. The value replaces all occurrences of the Parameter ${Name} expression during the Template to Config transformation. Optional.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "type": "object",
+                                "additionalProperties": false
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "objects"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            },
+            "required": [
+                "template"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status describes the current state of this TemplateInstance.",
+            "properties": {
+                "conditions": {
+                    "description": "conditions represent the latest available observations of a TemplateInstance's current state.",
+                    "items": {
+                        "description": "TemplateInstanceCondition contains condition information for a TemplateInstance.",
+                        "properties": {
+                            "lastTransitionTime": {
+                                "description": "LastTransitionTime is the last time a condition status transitioned from one state to another.",
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            "message": {
+                                "description": "Message is a human readable description of the details of the last transition, complementing reason.",
+                                "type": "string"
+                            },
+                            "reason": {
+                                "description": "Reason is a brief machine readable explanation for the condition's last transition.",
+                                "type": "string"
+                            },
+                            "status": {
+                                "description": "Status of the condition, one of True, False or Unknown.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "Type of the condition, currently Ready or InstantiateFailure.",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "lastTransitionTime",
+                            "message",
+                            "reason",
+                            "status",
+                            "type"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                },
+                "objects": {
+                    "description": "Objects references the objects created by the TemplateInstance.",
+                    "items": {
+                        "description": "TemplateInstanceObject references an object created by a TemplateInstance.",
+                        "properties": {
+                            "ref": {
+                                "description": "ref is a reference to the created object.  When used under .spec, only name and namespace are used; these can contain references to parameters which will be substituted following the usual rules.",
+                                "properties": {
+                                    "apiVersion": {
+                                        "description": "API version of the referent.",
+                                        "type": "string"
+                                    },
+                                    "fieldPath": {
+                                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                                        "type": "string"
+                                    },
+                                    "resourceVersion": {
+                                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                        "type": "string"
+                                    },
+                                    "uid": {
+                                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/user_user.openshift.io_v1.json
+++ b/openshift/v4.14-strict/user_user.openshift.io_v1.json
@@ -1,0 +1,40 @@
+{
+    "description": "Upon log in, every user of the system receives a User and Identity resource. Administrators may directly manipulate the attributes of the users for their own tracking, or set groups via the API. The user name is unique and is chosen based on the value provided by the identity provider - if a user already exists with the incoming name, the user name may have a number appended to it depending on the configuration of the system. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "fullName": {
+            "description": "FullName is the full name of user",
+            "type": "string"
+        },
+        "groups": {
+            "description": "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "identities": {
+            "description": "Identities are the identities associated with this user",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        }
+    },
+    "required": [
+        "groups"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/useridentitymapping_user.openshift.io_v1.json
+++ b/openshift/v4.14-strict/useridentitymapping_user.openshift.io_v1.json
@@ -1,0 +1,89 @@
+{
+    "description": "UserIdentityMapping maps a user to an identity \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "identity": {
+            "description": "Identity is a reference to an identity",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "user": {
+            "description": "User is a reference to a user",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                },
+                "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/openshift/v4.14-strict/vspheremachineproviderspec_machine.openshift.io_v1beta1.json
+++ b/openshift/v4.14-strict/vspheremachineproviderspec_machine.openshift.io_v1beta1.json
@@ -1,0 +1,186 @@
+{
+    "description": "VSphereMachineProviderSpec is the type that will be embedded in a Machine.Spec.ProviderSpec field for an VSphere virtual machine. It is used by the vSphere machine actuator to create a single Machine. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "cloneMode": {
+            "description": "CloneMode specifies the type of clone operation. The LinkedClone mode is only support for templates that have at least one snapshot. If the template has no snapshots, then CloneMode defaults to FullClone. When LinkedClone mode is enabled the DiskGiB field is ignored as it is not possible to expand disks of linked clones. Defaults to FullClone. When using LinkedClone, if no snapshots exist for the source template, falls back to FullClone.",
+            "type": "string"
+        },
+        "credentialsSecret": {
+            "description": "CredentialsSecret is a reference to the secret with vSphere credentials.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "diskGiB": {
+            "description": "DiskGiB is the size of a virtual machine's disk, in GiB. Defaults to the analogue property value in the template from which this machine is cloned. This parameter will be ignored if 'LinkedClone' CloneMode is set.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "memoryMiB": {
+            "description": "MemoryMiB is the size of a virtual machine's memory, in MiB. Defaults to the analogue property value in the template from which this machine is cloned.",
+            "format": "int64",
+            "type": "integer",
+            "minimum": -9223372036854776000,
+            "maximum": 9223372036854776000
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "network": {
+            "description": "Network is the network configuration for this machine's VM.",
+            "properties": {
+                "devices": {
+                    "description": "Devices defines the virtual machine's network interfaces.",
+                    "items": {
+                        "description": "NetworkDeviceSpec defines the network configuration for a virtual machine's network device.",
+                        "properties": {
+                            "addressesFromPools": {
+                                "description": "addressesFromPools is a list of references to IP pool types and instances which are handled by an external controller. addressesFromPool configurations provided via addressesFromPools defer IP address assignment to an external controller. IP addresses provided via ipAddrs, however, are intended to allow explicit assignment of a machine's IP address. If both addressesFromPool and ipAddrs are empty or not defined, DHCP will assign an IP address. If both ipAddrs and addressesFromPools are defined, the IP addresses associated with ipAddrs will be applied first followed by IP addresses from addressesFromPools.",
+                                "format": "ipv4",
+                                "items": {
+                                    "description": "AddressesFromPool is an IPAddressPool that will be used to create IPAddressClaims for fulfillment by an external controller.",
+                                    "properties": {
+                                        "group": {
+                                            "description": "group of the IP address pool type known to an external IPAM controller. This should be a fully qualified domain name, for example, externalipam.controller.io.",
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                        },
+                                        "name": {
+                                            "description": "name of an IP address pool, for example, pool-config-1.",
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                        },
+                                        "resource": {
+                                            "description": "resource of the IP address pool type known to an external IPAM controller. It is normally the plural form of the resource kind in lowercase, for example, ippools.",
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "group",
+                                        "name",
+                                        "resource"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array"
+                            },
+                            "gateway": {
+                                "description": "gateway is an IPv4 or IPv6 address which represents the subnet gateway, for example, 192.168.1.1.",
+                                "format": "ipv6",
+                                "type": "string"
+                            },
+                            "ipAddrs": {
+                                "description": "ipAddrs is a list of one or more IPv4 and/or IPv6 addresses and CIDR to assign to this device, for example, 192.168.1.100/24. IP addresses provided via ipAddrs are intended to allow explicit assignment of a machine's IP address. IP pool configurations provided via addressesFromPool, however, defer IP address assignment to an external controller. If both addressesFromPool and ipAddrs are empty or not defined, DHCP will be used to assign an IP address. If both ipAddrs and addressesFromPools are defined, the IP addresses associated with ipAddrs will be applied first followed by IP addresses from addressesFromPools.",
+                                "format": "ipv6",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "nameservers": {
+                                "description": "nameservers is a list of IPv4 and/or IPv6 addresses used as DNS nameservers, for example, 8.8.8.8. a nameserver is not provided by a fulfilled IPAddressClaim. If DHCP is not the source of IP addresses for this network device, nameservers should include a valid nameserver.",
+                                "format": "ipv6",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "networkName": {
+                                "description": "networkName is the name of the vSphere network or port group to which the network device will be connected, for example, port-group-1. When not provided, the vCenter API will attempt to select a default network. The available networks (port groups) can be listed using `govc ls 'network/*'`",
+                                "maxLength": 80,
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "numCPUs": {
+            "description": "NumCPUs is the number of virtual processors in a virtual machine. Defaults to the analogue property value in the template from which this machine is cloned.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "numCoresPerSocket": {
+            "description": "NumCPUs is the number of cores among which to distribute CPUs in this virtual machine. Defaults to the analogue property value in the template from which this machine is cloned.",
+            "format": "int32",
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647
+        },
+        "snapshot": {
+            "description": "Snapshot is the name of the snapshot from which the VM was cloned",
+            "type": "string"
+        },
+        "template": {
+            "description": "Template is the name, inventory path, or instance UUID of the template used to clone new machines.",
+            "type": "string"
+        },
+        "userDataSecret": {
+            "description": "UserDataSecret contains a local reference to a secret that contains the UserData to apply to the instance",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "workspace": {
+            "description": "Workspace describes the workspace to use for the machine.",
+            "properties": {
+                "datacenter": {
+                    "description": "Datacenter is the datacenter in which VMs are created/located.",
+                    "type": "string"
+                },
+                "datastore": {
+                    "description": "Datastore is the datastore in which VMs are created/located.",
+                    "type": "string"
+                },
+                "folder": {
+                    "description": "Folder is the folder in which VMs are created/located.",
+                    "type": "string"
+                },
+                "resourcePool": {
+                    "description": "ResourcePool is the resource pool in which VMs are created/located.",
+                    "type": "string"
+                },
+                "server": {
+                    "description": "Server is the IP address or FQDN of the vSphere endpoint.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}


### PR DESCRIPTION
[OpenShift v4.14 CRDs](https://github.com/datreeio/CRDs-catalog/commit/aaf0418b406b345ab924ba6928dc2c1b3054b0e7)

OpenShift API 4.14 CRD schemas were extracted with:

```sh
git clone https://github.com/openshift/api.git openshift-api
cd openshift-api && git checkout release-4.14
cd tools
make controller-gen # creates ./tools/_output/bin/linux/amd64/controller-gen
cd ..
mkdir crds
paths=($(find . -type d -regextype posix-extended -regex '.*v[0-9].*' -not -path './vendor/*' -not -path './tests/*' -not -path './tools/*'))
./tools/_output/bin/linux/amd64/controller-gen crd ${paths[@]/#/paths=} output:dir=./crds
mkdir -p v4.14-strict/
crd2jsonschema -o v4.14-strict/ -a crds/*.yaml
podman run --rm -v $(pwd):/app ghcr.io/tricktron/crd2jsonschema -a -o v4.14-strict/ crds/*.yaml
```

(adjusted from the previous PR: https://github.com/datreeio/CRDs-catalog/pull/142 )

Machine Config Operator v4.14 CRDs chemas were generated with:

```sh
git clone https://github.com/openshift/machine-config-operator.git
cd machine-config-operator/ && git checkout release-4.14 && cd ..
find machine-config-operator/ -wholename '*/install/*.crd.yaml' -exec python3 ./openapi2jsonschema.py {} \;
```

(the same as in https://github.com/datreeio/CRDs-catalog/pull/204 )